### PR TITLE
BUG: Travis update - generalize environment for forks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,7 @@ addons:
     - gfortran
     - libncurses5-dev
 
-# Setup anaconda
 before_install:
-  #- apt-get update
   - pip install coveralls
   - pip install future
   - pip install pysatCDF >/dev/null

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - cd /home/travis/build/pysat
+  - cd ./pysat
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,16 @@ before_install:
   #- apt-get update
   - pip install coveralls
   - pip install future
+  - pip install apexpy
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies
 install:
   - source activate test-environment
   # set up data directory
-  - mkdir /home/travis/build/pysat/pysatData
+  - mkdir /home/travis/build/pysatData
   # install pysat
-  - cd /home/travis/build/pysat/pysat
+  - cd /home/travis/build/pysat
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ before_install:
   #- apt-get update
   - pip install coveralls
   - pip install future
-  - pip install apexpy
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,9 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
+  - pwd
   - cd ./pysat
+  - pwd
   - python setup.py install
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,9 +29,6 @@ install:
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
-  - pwd
-  - cd ./pysat
-  - pwd
   - python setup.py install
 
 before_script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.X.X] - 2019-09-20
+## [2.X.X] - 2019-10-16
 - New Features
    - Added new velocity format options to utils.coords.scale_units
    - Improved failure messages for utils.coords.scale_units
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Updated travis.yml to work with python 2.7.15
    - Unit tests reload pysat_testing_xarray for xarray tests
    - Updated setup.py to not overwrite defauly `open` command from `codecs`
+   - Updated Travis CI settings to allow forks to run tests on local travis accounts
 - Documentation
   - Added info on how to cite the code and package.
   - Updated instrument docstring

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -63,7 +63,7 @@ if not os.path.isdir(pysat_dir):
     if not (os.environ.get('TRAVIS') == 'true'):
         data_dir = os.path.join(home_dir, 'pysatData')
     else:
-        data_dir = '/home/travis/build/pysat/pysatData'
+        data_dir = '/home/travis/build/pysatData'
     with open(os.path.join(pysat_dir, 'data_path.txt'), 'w') as f:
         f.write(data_dir)
     print(''.join(("\nHi there!  Pysat will nominally store data in the "


### PR DESCRIPTION
# Description

Addresses #295.

Updates the travis implementation of unit tests.  The `pysatData` directory is moved to the /home/travis/build directory, which is both writable and user-independent.  This allows the community to run Travis CI tests on forks of the main branch.  Also cleans up some areas of the travis.yml file.

Pulling from forked pysat to demonstrate.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via Travis CI, since this changes the environment settings there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
