### PR TITLE
Empty file fix

### DIFF
--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -433,7 +433,7 @@ class TestInstrumentWithFiles():
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
-    def test_init_on_ignore_empty_files(self):
+    def test_instrument_with_ignore_empty_files(self):
         """Make sure new instruments can ignore empty files"""
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,


### PR DESCRIPTION
# Description

Addresses # 268

Refactors empty file filter.
Adds tests to check that file objects and instruments can ignore empty files.

## Type of change
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

New tests in test_files.py:
- TestInstrumentWithFiles.test_instrument_with_ignore_empty_files
- TestInstrumentWithFiles.test_refresh_on_ignore_empty_files

**Test Configuration**:
* MacOS 10.13.6
* Python 3.7.3
* (mini)conda 4.7.11

# Checklist:

- [ x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [ x] My code follows the style guidelines of this project
- [ x] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x ] My changes generate no new warnings
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
