### PR TITLE
Deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Move `scale_units` to `utils._core`, old version is deprecated
   - Replace `season_date_range` with `create_date_range`, old version is deprecated
   - Added deprecation warnings to stat functions
+  - Added deprecation warnings to `ssnl` and `model_utils`
   - Removed `pysat_sgp4` instrument
 - Bug fix
    - Fixed implementation of utils routines in model_utils and jro_isr

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1342,7 +1342,7 @@ class Instrument(object):
                                  ')')
         else:
             warnings.warn('Strict times will eventually be enforced upon all instruments.'
-                          ' (strict_time_flag)', DeprecationWarning)
+                          ' (strict_time_flag)', DeprecationWarning, stacklevel=2)
 
         # apply default instrument routine, if data present
         if not self.empty:

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -18,7 +18,8 @@ import pandas as pds
 import warnings
 
 
-def satellite_view_through_model(sat, tie, scoords, tlabels):
+def satellite_view_through_model(sat=None, tie=None, scoords=None,
+                                 tlabels=None):
     """Interpolate model values onto satellite orbital path.
 
     Parameters

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -18,8 +18,7 @@ import pandas as pds
 import warnings
 
 
-def satellite_view_through_model(sat=None, tie=None, scoords=None,
-                                 tlabels=None):
+def satellite_view_through_model(sat, tie, scoords, tlabels):
     """Interpolate model values onto satellite orbital path.
 
     Parameters

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -37,7 +37,7 @@ def satellite_view_through_model(sat, tie, scoords, tlabels):
                             "removed in pysat 3.0.0. Please use",
                             "pysatModelUtils instead:"
                             "https://github.com/pysat/pysatModelUtils"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     # tiegcm is in pressure levels, need in altitude, but on regular
     # grid
@@ -127,7 +127,7 @@ def compare_model_and_inst(pairs=None, inst_name=[], mod_name=[],
                             "removed in pysat 3.0.0. Please use",
                             "pysatModelUtils instead:"
                             "https://github.com/pysat/pysatModelUtils"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     method_rout = {"bias": verify.bias, "accuracy": verify.accuracy,
                    "meanPercentageError": verify.meanPercentageError,
@@ -318,7 +318,7 @@ def collect_inst_model_pairs(start=None, stop=None, tinc=None, inst=None,
                             "removed in pysat 3.0.0. Please use",
                             "pysatModelUtils instead:"
                             "https://github.com/pysat/pysatModelUtils"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     matched_inst = None
 
@@ -511,7 +511,7 @@ def extract_modelled_observations(inst=None, model=None, inst_name=[],
                             "removed in pysat 3.0.0. Please use",
                             "pysatModelUtils instead:"
                             "https://github.com/pysat/pysatModelUtils"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     # Test input
     if inst is None:

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import
 import datetime as dt
 import numpy as np
 import pandas as pds
+import warnings
 
 
 def satellite_view_through_model(sat, tie, scoords, tlabels):
@@ -32,9 +33,11 @@ def satellite_view_through_model(sat, tie, scoords, tlabels):
         Variable names from model to interpolate onto sat locations
     """
 
-    import warnings
-
-    warnings.warn('Preliminary code.  Currently tested for TIE-GCM')
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatModelUtils instead:"
+                            "https://github.com/pysat/pysatModelUtils"]),
+                  DeprecationWarning)
 
     # tiegcm is in pressure levels, need in altitude, but on regular
     # grid
@@ -119,6 +122,12 @@ def compare_model_and_inst(pairs=None, inst_name=[], mod_name=[],
     """
     import verify  # PyForecastTools
     from pysat import utils
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatModelUtils instead:"
+                            "https://github.com/pysat/pysatModelUtils"]),
+                  DeprecationWarning)
 
     method_rout = {"bias": verify.bias, "accuracy": verify.accuracy,
                    "meanPercentageError": verify.meanPercentageError,
@@ -304,6 +313,12 @@ def collect_inst_model_pairs(start=None, stop=None, tinc=None, inst=None,
     """
     from os import path
     import pysat
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatModelUtils instead:"
+                            "https://github.com/pysat/pysatModelUtils"]),
+                  DeprecationWarning)
 
     matched_inst = None
 
@@ -491,6 +506,12 @@ def extract_modelled_observations(inst=None, model=None, inst_name=[],
     """
     from scipy import interpolate
     from pysat import utils
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatModelUtils instead:"
+                            "https://github.com/pysat/pysatModelUtils"]),
+                  DeprecationWarning)
 
     # Test input
     if inst is None:

--- a/pysat/ssnl/_core.py
+++ b/pysat/ssnl/_core.py
@@ -30,7 +30,7 @@ def computational_form(data):
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     if isinstance(data.iloc[0], DataFrame):
         dslice = Panel.from_dict(dict([(i, data.iloc[i])

--- a/pysat/ssnl/_core.py
+++ b/pysat/ssnl/_core.py
@@ -24,6 +24,13 @@ def computational_form(data):
     """
 
     from pysat import DataFrame, Series, Panel
+    import warnings
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
 
     if isinstance(data.iloc[0], DataFrame):
         dslice = Panel.from_dict(dict([(i, data.iloc[i])

--- a/pysat/ssnl/avg.py
+++ b/pysat/ssnl/avg.py
@@ -10,6 +10,7 @@ import pysat
 import numpy as np
 import pandas as pds
 import collections
+import warnings
 
 
 def median1D(const, bin1, label1, data_label, auto_bin=True, returnData=False):
@@ -40,6 +41,12 @@ def median1D(const, bin1, label1, data_label, auto_bin=True, returnData=False):
         the bin edges in 'bin_x'
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
 
     # const is either an Instrument or a Constellation, and we want to
     #  iterate over it.
@@ -124,6 +131,12 @@ def median2D(const, bin1, label1, bin2, label2, data_label,
 
     """
 
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
+
     # const is either an Instrument or a Constellation, and we want to
     #  iterate over it.
     # If it's a Constellation, then we can do that as is, but if it's
@@ -202,6 +215,7 @@ def median2D(const, bin1, label1, bin2, label2, data_label,
 
 def _calc_2d_median(ans, data_label, binx, biny, xarr, yarr, zarr, numx,
                     numy, numz, returnData=False):
+
     # set up output arrays
     medianAns = [[[None for i in xarr] for j in yarr] for k in zarr]
     countAns = [[[None for i in xarr] for j in yarr] for k in zarr]
@@ -325,6 +339,13 @@ def mean_by_day(inst, data_label):
         simple mean of data_label indexed by day
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
+
     return _core_mean(inst, data_label, by_day=True)
 
 
@@ -342,6 +363,13 @@ def mean_by_orbit(inst, data_label):
         simple mean of data_label indexed by start of each orbit
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
+
     return _core_mean(inst, data_label, by_orbit=True)
 
 
@@ -359,6 +387,13 @@ def mean_by_file(inst, data_label):
         simple mean of data_label indexed by start of each file
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
+
     return _core_mean(inst, data_label, by_file=True)
 
 
@@ -389,7 +424,7 @@ def _core_mean(inst, data_label, by_orbit=False, by_day=False, by_file=False):
             # perform average
             mean_val[date] = \
                 pysat.ssnl.computational_form(data).mean(axis=0,
-                                                          skipna=True)
+                                                         skipna=True)
 
     del iterator
     return mean_val
@@ -410,7 +445,8 @@ def _calc_1d_median(ans, data_label, binx, xarr, zarr, numx, numz,
     This is an overcomplicated way of doing this.  Try and simplify later
 
     """
-    # set up output arrays
+
+# set up output arrays
     medianAns = [[None for i in xarr] for k in zarr]
     countAns = [[None for i in xarr] for k in zarr]
     devAns = [[None for i in xarr] for k in zarr]

--- a/pysat/ssnl/avg.py
+++ b/pysat/ssnl/avg.py
@@ -446,7 +446,7 @@ def _calc_1d_median(ans, data_label, binx, xarr, zarr, numx, numz,
 
     """
 
-# set up output arrays
+    # set up output arrays
     medianAns = [[None for i in xarr] for k in zarr]
     countAns = [[None for i in xarr] for k in zarr]
     devAns = [[None for i in xarr] for k in zarr]

--- a/pysat/ssnl/avg.py
+++ b/pysat/ssnl/avg.py
@@ -46,7 +46,7 @@ def median1D(const, bin1, label1, data_label, auto_bin=True, returnData=False):
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     # const is either an Instrument or a Constellation, and we want to
     #  iterate over it.
@@ -135,7 +135,7 @@ def median2D(const, bin1, label1, bin2, label2, data_label,
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     # const is either an Instrument or a Constellation, and we want to
     #  iterate over it.
@@ -344,7 +344,7 @@ def mean_by_day(inst, data_label):
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _core_mean(inst, data_label, by_day=True)
 
@@ -368,7 +368,7 @@ def mean_by_orbit(inst, data_label):
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _core_mean(inst, data_label, by_orbit=True)
 
@@ -392,7 +392,7 @@ def mean_by_file(inst, data_label):
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _core_mean(inst, data_label, by_file=True)
 

--- a/pysat/ssnl/occur_prob.py
+++ b/pysat/ssnl/occur_prob.py
@@ -18,6 +18,7 @@ object as the season of interest.
 """
 
 import numpy as np
+import warnings
 
 
 def daily2D(inst, bin1, label1, bin2, label2, data_label, gate,
@@ -59,6 +60,12 @@ def daily2D(inst, bin1, label1, bin2, label2, data_label, gate,
     Season delineated by the bounds attached to Instrument object.
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
 
     return _occurrence2D(inst, bin1, label1, bin2, label2, data_label, gate,
                          by_orbit=False, returnBins=returnBins)
@@ -102,6 +109,12 @@ def by_orbit2D(inst, bin1, label1, bin2, label2, data_label, gate,
     Season delineated by the bounds attached to Instrument object.
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
 
     return _occurrence2D(inst, bin1, label1, bin2, label2, data_label, gate,
                          by_orbit=True, returnBins=returnBins)
@@ -211,6 +224,12 @@ def daily3D(inst, bin1, label1, bin2, label2, bin3, label3,
 
     """
 
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
+
     return _occurrence3D(inst, bin1, label1, bin2, label2, bin3, label3,
                          data_label, gate, returnBins=returnBins,
                          by_orbit=False)
@@ -253,6 +272,12 @@ def by_orbit3D(inst, bin1, label1, bin2, label2, bin3, label3,
     Season delineated by the bounds attached to Instrument object.
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
 
     return _occurrence3D(inst, bin1, label1, bin2, label2, bin3, label3,
                          data_label, gate, returnBins=returnBins,

--- a/pysat/ssnl/occur_prob.py
+++ b/pysat/ssnl/occur_prob.py
@@ -65,7 +65,7 @@ def daily2D(inst, bin1, label1, bin2, label2, data_label, gate,
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _occurrence2D(inst, bin1, label1, bin2, label2, data_label, gate,
                          by_orbit=False, returnBins=returnBins)
@@ -114,7 +114,7 @@ def by_orbit2D(inst, bin1, label1, bin2, label2, data_label, gate,
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _occurrence2D(inst, bin1, label1, bin2, label2, data_label, gate,
                          by_orbit=True, returnBins=returnBins)
@@ -228,7 +228,7 @@ def daily3D(inst, bin1, label1, bin2, label2, bin3, label3,
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _occurrence3D(inst, bin1, label1, bin2, label2, bin3, label3,
                          data_label, gate, returnBins=returnBins,
@@ -277,7 +277,7 @@ def by_orbit3D(inst, bin1, label1, bin2, label2, bin3, label3,
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     return _occurrence3D(inst, bin1, label1, bin2, label2, bin3, label3,
                          data_label, gate, returnBins=returnBins,

--- a/pysat/ssnl/plot.py
+++ b/pysat/ssnl/plot.py
@@ -36,7 +36,7 @@ def scatterplot(inst, labelx, labely, data_label, datalim, xlim=None,
                             "removed in pysat 3.0.0. Please use",
                             "pysatSeasons instead:"
                             "https://github.com/pysat/pysatSeasons"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     if mpl.is_interactive():
         interactive_mode = True

--- a/pysat/ssnl/plot.py
+++ b/pysat/ssnl/plot.py
@@ -5,6 +5,7 @@ import matplotlib as mpl
 import matplotlib.pyplot as plt
 from mpl_toolkits.mplot3d import Axes3D
 import numpy as np
+import warnings
 
 
 def scatterplot(inst, labelx, labely, data_label, datalim, xlim=None,
@@ -30,6 +31,12 @@ def scatterplot(inst, labelx, labely, data_label, datalim, xlim=None,
     stop datetime objects.
 
     """
+
+    warnings.warn(' '.join(["This function is deprecated here and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "pysatSeasons instead:"
+                            "https://github.com/pysat/pysatSeasons"]),
+                  DeprecationWarning)
 
     if mpl.is_interactive():
         interactive_mode = True

--- a/pysat/tests/test_model_utils.py
+++ b/pysat/tests/test_model_utils.py
@@ -21,18 +21,18 @@ class TestBasics():
     @raises(ValueError)
     def test_collect_inst_model_pairs_wo_date(self):
         """Try to run without start or stop dates"""
-        _ = mu.collect_inst_model_pairs(inst=self.testInst)
+        mu.collect_inst_model_pairs(inst=self.testInst)
 
     @raises(ValueError)
     def test_collect_inst_model_pairs_wo_inst(self):
         """Try to run without an instrument"""
-        _ = mu.collect_inst_model_pairs(start=self.start, stop=self.stop)
+        mu.collect_inst_model_pairs(start=self.start, stop=self.stop)
 
     @raises(ValueError)
     def test_collect_inst_model_pairs_wo_model(self):
         """Try to run without a model"""
-        _ = mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
-                                        inst=self.testInst)
+        mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
+                                    inst=self.testInst)
 
 
 class TestDeprecation():

--- a/pysat/tests/test_model_utils.py
+++ b/pysat/tests/test_model_utils.py
@@ -1,8 +1,4 @@
-import numpy as np
-import sys
-
-from nose.tools import assert_raises, raises
-import pandas as pds
+from nose.tools import raises
 
 import pysat
 from pysat import model_utils as mu
@@ -24,15 +20,15 @@ class TestBasics():
     @raises(ValueError)
     def test_collect_inst_model_pairs_wo_date(self):
         """Try to run without start or stop dates"""
-        match = mu.collect_inst_model_pairs(inst=self.testInst)
+        _ = mu.collect_inst_model_pairs(inst=self.testInst)
 
     @raises(ValueError)
     def test_collect_inst_model_pairs_wo_inst(self):
         """Try to run without an instrument"""
-        match = mu.collect_inst_model_pairs(start=self.start, stop=self.stop)
+        _ = mu.collect_inst_model_pairs(start=self.start, stop=self.stop)
 
     @raises(ValueError)
     def test_collect_inst_model_pairs_wo_model(self):
         """Try to run without a model"""
-        match = mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
-                                            inst=self.testInst)
+        _ = mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
+                                        inst=self.testInst)

--- a/pysat/tests/test_model_utils.py
+++ b/pysat/tests/test_model_utils.py
@@ -1,4 +1,5 @@
 from nose.tools import raises
+import warnings
 
 import pysat
 from pysat import model_utils as mu
@@ -32,3 +33,55 @@ class TestBasics():
         """Try to run without a model"""
         _ = mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
                                         inst=self.testInst)
+
+    def test_satellite_view_through_model_deprecation(self):
+        """Test if satellite_view_through_model is deprecated"""
+        warnings.simplefilter('always')
+
+        with warnings.catch_warnings(record=True) as w:
+            try:
+                mu.satellite_view_through_model()
+            except TypeError:
+                pass
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_collect_inst_model_pairs_deprecation(self):
+        """Test if collect_inst_model_pairs is deprecated"""
+        warnings.simplefilter('always')
+
+        with warnings.catch_warnings(record=True) as w:
+            try:
+                mu.collect_inst_model_pairs()
+            except ValueError:
+                pass
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_compare_model_and_inst_deprecation(self):
+        """Test if compare_model_and_inst is deprecated"""
+        warnings.simplefilter('always')
+
+        with warnings.catch_warnings(record=True) as w:
+            try:
+                mu.compare_model_and_inst()
+            except ValueError:
+                pass
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_extract_modelled_observations_deprecation(self):
+        """Test if extract_modelled_observations is deprecated"""
+        warnings.simplefilter('always')
+
+        with warnings.catch_warnings(record=True) as w:
+            try:
+                mu.extract_modelled_observations()
+            except ValueError:
+                pass
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_model_utils.py
+++ b/pysat/tests/test_model_utils.py
@@ -40,7 +40,7 @@ class TestBasics():
 
         with warnings.catch_warnings(record=True) as w:
             try:
-                mu.satellite_view_through_model()
+                mu.satellite_view_through_model(None, None, None, None)
             except TypeError:
                 pass
 

--- a/pysat/tests/test_model_utils.py
+++ b/pysat/tests/test_model_utils.py
@@ -34,14 +34,25 @@ class TestBasics():
         _ = mu.collect_inst_model_pairs(start=self.start, stop=self.stop,
                                         inst=self.testInst)
 
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
     def test_satellite_view_through_model_deprecation(self):
         """Test if satellite_view_through_model is deprecated"""
-        warnings.simplefilter('always')
 
         with warnings.catch_warnings(record=True) as w:
             try:
                 mu.satellite_view_through_model(None, None, None, None)
             except TypeError:
+                # Setting inst to None should produce a TypeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -49,12 +60,13 @@ class TestBasics():
 
     def test_collect_inst_model_pairs_deprecation(self):
         """Test if collect_inst_model_pairs is deprecated"""
-        warnings.simplefilter('always')
 
         with warnings.catch_warnings(record=True) as w:
             try:
-                mu.collect_inst_model_pairs()
+                mu.collect_inst_model_pairs(inst=None)
             except ValueError:
+                # Setting inst to None should produce a ValueError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -62,12 +74,13 @@ class TestBasics():
 
     def test_compare_model_and_inst_deprecation(self):
         """Test if compare_model_and_inst is deprecated"""
-        warnings.simplefilter('always')
 
         with warnings.catch_warnings(record=True) as w:
             try:
-                mu.compare_model_and_inst()
+                mu.compare_model_and_inst(pairs=None)
             except ValueError:
+                # Setting pairs to None should produce a ValueError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -75,12 +88,13 @@ class TestBasics():
 
     def test_extract_modelled_observations_deprecation(self):
         """Test if extract_modelled_observations is deprecated"""
-        warnings.simplefilter('always')
 
         with warnings.catch_warnings(record=True) as w:
             try:
-                mu.extract_modelled_observations()
+                mu.extract_modelled_observations(inst=None)
             except ValueError:
+                # Setting inst to None should produce a ValueError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -1,11 +1,10 @@
 """
 tests the pysat averaging code
 """
-import numpy as np
-
 from nose.tools import raises
+import numpy as np
 import pandas as pds
-
+import warnings
 import pysat
 from pysat.ssnl import avg
 
@@ -94,9 +93,7 @@ class TestDeprecation():
 
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         clean_level='clean')
-        self.bounds = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 1))
+        warnings.simplefilter("always")
 
     def teardown(self):
         """Runs after every method to clean up previous testing"""
@@ -104,87 +101,67 @@ class TestDeprecation():
     def test_median1D_deprecation_warning(self):
         """Test generation of deprecation warning for median1D"""
 
-        import warnings
-
-        warnings.simplefilter("always")
-
-        self.testInst.bounds = self.bounds
         with warnings.catch_warnings(record=True) as w:
-            med_dict = avg.median1D(self.testInst, [0., 360., 24.],
-                                    'longitude', ['dummy1'])
+            try:
+                avg.median1D(None, [0., 360., 24.],
+                             'longitude', ['dummy1'])
+            except ValueError:
+                # Setting inst to None should produce a ValueError
+                pass
 
-        # Test output type
-        assert isinstance(med_dict, dict)
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 
     def test_median2D_deprecation_warning(self):
         """Test generation of deprecation warning for median1D"""
 
-        import warnings
-
-        warnings.simplefilter("always")
-
-        self.testInst.bounds = self.bounds
         with warnings.catch_warnings(record=True) as w:
-            med_dict = avg.median2D(self.testInst, [0., 360., 24.],
-                                    'longitude', [0., 24., 24.], 'mlt',
-                                    ['dummy1'])
+            try:
+                avg.median2D(None, [0., 360., 24.], 'longitude',
+                             [0., 24., 24.], 'mlt', ['dummy1'])
+            except ValueError:
+                # Setting inst to None should produce a ValueError
+                pass
 
-        # Test output type
-        assert isinstance(med_dict, dict)
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 
     def test_mean_by_day_deprecation_warning(self):
         """Test generation of deprecation warning for mean_by_day"""
 
-        import warnings
-
-        warnings.simplefilter("always")
-
-        self.testInst.bounds = self.bounds
         with warnings.catch_warnings(record=True) as w:
-            med_dict = avg.mean_by_day(self.testInst, 'dummy1')
+            try:
+                avg.mean_by_day(None, 'dummy1')
+            except TypeError:
+                # Setting inst to None should produce a TypeError
+                pass
 
-        # Test output type
-        assert isinstance(med_dict, pds.Series)
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 
     def test_mean_by_orbit_deprecation_warning(self):
         """Test generation of deprecation warning for mean_by_orbit"""
 
-        import warnings
-
-        warnings.simplefilter("always")
-
-        orbit_info = {'kind': 'local time', 'index': 'mlt'}
-        self.testInst = pysat.Instrument('pysat', 'testing',
-                                         clean_level='clean',
-                                         orbit_info=orbit_info)
-        self.testInst.bounds = self.bounds
         with warnings.catch_warnings(record=True) as w:
-            med_dict = avg.mean_by_orbit(self.testInst, 'dummy1')
+            try:
+                avg.mean_by_orbit(None, 'dummy1')
+            except AttributeError:
+                # Setting inst to None should produce a AttributeError
+                pass
 
-        # Test output type
-        assert isinstance(med_dict, pds.Series)
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 
     def test_mean_by_file_deprecation_warning(self):
         """Test generation of deprecation warning for mean_by_file"""
 
-        import warnings
-
-        warnings.simplefilter("always")
-
-        self.testInst.bounds = self.bounds
         with warnings.catch_warnings(record=True) as w:
-            med_dict = avg.mean_by_file(self.testInst, 'dummy1')
+            try:
+                avg.mean_by_file(None, 'dummy1')
+            except TypeError:
+                # Setting inst to None should produce a TypeError
+                pass
 
-        # Test output type
-        assert isinstance(med_dict, pds.Series)
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -5,6 +5,7 @@ import numpy as np
 
 from nose.tools import raises
 import pandas as pds
+import sys
 
 import pysat
 from pysat.ssnl import avg
@@ -94,6 +95,8 @@ class TestDeprecation():
 
     def setup(self):
         """Runs before every method to create a clean testing setup"""
+        if sys.version_info.major == 2:
+            reload(avg)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean')
         self.bounds = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 1))

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -162,11 +162,11 @@ class TestDeprecation():
 
         warnings.simplefilter("always")
 
-        self.testInst.bounds = self.bounds
         orbit_info = {'kind': 'local time', 'index': 'mlt'}
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info=orbit_info)
+        self.testInst.bounds = self.bounds
         with warnings.catch_warnings(record=True) as w:
             med_dict = avg.mean_by_orbit(self.testInst, 'dummy1')
 

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -160,6 +160,10 @@ class TestDeprecation():
         warnings.simplefilter("always")
 
         self.testInst.bounds = self.bounds
+        orbit_info = {'kind': 'local time', 'index': 'mlt'}
+        self.testInst = pysat.Instrument('pysat', 'testing',
+                                         clean_level='clean',
+                                         orbit_info=orbit_info)
         with warnings.catch_warnings(record=True) as w:
             med_dict = avg.mean_by_orbit(self.testInst, 'dummy1')
 

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -5,7 +5,6 @@ import numpy as np
 
 from nose.tools import raises
 import pandas as pds
-import sys
 
 import pysat
 from pysat.ssnl import avg
@@ -95,8 +94,6 @@ class TestDeprecation():
 
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        if sys.version_info.major == 2:
-            reload(avg)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean')
         self.bounds = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 1))

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -90,6 +90,101 @@ class TestBasics():
         assert np.all(ans == 86399/2.0)
 
 
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
+                                         clean_level='clean')
+        self.bounds = (pysat.datetime(2008, 1, 1), pysat.datetime(2008, 1, 1))
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
+    def test_median1D_deprecation_warning(self):
+        """Test generation of deprecation warning for median1D"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+
+        self.testInst.bounds = self.bounds
+        with warnings.catch_warnings(record=True) as w:
+            med_dict = avg.median1D(self.testInst, [0., 360., 24.],
+                                    'longitude', ['dummy1'])
+
+        # Test output type
+        assert isinstance(med_dict, dict)
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_median2D_deprecation_warning(self):
+        """Test generation of deprecation warning for median1D"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+
+        self.testInst.bounds = self.bounds
+        with warnings.catch_warnings(record=True) as w:
+            med_dict = avg.median2D(self.testInst, [0., 360., 24.],
+                                    'longitude', [0., 24., 24.], 'mlt',
+                                    ['dummy1'])
+
+        # Test output type
+        assert isinstance(med_dict, dict)
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_mean_by_day_deprecation_warning(self):
+        """Test generation of deprecation warning for mean_by_day"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+
+        self.testInst.bounds = self.bounds
+        with warnings.catch_warnings(record=True) as w:
+            med_dict = avg.mean_by_day(self.testInst, 'dummy1')
+
+        # Test output type
+        assert isinstance(med_dict, pds.Series)
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_mean_by_orbit_deprecation_warning(self):
+        """Test generation of deprecation warning for mean_by_orbit"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+
+        self.testInst.bounds = self.bounds
+        with warnings.catch_warnings(record=True) as w:
+            med_dict = avg.mean_by_orbit(self.testInst, 'dummy1')
+
+        # Test output type
+        assert isinstance(med_dict, pds.Series)
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_mean_by_file_deprecation_warning(self):
+        """Test generation of deprecation warning for mean_by_file"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+
+        self.testInst.bounds = self.bounds
+        with warnings.catch_warnings(record=True) as w:
+            med_dict = avg.mean_by_file(self.testInst, 'dummy1')
+
+        # Test output type
+        assert isinstance(med_dict, pds.Series)
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+
 class TestFrameProfileAverages():
     def setup(self):
         """Runs before every method to create a clean testing setup."""

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -106,7 +106,8 @@ class TestDeprecation():
                 avg.median1D(None, [0., 360., 24.],
                              'longitude', ['dummy1'])
             except ValueError:
-                # Setting inst to None should produce a ValueError
+                # Setting inst to None should produce a ValueError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -120,7 +121,8 @@ class TestDeprecation():
                 avg.median2D(None, [0., 360., 24.], 'longitude',
                              [0., 24., 24.], 'mlt', ['dummy1'])
             except ValueError:
-                # Setting inst to None should produce a ValueError
+                # Setting inst to None should produce a ValueError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -133,7 +135,8 @@ class TestDeprecation():
             try:
                 avg.mean_by_day(None, 'dummy1')
             except TypeError:
-                # Setting inst to None should produce a TypeError
+                # Setting inst to None should produce a TypeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -146,7 +149,8 @@ class TestDeprecation():
             try:
                 avg.mean_by_orbit(None, 'dummy1')
             except AttributeError:
-                # Setting inst to None should produce a AttributeError
+                # Setting inst to None should produce a AttributeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -159,7 +163,8 @@ class TestDeprecation():
             try:
                 avg.mean_by_file(None, 'dummy1')
             except TypeError:
-                # Setting inst to None should produce a TypeError
+                # Setting inst to None should produce a TypeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1

--- a/pysat/tests/test_ssnl_occur_prob.py
+++ b/pysat/tests/test_ssnl_occur_prob.py
@@ -158,7 +158,8 @@ class TestBasics():
         warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
             occur_prob.by_orbit3D(self.testInst, [0, 24, 2], 'slt',
-                                  [-60, 60, 3], 'latitude', ['slt'], [12.],
+                                  [-60, 60, 3], 'latitude', [0, 360, 4],
+                                  'longitude', ['slt'], [12.],
                                   returnBins=True)
 
         assert len(w) >= 1

--- a/pysat/tests/test_ssnl_occur_prob.py
+++ b/pysat/tests/test_ssnl_occur_prob.py
@@ -125,7 +125,8 @@ class TestDeprecation():
                 occur_prob.daily2D(None, [0, 24, 2], 'slt',
                                    [-60, 60, 3], 'latitude', ['slt'], [12.])
             except TypeError:
-                # Setting inst to None should produce a TypeError
+                # Setting inst to None should produce a TypeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -139,7 +140,8 @@ class TestDeprecation():
                 occur_prob.by_orbit2D(None, [0, 24, 2], 'slt',
                                       [-60, 60, 3], 'latitude', ['slt'], [12.])
             except AttributeError:
-                # Setting inst to None should produce a AttributeError
+                # Setting inst to None should produce a AttributeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -154,7 +156,8 @@ class TestDeprecation():
                                    [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
                                    ['slt'], [12.])
             except TypeError:
-                # Setting inst to None should produce a TypeError
+                # Setting inst to None should produce a TypeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1
@@ -169,7 +172,8 @@ class TestDeprecation():
                                       [-60, 60, 3], 'latitude', [0, 360, 4],
                                       'longitude', ['slt'], [12.])
             except AttributeError:
-                # Setting inst to None should produce a AttributeError
+                # Setting inst to None should produce a AttributeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1

--- a/pysat/tests/test_ssnl_occur_prob.py
+++ b/pysat/tests/test_ssnl_occur_prob.py
@@ -36,20 +36,20 @@ class TestBasics():
     @raises(ValueError)
     def test_occur_prob_daily_2D_w_bad_data_label(self):
         """Catch a data_label that is not list-like"""
-        ans = occur_prob.daily2D(self.testInst, [0, 360, 4], 'longitude',
-                                 [-60, 60, 3], 'latitude', 'slt', [12.])
+        occur_prob.daily2D(self.testInst, [0, 360, 4], 'longitude',
+                           [-60, 60, 3], 'latitude', 'slt', [12.])
 
     @raises(ValueError)
     def test_occur_prob_daily_2D_w_bad_gate(self):
         """Catch a gate that is not list-like"""
-        ans = occur_prob.daily2D(self.testInst, [0, 360, 4], 'longitude',
-                                 [-60, 60, 3], 'latitude', ['slt'], 12.)
+        occur_prob.daily2D(self.testInst, [0, 360, 4], 'longitude',
+                           [-60, 60, 3], 'latitude', ['slt'], 12.)
 
     @raises(ValueError)
     def test_occur_prob_daily_2D_w_mismatched_gate_and_data_label(self):
         """Catch a gate that does not match the data_label"""
-        ans = occur_prob.daily2D(self.testInst, [0, 360, 4], 'longitude',
-                                 [-60, 60, 3], 'latitude', ['slt'], [12., 18.])
+        occur_prob.daily2D(self.testInst, [0, 360, 4], 'longitude',
+                           [-60, 60, 3], 'latitude', ['slt'], [12., 18.])
 
     def test_occur_prob_by_orbit_2D_w_bins(self):
         """Runs a basic probability routine by orbit 2D"""
@@ -77,23 +77,23 @@ class TestBasics():
     @raises(ValueError)
     def test_occur_prob_daily_3D_w_bad_data_label(self):
         """Catch a data_label that is not list-like"""
-        ans = occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
-                                 [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
-                                 'slt', [12.])
+        occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
+                           [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
+                           'slt', [12.])
 
     @raises(ValueError)
     def test_occur_prob_daily_3D_w_bad_gate(self):
         """Catch a gate that is not list-like"""
-        ans = occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
-                                 [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
-                                 ['slt'], 12.)
+        occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
+                           [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
+                           ['slt'], 12.)
 
     @raises(ValueError)
     def test_occur_prob_daily_3D_w_mismatched_gate_and_data_label(self):
         """Catch a gate that does not match the data_label"""
-        ans = occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
-                                 [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
-                                 ['slt'], [12., 18.])
+        occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
+                           [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
+                           ['slt'], [12., 18.])
 
     def test_occur_prob_by_orbit_3D_w_bins(self):
         """Runs a basic probability routine by orbit 3D"""
@@ -107,3 +107,59 @@ class TestBasics():
         assert abs(ans['slt']['bin_x'] - [0, 90, 180, 270, 360]).max() < 1.0e-6
         assert abs(ans['slt']['bin_y'] - [-60, -20, 20, 60]).max() < 1.0e-6
         assert abs(ans['slt']['bin_z'] - [0, 12, 24]).max() < 1.0e-6
+
+    def test_deprecation_warning_daily_2D(self):
+        """Test if occur_prob.daily2D is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            occur_prob.daily2D(self.testInst, [0, 24, 2], 'slt',
+                               [-60, 60, 3], 'latitude', ['slt'], [12.],
+                               returnBins=True)
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_deprecation_warning_by_orbit_2D(self):
+        """Test if occur_prob.by_orbit2D is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            occur_prob.by_orbit2D(self.testInst, [0, 24, 2], 'slt',
+                                  [-60, 60, 3], 'latitude', ['slt'], [12.],
+                                  returnBins=True)
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_deprecation_warning_daily_3D(self):
+        """Test if occur_prob.daily3D is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
+                               [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
+                               ['slt'], [12.], returnBins=True)
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning
+
+    def test_deprecation_warning_by_orbit_3D(self):
+        """Test if occur_prob.by_orbit3D is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            occur_prob.by_orbit3D(self.testInst, [0, 24, 2], 'slt',
+                                  [-60, 60, 3], 'latitude', ['slt'], [12.],
+                                  returnBins=True)
+
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_ssnl_occur_prob.py
+++ b/pysat/tests/test_ssnl_occur_prob.py
@@ -3,7 +3,7 @@ tests the pysat occur_prob object and code
 """
 
 from nose.tools import raises
-
+import warnings
 import pysat
 from pysat.ssnl import occur_prob
 
@@ -108,16 +108,25 @@ class TestBasics():
         assert abs(ans['slt']['bin_y'] - [-60, -20, 20, 60]).max() < 1.0e-6
         assert abs(ans['slt']['bin_z'] - [0, 12, 24]).max() < 1.0e-6
 
+
+class TestDeprecation():
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+
     def test_deprecation_warning_daily_2D(self):
         """Test if occur_prob.daily2D is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            occur_prob.daily2D(self.testInst, [0, 24, 2], 'slt',
-                               [-60, 60, 3], 'latitude', ['slt'], [12.],
-                               returnBins=True)
+            try:
+                occur_prob.daily2D(None, [0, 24, 2], 'slt',
+                                   [-60, 60, 3], 'latitude', ['slt'], [12.])
+            except TypeError:
+                # Setting inst to None should produce a TypeError
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
@@ -125,13 +134,13 @@ class TestBasics():
     def test_deprecation_warning_by_orbit_2D(self):
         """Test if occur_prob.by_orbit2D is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            occur_prob.by_orbit2D(self.testInst, [0, 24, 2], 'slt',
-                                  [-60, 60, 3], 'latitude', ['slt'], [12.],
-                                  returnBins=True)
+            try:
+                occur_prob.by_orbit2D(None, [0, 24, 2], 'slt',
+                                      [-60, 60, 3], 'latitude', ['slt'], [12.])
+            except AttributeError:
+                # Setting inst to None should produce a AttributeError
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
@@ -139,13 +148,14 @@ class TestBasics():
     def test_deprecation_warning_daily_3D(self):
         """Test if occur_prob.daily3D is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            occur_prob.daily3D(self.testInst, [0, 360, 4], 'longitude',
-                               [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
-                               ['slt'], [12.], returnBins=True)
+            try:
+                occur_prob.daily3D(None, [0, 360, 4], 'longitude',
+                                   [-60, 60, 3], 'latitude', [0, 24, 2], 'slt',
+                                   ['slt'], [12.])
+            except TypeError:
+                # Setting inst to None should produce a TypeError
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
@@ -153,14 +163,14 @@ class TestBasics():
     def test_deprecation_warning_by_orbit_3D(self):
         """Test if occur_prob.by_orbit3D is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            occur_prob.by_orbit3D(self.testInst, [0, 24, 2], 'slt',
-                                  [-60, 60, 3], 'latitude', [0, 360, 4],
-                                  'longitude', ['slt'], [12.],
-                                  returnBins=True)
+            try:
+                occur_prob.by_orbit3D(None, [0, 24, 2], 'slt',
+                                      [-60, 60, 3], 'latitude', [0, 360, 4],
+                                      'longitude', ['slt'], [12.])
+            except AttributeError:
+                # Setting inst to None should produce a AttributeError
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_ssnl_plot.py
+++ b/pysat/tests/test_ssnl_plot.py
@@ -89,7 +89,8 @@ class TestDeprecation():
                 plot.scatterplot(None, 'longitude', 'latitude', ['slt', 'mlt'],
                                  [0.0, 24.0])
             except TypeError:
-                # Setting inst to None should produce a TypeError
+                # Setting inst to None should produce a TypeError after
+                # warning is generated
                 pass
 
         assert len(w) >= 1

--- a/pysat/tests/test_ssnl_plot.py
+++ b/pysat/tests/test_ssnl_plot.py
@@ -4,7 +4,7 @@ tests the pysat averaging code
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
-
+import warnings
 import pysat
 from pysat.ssnl import plot
 
@@ -72,16 +72,25 @@ class TestBasics():
         assert len(axes) == 3
         assert len(axes2) == 3
 
+
+class TestDeprecation():
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+
     def test_deprecation_warning_scatterplot(self):
         """Test if scatterplot in ssnl is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            figs = plot.scatterplot(self.testInst, 'longitude', 'latitude',
-                                    'slt', [0.0, 24.0])
+            try:
+                plot.scatterplot(None, 'longitude', 'latitude', ['slt', 'mlt'],
+                                 [0.0, 24.0])
+            except TypeError:
+                # Setting inst to None should produce a TypeError
+                pass
 
-        assert len(figs) == 1
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_ssnl_plot.py
+++ b/pysat/tests/test_ssnl_plot.py
@@ -71,3 +71,17 @@ class TestBasics():
         assert len(figs) == 2
         assert len(axes) == 3
         assert len(axes2) == 3
+
+    def test_deprecation_warning_scatterplot(self):
+        """Test if scatterplot in ssnl is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            figs = plot.scatterplot(self.testInst, 'longitude', 'latitude',
+                                    'slt', [0.0, 24.0])
+
+        assert len(figs) == 1
+        assert len(w) >= 1
+        assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -52,7 +52,7 @@ def test_deprecation_warning_computational_form():
         dslice2 = pysat.utils.computational_form(data)
 
     assert (dslice1 == dslice2).all()
-    assert len(w) == 1
+    assert len(w) >= 1
     assert w[0].category == DeprecationWarning
 
 

--- a/pysat/tests/test_utils_stats.py
+++ b/pysat/tests/test_utils_stats.py
@@ -79,7 +79,7 @@ class TestBasics():
 
         import warnings
 
-        warnings.simplefilter("always", DeprecationWarning)
+        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
             pystats.nan_circmean(self.test_angles, **self.circ_kwargs)
 
@@ -91,7 +91,7 @@ class TestBasics():
 
         import warnings
 
-        warnings.simplefilter("always", DeprecationWarning)
+        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
             pystats.nan_circstd(self.test_angles, **self.circ_kwargs)
 

--- a/pysat/tests/test_utils_stats.py
+++ b/pysat/tests/test_utils_stats.py
@@ -2,9 +2,8 @@
 tests the pysat utils.stats area
 """
 import numpy as np
-
 from scipy import stats as scistats
-
+import warnings
 from pysat.utils import stats as pystats
 
 
@@ -58,18 +57,26 @@ class TestBasics():
         assert np.isnan(ref_nan)
         assert ref_std == test_nan
 
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
     def test_deprecation_warning_median1d(self):
         """Test if median1D in stats is deprecated"""
 
-        import warnings
-        import pysat
-
-        testInst = pysat.Instrument('pysat', 'testing')
-        testInst.load(date=pysat.datetime(2009, 1, 1))
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            pystats.median1D(testInst, [0, 24, 2], 'slt', 'slt')
+            try:
+                pystats.median1D(None, [0, 24, 2], 'slt', 'slt')
+            except AttributeError:
+                # Setting inst to None should produce a AttributeError after
+                # warning is generated
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
@@ -77,11 +84,13 @@ class TestBasics():
     def test_deprecation_warning_circmean(self):
         """Test if circmean in stats is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            pystats.nan_circmean(self.test_angles, **self.circ_kwargs)
+            try:
+                pystats.nan_circmean(None)
+            except TypeError:
+                # Setting input to None should produce a TypeError after
+                # warning is generated
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning
@@ -89,11 +98,13 @@ class TestBasics():
     def test_deprecation_warning_circstd(self):
         """Test if circstd in stats is deprecated"""
 
-        import warnings
-
-        warnings.simplefilter("always")
         with warnings.catch_warnings(record=True) as w:
-            pystats.nan_circstd(self.test_angles, **self.circ_kwargs)
+            try:
+                pystats.nan_circstd(None)
+            except TypeError:
+                # Setting input to None should produce a TypeError after
+                # warning is generated
+                pass
 
         assert len(w) >= 1
         assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_utils_stats.py
+++ b/pysat/tests/test_utils_stats.py
@@ -79,7 +79,7 @@ class TestBasics():
 
         import warnings
 
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", DeprecationWarning)
         with warnings.catch_warnings(record=True) as w:
             pystats.nan_circmean(self.test_angles, **self.circ_kwargs)
 
@@ -91,7 +91,7 @@ class TestBasics():
 
         import warnings
 
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", DeprecationWarning)
         with warnings.catch_warnings(record=True) as w:
             pystats.nan_circstd(self.test_angles, **self.circ_kwargs)
 

--- a/pysat/tests/test_utils_stats.py
+++ b/pysat/tests/test_utils_stats.py
@@ -71,7 +71,7 @@ class TestBasics():
         with warnings.catch_warnings(record=True) as w:
             pystats.median1D(testInst, [0, 24, 2], 'slt', 'slt')
 
-        assert len(w) == 1
+        assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 
     def test_deprecation_warning_circmean(self):
@@ -83,7 +83,7 @@ class TestBasics():
         with warnings.catch_warnings(record=True) as w:
             pystats.nan_circmean(self.test_angles, **self.circ_kwargs)
 
-        assert len(w) == 1
+        assert len(w) >= 1
         assert w[0].category == DeprecationWarning
 
     def test_deprecation_warning_circstd(self):
@@ -95,5 +95,5 @@ class TestBasics():
         with warnings.catch_warnings(record=True) as w:
             pystats.nan_circstd(self.test_angles, **self.circ_kwargs)
 
-        assert len(w) == 1
+        assert len(w) >= 1
         assert w[0].category == DeprecationWarning

--- a/pysat/tests/test_utils_stats.py
+++ b/pysat/tests/test_utils_stats.py
@@ -57,3 +57,43 @@ class TestBasics():
 
         assert np.isnan(ref_nan)
         assert ref_std == test_nan
+
+    def test_deprecation_warning_median1d(self):
+        """Test if median1D in stats is deprecated"""
+
+        import warnings
+        import pysat
+
+        testInst = pysat.Instrument('pysat', 'testing')
+        testInst.load(date=pysat.datetime(2009, 1, 1))
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            pystats.median1D(testInst, [0, 24, 2], 'slt', 'slt')
+
+        assert len(w) == 1
+        assert w[0].category == DeprecationWarning
+
+    def test_deprecation_warning_circmean(self):
+        """Test if circmean in stats is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            pystats.nan_circmean(self.test_angles, **self.circ_kwargs)
+
+        assert len(w) == 1
+        assert w[0].category == DeprecationWarning
+
+    def test_deprecation_warning_circstd(self):
+        """Test if circstd in stats is deprecated"""
+
+        import warnings
+
+        warnings.simplefilter("always")
+        with warnings.catch_warnings(record=True) as w:
+            pystats.nan_circstd(self.test_angles, **self.circ_kwargs)
+
+        assert len(w) == 1
+        assert w[0].category == DeprecationWarning

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -44,7 +44,7 @@ def computational_form(data):
 
     warnings.warn(' '.join(["utils.computational_form is deprecated, use",
                             "pysat.ssnl.computational_form instead"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
     dslice = pysat.ssnl.computational_form(data)
 
     return dslice

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -143,7 +143,7 @@ def scale_units(out_unit, in_unit):
 
     warnings.warn(' '.join(["utils.computational_form is deprecated, use",
                             "pysat.ssnl.computational_form instead"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
     unit_scale = utils.scale_units(out_unit, in_unit)
 
     return unit_scale

--- a/pysat/utils/stats.py
+++ b/pysat/utils/stats.py
@@ -32,8 +32,9 @@ def median1D(self, bin_params, bin_label, data_label):
 
     """
 
-    warnings.warn(' '.join(("utils.stats.median1D is deprecated, use",
-                            "ssnl.avg.median1D instead")),
+    warnings.warn(' '.join(["utils.stats.median1D is deprecated and will be",
+                            "removed in pysat 3.0.0. Please use",
+                            "ssnl.avg.median1D instead"]),
                   DeprecationWarning)
 
     bins = np.arange(bin_params[0], bin_params[1] + bin_params[2],
@@ -41,7 +42,7 @@ def median1D(self, bin_params, bin_label, data_label):
     medians = 0. * bins[0:-1]
     ind = np.digitize(self.data[bin_label], bins)
 
-    for i in xrange(bins.size-1):
+    for i in range(bins.size-1):
         index, = np.where(ind == (i + 1))
         if len(index) > 0:
             idx = self.data.index[index.astype(int)]
@@ -71,11 +72,11 @@ def nan_circmean(samples, high=2.0*np.pi, low=0.0, axis=None):
         Circular mean
 
     """
-    
-    warnings.warn(' '.join(("utils.stats.nan_circmean is deprecated and will ",
-                            "be removed is a future version. This function is ",
-                            "part of the scipy 1.4.0 milestones and will be ",
-                            "migrated there.")),
+
+    warnings.warn(' '.join(["utils.stats.nan_circmean is deprecated and will",
+                            "be removed in pysat 3.0.0. This function is",
+                            "part of the scipy 1.4.0 milestones and will be",
+                            "migrated there."]),
                   DeprecationWarning)
 
     samples = np.asarray(samples)
@@ -127,10 +128,10 @@ def nan_circstd(samples, high=2.0*np.pi, low=0.0, axis=None):
 
     """
 
-    warnings.warn(' '.join(("utils.stats.nan_circstd is deprecated and will ",
-                            "be removed is a future version. This function is ",
-                            "part of the scipy 1.4.0 milestones and will be ",
-                            "migrated there.")),
+    warnings.warn(' '.join(["utils.stats.nan_circstd is deprecated and will",
+                            "be removed in pysat 3.0.0. This function is",
+                            "part of the scipy 1.4.0 milestones and will be",
+                            "migrated there."]),
                   DeprecationWarning)
 
     samples = np.asarray(samples)

--- a/pysat/utils/stats.py
+++ b/pysat/utils/stats.py
@@ -77,7 +77,7 @@ def nan_circmean(samples, high=2.0*np.pi, low=0.0, axis=None):
                             "be removed in pysat 3.0.0. This function is",
                             "part of the scipy 1.4.0 milestones and will be",
                             "migrated there."]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     samples = np.asarray(samples)
     samples = samples[~np.isnan(samples)]
@@ -132,7 +132,7 @@ def nan_circstd(samples, high=2.0*np.pi, low=0.0, axis=None):
                             "be removed in pysat 3.0.0. This function is",
                             "part of the scipy 1.4.0 milestones and will be",
                             "migrated there."]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     samples = np.asarray(samples)
     samples = samples[~np.isnan(samples)]

--- a/pysat/utils/stats.py
+++ b/pysat/utils/stats.py
@@ -35,7 +35,7 @@ def median1D(self, bin_params, bin_label, data_label):
     warnings.warn(' '.join(["utils.stats.median1D is deprecated and will be",
                             "removed in pysat 3.0.0. Please use",
                             "ssnl.avg.median1D instead"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     bins = np.arange(bin_params[0], bin_params[1] + bin_params[2],
                      bin_params[2])

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -136,7 +136,7 @@ def season_date_range(start, stop, freq='D'):
 
     warnings.warn(' '.join(["utils.time.season_date_range is deprecated, use",
                             "utils.time.create_date_range instead"]),
-                  DeprecationWarning)
+                  DeprecationWarning, stacklevel=2)
 
     season = create_date_range(start, stop, freq='D')
 


### PR DESCRIPTION
# Description

Addresses pysat roadmap.  Replaces #308.

- Adds deprecation warnings to `model_utils` and `ssnl`
- Adds tests for deprecation to `model_utls`, `ssnl` and `utils.stats`
- Cleans up some unused variables in tests
- Replaces `xrange` with `range` for python 3.x compatibility (in deprecated function)

## Type of change

- This change adds deprecation warnings

# How Has This Been Tested?

Tested locally via

```
pytest pysat/tests/test_ssnl_ave.py
pytest pysat/tests/test_ssnl_occur_prob.py
pytest pysat/tests/test_ssnl_plot.py
pytest pysat/tests/test_utils.stats.py
```

Python 3.7.3, Mac OS X 10.14.6

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
