### PR TITLE
combining kp with no data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Improved failure messages for utils.coords.scale_units
    - Added some tests for model_utils
    - Added option to to_netCDF that names variables in the written file
-   based upon the strings in the Instrument.meta object
+     based upon the strings in the Instrument.meta object
    - Improved compatibility with NASA ICON's file standards
    - Improved file downloading for Kp
 - Code Restructure
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Fixed implementation of utils routines in model_utils and jro_isr
    - Fixed error catching bug in model_utils
    - Fixed error introduced by upstream change in NOAA F10.7 file format
+   - Fixed a bug when trying to combine empty kp lists
 - Documentation
   - Added info on how to cite the code and package.
 

--- a/pysat/instruments/methods/sw.py
+++ b/pysat/instruments/methods/sw.py
@@ -193,9 +193,13 @@ def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
         notes += "{:})".format(itime.date())
 
     # Determine if the beginning or end of the time series needs to be padded
-    freq = pysat.utils.time.calc_freq(kp_times)
+    
+    freq = None if len(kp_times) < 2 else pysat.utils.time.calc_freq(kp_times)
     date_range = pds.date_range(start=start, end=stop-pds.DateOffset(days=1),
                                 freq=freq)
+
+    if len(kp_times) == 0:
+        kp_times = date_range
 
     if date_range[0] < kp_times[0]:
         # Extend the time and value arrays from their beginning with fill

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -267,7 +267,7 @@ class TestSwKpCombine():
     def test_combine_kp_no_data(self):
         """Test combine_kp when no data is present for specified times"""
 
-        combo_in = {kk: self.combine[kk] for kk in
+        combo_in = {kk: self.combine['forecast_inst'] for kk in
                     ['standard_inst', 'recent_inst', 'forecast_inst']}
         combo_in['start'] = pysat.datetime(2014, 2, 19)
         combo_in['stop'] = pysat.datetime(2014, 2, 24)
@@ -275,7 +275,7 @@ class TestSwKpCombine():
 
         assert kp_inst.data.isnull().all()["Kp"]
 
-        del combo_in
+        del combo_in, kp_inst
 
     def test_combine_kp_inst_time(self):
         """Test combine_kp when times are provided through the instruments"""

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -264,6 +264,19 @@ class TestSwKpCombine():
 
         del combo_in
 
+    def test_combine_kp_no_data(self):
+        """Test combine_kp when no data is present for specified times"""
+
+        combo_in = {kk: self.combine[kk] for kk in
+                    ['standard_inst', 'recent_inst', 'forecast_inst']}
+        combo_in['start'] = pysat.datetime(2014, 2, 19)
+        combo_in['stop'] = pysat.datetime(2014, 2, 24)
+        kp_inst = sw_meth.combine_kp(**combo_in)
+
+        assert kp_inst.data.isnull().all()["Kp"]
+
+        del combo_in
+
     def test_combine_kp_inst_time(self):
         """Test combine_kp when times are provided through the instruments"""
 


### PR DESCRIPTION
# Description

Fix a bug that presented itself when the list of kp_times was empty (nothing was
downloaded).  Will now return a padded list of NaN.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
import datetime as dt

standard_inst = pysat.Instrument('sw', 'kp', '')
recent_inst = pysat.Instrument('sw', 'kp', 'recent')

stime = dt.datetime(2014, 2, 19)
etime = dt.datetime(2014, 2, 24)

standard_inst.download(start=stime, stop=etime, freq='M')
recent_inst.download(start=stime, stop=etime)

kp_inst = python.instrument.methods.sw.combine_kp(standard_inst=standard_inst, recent_inst=recent_inst, start=stime, stop=etime)

print(kp_inst)
```

If you take out `freq='M'`, you will get data.  With it in, you should get NaN.

**Test Configuration**:
* OS X Sierra
* Python 2.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
