### PR TITLE
BUG: IVM clean fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Unit tests reload pysat_testing_xarray for xarray tests
    - Updated setup.py to not overwrite defauly `open` command from `codecs`
    - Updated Travis CI settings to allow forks to run tests on local travis accounts
+   - Fixed selection bugs in the DEMETER IAP, CNOFS IVM, and model_utils routines
 - Documentation
   - Added info on how to cite the code and package.
   - Updated instrument docstring

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Replace `season_date_range` with `create_date_range`, old version is deprecated
   - Added deprecation warnings to stat functions
   - Removed `pysat_sgp4` instrument
+  - Added cleaning steps to the C/NOFS IVM ion fraction data
 - Bug fix
    - Fixed implementation of utils routines in model_utils and jro_isr
    - Fixed error catching bug in model_utils

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -20,13 +20,13 @@ scintillations, J. Atmos. Sol. Terr. Phys., 66, 1573–1591,
 doi:10.1016/j.jastp.2004.07.030.
 
 Discussion of cleaning parameters for ion drifts can be found in:
-Burrell, Angeline G., Equatorial topside magnetic field-aligned ion drifts 
-at solar minimum, The University of Texas at Dallas, ProQuest 
-Dissertations Publishing, 2012. 3507604. 
+Burrell, Angeline G., Equatorial topside magnetic field-aligned ion drifts
+at solar minimum, The University of Texas at Dallas, ProQuest
+Dissertations Publishing, 2012. 3507604.
 
 Discussion of cleaning parameters for ion temperature can be found in:
-Hairston, M. R., W. R. Coley, and R. A. Heelis (2010), Mapping the 
-duskside topside ionosphere with CINDI and DMSP, J. Geophys. Res.,115, 
+Hairston, M. R., W. R. Coley, and R. A. Heelis (2010), Mapping the
+duskside topside ionosphere with CINDI and DMSP, J. Geophys. Res.,115,
 A08324, doi:10.1029/2009JA015051.
 
 
@@ -175,13 +175,12 @@ def clean(inst):
         inst['ionTemperature'][idx] = np.NaN
 
         # The ion fractions should always sum to one and never drop below zero
-        ifracs = ['ion{:d}fraction'.format(i) for i in np.arange(1,6)]
+        ifracs = ['ion{:d}fraction'.format(i) for i in np.arange(1, 6)]
         ion_sum = np.sum([inst[label] for label in ifracs], axis=0)
         ion_min = np.min([inst[label] for label in ifracs], axis=0)
         idx, = np.where((ion_sum != 1.0) | (ion_min < 0.0))
         for label in ifracs:
             inst.data[label][idx] = np.NaN
-        
 
     # basic quality check on drifts and don't let UTS go above 86400.
     idx, = np.where(inst.data.time <= 86400.)

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -169,11 +169,19 @@ def clean(inst):
         # The RPA component of the ram velocity is always 100%
         inst.data['ionVelocityX'][idx] = np.NaN
 
-    # Check for bad temperature fits (O+ < 15%), replace with NaNs
-    # Criteria from Hairston et al, 2010
-    if (inst.clean_level == 'clean') | (inst.clean_level == 'dusty'):
+        # Check for bad temperature fits (O+ < 15%), replace with NaNs
+        # Criteria from Hairston et al, 2010
         idx, = np.where(inst.data.ion1fraction < 0.15)
         inst['ionTemperature'][idx] = np.NaN
+
+        # The ion fractions should always sum to one and never drop below zero
+        ifracs = ['ion{:d}fraction'.format(i) for i in np.arange(1,6)]
+        ion_sum = np.sum([inst[label] for label in ifracs], axis=0)
+        ion_min = np.min([inst[label] for label in ifracs], axis=0)
+        idx, = np.where((ion_sum != 1.0) | (ion_min < 0.0))
+        for label in ifracs:
+            inst.data[label][idx] = np.NaN
+        
 
     # basic quality check on drifts and don't let UTS go above 86400.
     idx, = np.where(inst.data.time <= 86400.)

--- a/pysat/instruments/demeter_iap.py
+++ b/pysat/instruments/demeter_iap.py
@@ -270,8 +270,8 @@ def clean(inst):
                 # Need Level 0 files to select data with J >= 1 nA
                 print("WARNING: Level 0 files needed to finish cleaning data")
 
-                # Select times with at least two ion species
-                idx, = np.where(nions > 1)
+        # Select times with at least two ion species
+        idx, = np.where(nions > 1)
     else:
         idx = slice(0, inst.index.shape[0])
 

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -354,9 +354,13 @@ def collect_inst_model_pairs(start=None, stop=None, tinc=None, inst=None,
         mod_file = start.strftime(model_files)
 
         if path.isfile(mod_file):
-            mdata = model_load_rout(mod_file, start)
-            lon_high = float(mdata.coords[mod_lon_name].max())
-            lon_low = float(mdata.coords[mod_lon_name].min())
+            try:
+                mdata = model_load_rout(mod_file, start)
+                lon_high = float(mdata.coords[mod_lon_name].max())
+                lon_low = float(mdata.coords[mod_lon_name].min())
+            except Exception as err:
+                print("unable to load {:s}: {:}".format(mod_file, err))
+                mdata = None
         else:
             mdata = None
 


### PR DESCRIPTION
# Description

Both the DEMETER and CINDI IVM cleaning routines had bugs.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1) C/NOFS IVM:
 I tested this by examining the time period used to determine the IVM selection criteria in Burrell, 2012.  The buggy behaviour is shown in the first figure and the fixed behavour is shown in the second

![pysat2 1_ivm_clean_plus_demeter_options](https://user-images.githubusercontent.com/7045886/67511556-2dadb780-f665-11e9-907f-8f2da25dd672.png)
![pysat2 1_ivm_clean_bugfix](https://user-images.githubusercontent.com/7045886/67511577-38684c80-f665-11e9-8f4c-0c4c8b53ea47.png)

2) DEMETER IAP:
I tested this by running the same selection criteria on the C/NOFS IVM data.  These are labeled as Berthelier et al. Species Threshold in the top figure.

3) model_utils
This has been tested in a year-long model validation run where the bug originally occurred.  You can reproduce it by attempting to load a validation period with a gap in available model files.

**Test Configuration**:
* OS X Sierra
* Python 2.7.16

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
