### PR TITLE
python 2.7.15 tests in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 matrix:
   include:
-    - python: 2.7.14
+    - python: 2.7
       services: xvfb
     - python: 3.7
       dist: xenial
@@ -23,6 +23,7 @@ before_install:
   #- apt-get update
   - pip install coveralls
   - pip install future
+  - pip install apexpy
   - pip install pysatCDF >/dev/null
   # install pyglow, space science models
   - cd ..

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Fixed issue with data access via Instrument object using time and name slicing and xarray. Added unit test.
    - Updated travis.yml to work under pysat organization
    - Added missing requirements (matplotlib, netCDF4)
+   - Updated travis.yml to work with python 2.7.15
 - Documentation
   - Added info on how to cite the code and package.
   - Updated instrument docstring


### PR DESCRIPTION
# Description

Back in April, we ran into an issue with installing apexpy on Travis for python 2.7.15.  It is still not known why this was an issue, but it was unique to the automated installation through install requires on the Travis environment.  Issues did not appear on the `apexpy` account for 2.7.15.  This issue was temporarily solved by forcing Travis CI tests to run for python 2.7.14.

This PR manually installs apexpy as part of the Travis CI setup, which circumvents the problem in the testing environment and allows 2.7.15 to be tested.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested on Travis CI (change in configuration)

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
