### PR TITLE
BUG: add deprecation warning for season_date_range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Added keyword ignore_empty_files to pysat.Instrument and Files objects
     to filter out empty files from the stored file list
 - Code Restructure
-  - Move `computational_form` to `ssnl`
-  - Move `scale_units` to `utils._core`
-  - Replace `season_date_range` with `create_date_range`, add deprecation warning
+  - Move `computational_form` to `ssnl`, old version is deprecated
+  - Move `scale_units` to `utils._core`, old version is deprecated
+  - Replace `season_date_range` with `create_date_range`, old version is deprecated
   - Added deprecation warnings to stat functions
 - Bug fix
    - Fixed implementation of utils routines in model_utils and jro_isr

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Code Restructure
   - Move `computational_form` to `ssnl`
   - Move `scale_units` to `utils._core`
-  - Rename `season_date_range` as `create_date_range`
+  - Replace `season_date_range` with `create_date_range`, add deprecation warning
   - Added deprecation warnings to stat functions
 - Bug fix
    - Fixed implementation of utils routines in model_utils and jro_isr

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -39,6 +39,23 @@ def remove_files(inst):
                 os.unlink(file_path)
 
 
+def test_deprecation_warning_computational_form():
+    """Test if computational form in utils is deprecated"""
+
+    import pandas as pds
+    import warnings
+
+    data = pds.Series([0, 1, 2])
+    warnings.simplefilter("always")
+    dslice1 = pysat.ssnl.computational_form(data)
+    with warnings.catch_warnings(record=True) as w:
+        dslice2 = pysat.utils.computational_form(data)
+
+    assert (dslice1 == dslice2).all()
+    assert len(w) == 1
+    assert w[0].category == DeprecationWarning
+
+
 class TestBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup."""

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -109,6 +109,20 @@ class TestBasics():
         coords.calc_solar_local_time(self.testInst, lon_name="not longitude",
                                      slt_name='slt')
 
+    def test_deprecation_warning_scale_units(self):
+        """Test deprecation warning for this function"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        scale1 = pysat.utils.scale_units("happy", "happy")
+        with warnings.catch_warnings(record=True) as w:
+            scale2 = coords.scale_units("happy", "happy")
+
+        assert scale1 == scale2
+        assert len(w) == 1
+        assert w[0].category == DeprecationWarning
+
     ###################################
     # Geodetic / Geocentric conversions
 

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -165,3 +165,23 @@ def test_create_datetime_index_wo_month_day_uts():
     assert dates[0] == pds.datetime(2012, 1, 1)
     assert dates[-1] == pds.datetime(2012, 1, 1)
     assert len(dates) == 4
+
+
+def test_deprecated_season_date_range():
+    """Tests that deprecation of season_date_range is working"""
+
+    import warnings
+
+    start = pds.datetime(2012, 2, 28)
+    stop = pds.datetime(2012, 3, 1)
+    warnings.simplefilter("always")
+    with warnings.catch_warnings(record=True) as w1:
+        season1 = pytime.create_date_range(start, stop, freq='D')
+    with warnings.catch_warnings(record=True) as w2:
+        season2 = pytime.season_date_range(start, stop, freq='D')
+
+    assert len(season1) == len(season2)
+    assert (season1 == season2).all()
+    assert len(w1) == 0
+    assert len(w2) == 1
+    assert w2[0].category == DeprecationWarning

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -62,7 +62,7 @@ def test_parse_date_4_digit_year():
 def test_parse_date_bad_input():
     """Test the ability to idenitfy a non-physical date"""
 
-    date = pytime.parse_date('194', '15', '31')
+    _ = pytime.parse_date('194', '15', '31')
 
 
 ############
@@ -152,7 +152,7 @@ def test_create_datetime_index():
 def test_create_datetime_index_wo_year():
     """Must include a year"""
 
-    dates = pytime.create_datetime_index()
+    _ = pytime.create_datetime_index()
 
 
 def test_create_datetime_index_wo_month_day_uts():

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -10,4 +10,4 @@ for the pysat data directory structure.
 """
 
 from . import coords, stats, time
-from ._core import set_data_dir, scale_units, load_netcdf4
+from ._core import set_data_dir, scale_units, load_netcdf4, computational_form

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import numpy as np
+import pysat
 
 
 def set_data_dir(path=None, store=True):
@@ -34,6 +35,19 @@ def set_data_dir(path=None, store=True):
         pysat._instrument = re_load(pysat._instrument)
     else:
         raise ValueError('Path %s does not lead to a valid directory.' % path)
+
+
+def computational_form(data):
+    """Deprecated function.  Moved to pysat.ssnl.computational_form"""
+
+    import warnings
+
+    warnings.warn(' '.join(["utils.computational_form is deprecated, use",
+                            "pysat.ssnl.computational_form instead"]),
+                  DeprecationWarning)
+    dslice = pysat.ssnl.computational_form(data)
+
+    return dslice
 
 
 def scale_units(out_unit, in_unit):

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -135,6 +135,20 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
     return
 
 
+def scale_units(out_unit, in_unit):
+    """Deprecated function, moved to pysat.utils._core"""
+
+    import warnings
+    from pysat import utils
+
+    warnings.warn(' '.join(["utils.computational_form is deprecated, use",
+                            "pysat.ssnl.computational_form instead"]),
+                  DeprecationWarning)
+    unit_scale = utils.scale_units(out_unit, in_unit)
+
+    return unit_scale
+
+
 def geodetic_to_geocentric(lat_in, lon_in=None, inverse=False):
     """Converts position from geodetic to geocentric or vice-versa.
 

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -124,6 +124,29 @@ def calc_freq(index):
     return freq
 
 
+def season_date_range(start, stop, freq='D'):
+    """
+    Return array of datetime objects using input frequency from start to stop
+
+    Supports single datetime object or list, tuple, ndarray of start and
+    stop dates.
+
+    freq codes correspond to pandas date_range codes, D daily, M monthly,
+    S secondly
+
+    """
+
+    import warnings
+
+    warnings.warn(' '.join(["utils.time.season_date_range is deprecated, use",
+                            "utils.time.create_date_range instead"]),
+                  DeprecationWarning)
+
+    season = create_date_range(start, stop, freq='D')
+
+    return season
+
+
 def create_date_range(start, stop, freq='D'):
     """
     Return array of datetime objects using input frequency from start to stop

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -126,13 +126,9 @@ def calc_freq(index):
 
 def season_date_range(start, stop, freq='D'):
     """
-    Return array of datetime objects using input frequency from start to stop
+    Deprecated Function, will be removed in future version.
 
-    Supports single datetime object or list, tuple, ndarray of start and
-    stop dates.
-
-    freq codes correspond to pandas date_range codes, D daily, M monthly,
-    S secondly
+    Replaced by create_date_range
 
     """
 


### PR DESCRIPTION
# Description

Back in #272, `season_date_range` was renamed as `create_date_range`.  There should be a deprecation warning for users or packages that use this notation (eg, pysat/pysatMagVect#24).

This pull adds `season_date_range` back to `pysat.utils.time`, which now triggers a deprecation warning and calls the new function.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
start = pysat.datetime(2019,1,1) 
stop = pysat.datetime(2019,1,31) 
pysat.utils.time.create_date_range(start,stop)  
pysat.utils.time.season_date_range(start,stop)   
```

Output should be identical.  Deprecation warning not showing up on my system.  :/

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
