### PR TITLE
BUG: COSMIC downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Unit tests reload pysat_testing_xarray for xarray tests
    - Updated setup.py to not overwrite defauly `open` command from `codecs`
    - Updated Travis CI settings to allow forks to run tests on local travis accounts
+   - Fixed a bug with COSMIC GPS downloads
 - Documentation
   - Added info on how to cite the code and package.
   - Updated instrument docstring

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -44,7 +44,6 @@ from __future__ import absolute_import
 import glob
 import numpy as np
 import os
-import pandas as pds
 import sys
 
 import netCDF4
@@ -319,7 +318,7 @@ def download(date_array, tag, sat_id, data_path=None,
             req = requests.get(dwnld, auth=HTTPBasicAuth(user, password))
             req.raise_for_status()
         except requests.exceptions.HTTPError:
-        # if repsonse is negative, try post-processed data
+            # if repsonse is negative, try post-processed data
             try:
                 dwnld = ''.join(("https://cdaac-www.cosmic.ucar.edu/cdaac/",
                                  "rest/tarservice/data/cosmic/"))

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -330,17 +330,16 @@ def download(date_array, tag, sat_id, data_path=None,
             except requests.exceptions.HTTPError as err:
                 estr = ''.join([str(err), '\n', 'Data not found'])
                 print(estr)
+        fname = os.path.join(data_path,
+                             'cosmic_' + sub_dir + '_' + yrdoystr + '.tar')
+        with open(fname, "wb") as local_file:
+            local_file.write(req.content)
+            local_file.close()
         try:
-            fname = os.path.join(data_path,
-                                 'cosmic_' + sub_dir + '_' + yrdoystr + '.tar')
-            with open(fname, "wb") as local_file:
-                local_file.write(req.content)
-                local_file.close()
             # uncompress files and remove tarball
             tar = tarfile.open(fname)
             tar.extractall(path=data_path)
             tar.close()
-            os.remove(fname)
             # move files
             source_dir = os.path.join(top_dir, sub_dir, yrdoystr)
             destination_dir = os.path.join(data_path, yrdoystr)
@@ -352,6 +351,7 @@ def download(date_array, tag, sat_id, data_path=None,
         except tarfile.ReadError:
             # If file cannot be read, file cannot be downloaded
             pass
+        os.remove(fname)
 
     return
 

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -331,24 +331,28 @@ def download(date_array, tag, sat_id, data_path=None,
             except requests.exceptions.HTTPError as err:
                 estr = ''.join(str(err), '\n', 'Data not found')
                 print(estr)
-        fname = os.path.join(data_path,
-                             'cosmic_' + sub_dir + '_' + yrdoystr + '.tar')
-        with open(fname, "wb") as local_file:
-            local_file.write(req.content)
-            local_file.close()
-        # uncompress files and remove tarball
-        tar = tarfile.open(fname)
-        tar.extractall(path=data_path)
-        tar.close()
-        os.remove(fname)
-        # move files
-        source_dir = os.path.join(top_dir, sub_dir, yrdoystr)
-        destination_dir = os.path.join(data_path, yrdoystr)
-        if os.path.exists(destination_dir):
-            shutil.rmtree(destination_dir)
-        shutil.move(source_dir, destination_dir)
-        # Get rid of empty directories from tar process
-        shutil.rmtree(top_dir)
+        try:
+            fname = os.path.join(data_path,
+                                 'cosmic_' + sub_dir + '_' + yrdoystr + '.tar')
+            with open(fname, "wb") as local_file:
+                local_file.write(req.content)
+                local_file.close()
+            # uncompress files and remove tarball
+            tar = tarfile.open(fname)
+            tar.extractall(path=data_path)
+            tar.close()
+            os.remove(fname)
+            # move files
+            source_dir = os.path.join(top_dir, sub_dir, yrdoystr)
+            destination_dir = os.path.join(data_path, yrdoystr)
+            if os.path.exists(destination_dir):
+                shutil.rmtree(destination_dir)
+            shutil.move(source_dir, destination_dir)
+            # Get rid of empty directories from tar process
+            shutil.rmtree(top_dir)
+        except tarfile.ReadError:
+            # If file cannot be read, file cannot be downloaded
+            pass
 
     return
 

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -329,7 +329,7 @@ def download(date_array, tag, sat_id, data_path=None,
                 req = requests.get(dwnld, auth=HTTPBasicAuth(user, password))
                 req.raise_for_status()
             except requests.exceptions.HTTPError as err:
-                estr = ''.join(str(err), '\n', 'Data not found')
+                estr = ''.join([str(err), '\n', 'Data not found'])
                 print(estr)
         try:
             fname = os.path.join(data_path,


### PR DESCRIPTION
# Description

Addresses #312

Fixes a bug where cosmic data downloads crash if a day of data in the requested range is missing.  Also cleans up a few things in the instrument file.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This is outside the Eye of Travis.  Local tests need to be run.
```
import pysat
cosmic = pysat.Instrument('cosmic', 'gps', tag='ionprf')  
start = pysat.datetime(2018, 1, 22)
stop = pysat.datetime(2018, 1, 24)
cosmic.download(start, stop, user=user, password=password)
```
Jan 23 is missing, Jan 22 and 24 exist.  

The code in `develop`  will crash after attempting to download Jan 23.  The list of files obtained by invoking `cosmic.files.files` will not include Jan 22.

The code in this branch should download Jan 22 and Jan 24, and properly update the file list.

**Test Configuration**:
* Mac Os X 10.14.6
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [na] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [na] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
