### PR TITLE
S4 scintillation added to cosmic_gps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Added keyword ignore_empty_files to pysat.Instrument and Files objects
     to filter out empty files from the stored file list
    - Updated cleaning routines for C/NOFS IVM
+   - Added S4 scintillation data to the cosmic-gps instrument
 - Code Restructure
   - Move `computational_form` to `ssnl`, old version is deprecated
   - Move `scale_units` to `utils._core`, old version is deprecated

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -22,7 +22,7 @@ platform : string
 name : string
     'gps' for Radio Occultation profiles
 tag : string
-    Select profile type, or scintillation, one of: 
+    Select profile type, or scintillation, one of:
     {'ionprf', 'sonprf', 'wetprf', 'atmprf', 'scnlv1'}
 sat_id : string
     None supported

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -22,7 +22,8 @@ platform : string
 name : string
     'gps' for Radio Occultation profiles
 tag : string
-    Select profile type, one of {'ionprf', 'sonprf', 'wetprf', 'atmprf'}
+    Select profile type, or scintillation, one of: 
+    {'ionprf', 'sonprf', 'wetprf', 'atmprf', 'scnlv1'}
 sat_id : string
     None supported
 

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -32,7 +32,7 @@ Note
 - 'ionprf: 'ionPrf' ionosphere profiles
 - 'sonprf': 'sonPrf' files
 - 'wetprf': 'wetPrf' files
-- 'atmPrf': 'atmPrf' files
+- 'atmprf': 'atmPrf' files
 - 'scnlv1': 'scnLv1' files
 
 Warnings
@@ -63,7 +63,8 @@ sat_ids = {'': ['ionprf', 'sonprf', 'wetprf', 'atmprf', 'scnlv1']}
 test_dates = {'': {'ionprf': pysat.datetime(2008, 1, 1),
                    'sonprf': pysat.datetime(2008, 1, 1),
                    'wetprf': pysat.datetime(2008, 1, 1),
-                   'atmprf': pysat.datetime(2008, 1, 1)}}
+                   'atmprf': pysat.datetime(2008, 1, 1),
+                   'scnlv1': pysat.datetime(2008, 1, 1)}}
 
 
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
@@ -305,7 +306,7 @@ def download(date_array, tag, sat_id, data_path=None,
         sub_dir = 'sonPrf'
     elif tag == 'wetprf':
         sub_dir = 'wetPrf'
-    elif tag == 'atmPrf':
+    elif tag == 'atmprf':
         sub_dir = 'atmPrf'
     elif tag == 'scnlv1':
         sub_dir = 'scnLv1'

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -32,6 +32,7 @@ Note
 - 'sonprf': 'sonPrf' files
 - 'wetprf': 'wetPrf' files
 - 'atmPrf': 'atmPrf' files
+- 'scnlv1': 'scnLv1' files
 
 Warnings
 --------
@@ -55,8 +56,9 @@ name = 'gps'
 tags = {'ionprf': '',
         'sonprf': '',
         'wetprf': '',
-        'atmprf': ''}
-sat_ids = {'': ['ionprf', 'sonprf', 'wetprf', 'atmprf']}
+        'atmprf': '',
+        'scnlv1': ''}
+sat_ids = {'': ['ionprf', 'sonprf', 'wetprf', 'atmprf', 'scnlv1']}
 test_dates = {'': {'ionprf': pysat.datetime(2008, 1, 1),
                    'sonprf': pysat.datetime(2008, 1, 1),
                    'wetprf': pysat.datetime(2008, 1, 1),
@@ -106,11 +108,17 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         microseconds = [None] * num
         for i, f in enumerate(fnames):
             f2 = f.split('.')
-            year[i] = f2[-6]
-            days[i] = f2[-5]
-            hours[i] = f2[-4]
-            minutes[i] = f2[-3]
             microseconds[i] = i
+            if tag != 'scnlv1':
+                year[i] = f2[-6]
+                days[i] = f2[-5]
+                hours[i] = f2[-4]
+                minutes[i] = f2[-3]
+            else:
+                year[i] = f2[-8]
+                days[i] = f2[-7]
+                hours[i] = f2[-6]
+                minutes[i] = f2[-5]
 
         year = np.array(year).astype(int)
         days = np.array(days).astype(int)
@@ -298,6 +306,8 @@ def download(date_array, tag, sat_id, data_path=None,
         sub_dir = 'wetPrf'
     elif tag == 'atmPrf':
         sub_dir = 'atmPrf'
+    elif tag == 'scnlv1':
+        sub_dir = 'scnLv1'
     else:
         raise ValueError('Unknown cosmic_gps tag')
 
@@ -329,7 +339,7 @@ def download(date_array, tag, sat_id, data_path=None,
                 req = requests.get(dwnld, auth=HTTPBasicAuth(user, password))
                 req.raise_for_status()
             except requests.exceptions.HTTPError as err:
-                estr = ''.join(str(err), '\n', 'Data not found')
+                estr = ''.join((str(err), '\n', 'Data not found'))
                 print(estr)
         fname = os.path.join(data_path,
                              'cosmic_' + sub_dir + '_' + yrdoystr + '.tar')
@@ -413,7 +423,7 @@ def clean(inst):
         # filter out any measurements where things have been set to NaN
         inst.data = inst.data[inst.data.edmaxalt.notnull()]
 
-    elif inst.tag == 'scnlvl1':
+    elif inst.tag == 'scnlv1':
         # scintillation files
         if inst.clean_level == 'clean':
             # try and make sure all data is good


### PR DESCRIPTION
added S4 scintillation tag and filename handling to the cosmic_gps instrument

# Description
Small update to the cosmic_gps instrument to include the tag 'scnlv1' for the 'scnLv1' data from CDAAC.

Addresses # (issue)
No existing issue, but the S4 data is an important data product from COSMIC that is not included in the current develop branch.
No new dependencies

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- pylint
- Downloaded cosmic data from CDAAC
- ran a seasonal average using the downloaded data
- ran the unit tests successfully (although this instrument is skipped)

**Test Configuration**:
OS: CentOS 7 (rhel fedora)
Python 3.7
ran this in a conda environment. Didn't reset any of the files in the ~/.pysat directory so technically not a 100% "clean" pysat install

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
