### PR TITLE
ENH: C/NOFS IVM Cleaning Routine Update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    based upon the strings in the Instrument.meta object
    - Improved compatibility with NASA ICON's file standards
    - Improved file downloading for Kp
+   - Updated cleaning routines for C/NOFS IVM
 - Code Restructure
   - Move `computational_form` to `ssnl`
   - Move `scale_units` to `utils._core`

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -121,8 +121,8 @@ def clean(inst):
     idx, = np.where(inst.data.RPAflag <= max_rpa_flag)
     if (inst.clean_level == 'clean'):
         nO = inst.data.ion1fraction*inst.data.Ni
-        idx2 = np.where((inst.data.RPAflag <= 3) and (nO > 3.0e4))
-        idx = np.unique(idx.extend(idx2))
+        idx2, = np.where((inst.data.RPAflag <= 3) & (nO > 3.0e4))
+        idx = np.unique(np.concatenate((idx, idx2)))
     inst.data = inst[idx, :]
 
     # Second pass, find bad drifts, replace with NaNs
@@ -135,7 +135,7 @@ def clean(inst):
             idx2, = np.where(np.abs(inst.data.ionVelmeridional) >= 10000.)
             # shallow fit region for vx
             idx3, = np.where(inst.data.ion1fraction >= 1.0)
-            idx = np.unique(idx.extend(idx2, idx3))
+            idx = np.unique(np.concatenate((idx, idx2, idx3)))
         except AttributeError:
             pass
 

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -132,8 +132,6 @@ def clean(inst):
     inst.data = inst[idx, :]
 
     # Second pass, find bad drifts
-    drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
-                    'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
     idx, = np.where(inst.data.driftMeterflag > max_dm_flag)
 
     # Also exclude very large drifts
@@ -144,6 +142,8 @@ def clean(inst):
         except AttributeError:
             pass
 
+    drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
+                    'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
     for label in drift_labels:
         inst[label][idx] = np.NaN
 

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -137,10 +137,10 @@ def clean(inst):
                     'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
     for label in drift_labels:
         inst[label][idx] = np.NaN
-        
+
     # Check for bad temperature fits (O+ < 15%), replace with NaNs
     # Criteria from Hairston et al, 2015
-    idx, = np.where(ivm.data.ion1fraction < 0.15)
+    idx, = np.where(inst.data.ion1fraction < 0.15)
     inst['ionTemperature'][idx] = np.NaN
 
     # basic quality check on drifts and don't let UTS go above 86400.

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -103,13 +103,6 @@ def clean(inst):
 
     """
 
-    # cleans cindi data
-    if inst.clean_level == 'clean':
-        # choose areas below 550km
-        # inst.data = inst.data[inst.data.alt <= 550]
-        idx, = np.where(inst.data.altitude <= 550)
-        inst.data = inst[idx, :]
-
     # make sure all -999999 values are NaN
     inst.data.replace(-999999., np.nan, inplace=True)
 
@@ -120,12 +113,9 @@ def clean(inst):
     elif inst.clean_level == 'dusty':
         max_rpa_flag = 3
         max_dm_flag = 3
-    elif inst.clean_level == 'dirty':
+    else:
         max_rpa_flag = 4
         max_dm_flag = 6
-    else:
-        max_rpa_flag = 9
-        max_dm_flag = 9
 
     # First pass, remove bad densities
     idx, = np.where(inst.data.RPAflag <= max_rpa_flag)

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -131,16 +131,7 @@ def clean(inst):
             idx2, = np.where(np.abs(inst.data.ionVelmeridional) >= 10000.)
             # shallow fit region for vx
             idx3, = np.where(inst.data.ion1fraction >= 1.0)
-            if len(idx2)>0:
-                if len(idx)>0:
-                    idx = np.unique(np.append(idx, idx2))
-                else:
-                    idx = idx2
-            if len(idx3)>0:
-                if len(idx)>0:
-                    idx = np.unique(np.append(idx, idx3))
-                else:
-                    idx = idx3
+            idx = np.unique(idx.extend(idx2, idx3))
         except AttributeError:
             pass
 

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -139,7 +139,7 @@ def clean(inst):
         except AttributeError:
             pass
 
-    if len(idx)>0:
+    if len(idx) > 0:
         drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
                         'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
         for label in drift_labels:

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -160,8 +160,9 @@ def clean(inst):
 
     # Check for bad temperature fits (O+ < 15%), replace with NaNs
     # Criteria from Hairston et al, 2015
-    idx, = np.where(inst.data.ion1fraction < 0.15)
-    inst['ionTemperature'][idx] = np.NaN
+    if (inst.clean_level == 'clean') | (inst.clean_level == 'dusty'):
+        idx, = np.where(inst.data.ion1fraction < 0.15)
+        inst['ionTemperature'][idx] = np.NaN
 
     # basic quality check on drifts and don't let UTS go above 86400.
     idx, = np.where(inst.data.time <= 86400.)

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -147,7 +147,7 @@ def clean(inst):
         idx, = np.where(inst.data.ion1fraction >= 1.0)
         # Low O+ concentrations for RPA Flag of 3 are suspect
         nO = inst.data.ion1fraction*inst.data.Ni
-        idx2, = np.where((inst.data.RPAflag <= 3) & (nO <= 3.0e4))
+        idx2, = np.where((inst.data.RPAflag == 3) & (nO <= 3.0e4))
         idx = np.unique(np.concatenate((idx, idx2)))
         # However, only remove these if RPA component of drift is significant
         unit_vecs = {'ionVelmeridional': 'meridionalunitvectorX',

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -117,8 +117,12 @@ def clean(inst):
         max_rpa_flag = 4
         max_dm_flag = 6
 
-    # First pass, remove bad densities
+    # First pass, keep good RPA fits
     idx, = np.where(inst.data.RPAflag <= max_rpa_flag)
+    if (inst.clean_level == 'clean'):
+        nO = inst.data.ion1fraction*inst.data.Ni
+        idx2 = np.where((inst.data.RPAflag <= 3) and (nO > 3.0e4))
+        idx = np.unique(idx.extend(idx2))
     inst.data = inst[idx, :]
 
     # Second pass, find bad drifts, replace with NaNs

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -134,7 +134,7 @@ def clean(inst):
     # Second pass, find bad drifts
     drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
                     'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
-    idx, = np.where(inst.data.DMflag > max_dm_flag)
+    idx, = np.where(inst.data.driftMeterflag > max_dm_flag)
 
     # Also exclude very large drifts
     if (inst.clean_level == 'clean') | (inst.clean_level == 'dusty'):

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -19,6 +19,17 @@ de La Beaujardière, O., et al. (2004), C/NOFS: A mission to forecast
 scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
 doi:10.1016/j.jastp.2004.07.030.
 
+Discussion of cleaning parameters for ion drifts can be found in:
+Burrell, Angeline G., Equatorial topside magnetic field-aligned ion drifts 
+at solar minimum, The University of Texas at Dallas, ProQuest 
+Dissertations Publishing, 2012. 3507604. 
+
+Discussion of cleaning parameters for ion temperature can be found in:
+Hairston, M. R., W. R. Coley, and R. A. Heelis (2010), Mapping the 
+duskside topside ionosphere with CINDI and DMSP, J. Geophys. Res.,115, 
+A08324, doi:10.1029/2009JA015051.
+
+
 Parameters
 ----------
 platform : string
@@ -141,7 +152,6 @@ def clean(inst):
 
     # Check for bad RPA fits in dusty regime.
     # O+ concentration criteria from Burrell, 2012
-    # Shallow Fit region from Klenzing and Stoneback ????
     if (inst.clean_level == 'dusty'):
         # shallow fit region for vx
         idx, = np.where(inst.data.ion1fraction >= 1.0)
@@ -159,7 +169,7 @@ def clean(inst):
             inst[label][idx0] = np.NaN
 
     # Check for bad temperature fits (O+ < 15%), replace with NaNs
-    # Criteria from Hairston et al, 2015
+    # Criteria from Hairston et al, 2010
     if (inst.clean_level == 'clean') | (inst.clean_level == 'dusty'):
         idx, = np.where(inst.data.ion1fraction < 0.15)
         inst['ionTemperature'][idx] = np.NaN

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -127,16 +127,28 @@ def clean(inst):
     # Also exclude very large drifts and drifts where 100% O+
     if (inst.clean_level == 'clean') | (inst.clean_level == 'dusty'):
         try:
+            # unrealistic velocities
             idx2, = np.where(np.abs(inst.data.ionVelmeridional) >= 10000.)
+            # shallow fit region for vx
             idx3, = np.where(inst.data.ion1fraction >= 1.0)
-            idx = np.unique(np.append(idx, idx2, idx3))
+            if len(idx2)>0:
+                if len(idx)>0:
+                    idx = np.unique(np.append(idx, idx2))
+                else:
+                    idx = idx2
+            if len(idx3)>0:
+                if len(idx)>0:
+                    idx = np.unique(np.append(idx, idx3))
+                else:
+                    idx = idx3
         except AttributeError:
             pass
 
-    drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
-                    'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
-    for label in drift_labels:
-        inst[label][idx] = np.NaN
+    if len(idx)>0:
+        drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
+                        'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
+        for label in drift_labels:
+            inst[label][idx] = np.NaN
 
     # Check for bad temperature fits (O+ < 15%), replace with NaNs
     # Criteria from Hairston et al, 2015


### PR DESCRIPTION
# Description

Addresses #115.

Currently the C/NOFS IVM cleaning routine only provides data for where the drifts are reliable.  However, it is possible in some cases to have reliable density, composition, and temperature information where the drifts are suspect.  This updates the clean parameters to allow all desired data through while replacing suspect drifts with NaNs.

Instrument quality flags described in https://cdaweb.gsfc.nasa.gov/pub/data/cnofs/cindi/CINDI%20IVM%20Quality%20Flag%20Description.doc (last updated 2018-01-25).

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

tested ivm.load locally.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
