### PR TITLE
TST: remove apexpy from test environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - cd /home/travis/build/pysat
+  - cd ./pysat
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,16 @@ before_install:
   #- apt-get update
   - pip install coveralls
   - pip install future
+  - pip install apexpy
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies
 install:
   - source activate test-environment
   # set up data directory
-  - mkdir /home/travis/build/pysat/pysatData
+  - mkdir /home/travis/build/pysatData
   # install pysat
-  - cd /home/travis/build/pysat/pysat
+  - cd /home/travis/build/pysat
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
   #- apt-get update
   - pip install coveralls
   - pip install future
-  - pip install apexpy
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
+  - pwd
   - cd ./pysat
+  - pwd
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - pwd
-  - cd ./pysat
-  - pwd
   - python setup.py install
 
 before_script:

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -63,7 +63,7 @@ if not os.path.isdir(pysat_dir):
     if not (os.environ.get('TRAVIS') == 'true'):
         data_dir = os.path.join(home_dir, 'pysatData')
     else:
-        data_dir = '/home/travis/build/pysat/pysatData'
+        data_dir = '/home/travis/build/pysatData'
     with open(os.path.join(pysat_dir, 'data_path.txt'), 'w') as f:
         f.write(data_dir)
     print(''.join(("\nHi there!  Pysat will nominally store data in the "


### PR DESCRIPTION
# Description

Accidentally left apexpy in the list of manual travis installs back in #299.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing on travis CI, since this is part of the setup.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
