### PR TITLE
STY: do not overwrite open in setup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Added missing requirements (matplotlib, netCDF4)
    - Fixed a bug when trying to combine empty kp lists
    - Updated travis.yml to work with python 2.7.15
+   - Updated setup.py to not overwrite defauly `open` command from `codecs`
 - Documentation
   - Added info on how to cite the code and package.
   - Updated instrument docstring

--- a/setup.py
+++ b/setup.py
@@ -7,15 +7,15 @@ https://github.com/pypa/sampleproject
 # Always prefer setuptools over distutils
 from setuptools import setup
 # To use a consistent encoding
-from codecs import open
+import codecs
 import os
 import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(here, 'description.txt'), encoding='utf-8') as f:
+with codecs.open(os.path.join(here, 'description.txt'), encoding='utf-8') as f:
     long_description = f.read()
 version_filename = os.path.join('pysat', 'version.txt')
-with open(os.path.join(here, version_filename)) as version_file:
+with codecs.open(os.path.join(here, version_filename)) as version_file:
     version = version_file.read().strip()
 
 # change setup.py for readthedocs


### PR DESCRIPTION
# Description

Setup currently overwrites `open` by importing from `codecs`.  Rewriting to keep code more clear.  This was caught in the subpackages.  Updating here for consistency.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Travis CI

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
