### PR TITLE
BUG: Corrected feedback in download_updated_file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.X.X] - 2019-12-05
+- Bug Fixes
+  - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
+
 ## [2.X.X] - 2019-10-16
 - New Features
    - Added new velocity format options to utils.coords.scale_units

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1578,7 +1578,7 @@ class Instrument(object):
             if e.errno != errno.EEXIST:
                 raise
 
-        if (start is None) or (stop is None) and (date_array is None):
+        if ((start is None) or (stop is None)) and (date_array is None):
             # defaults for downloads are set here rather than
             # in the method signature since method defaults are
             # only set once! If an Instrument object persists


### PR DESCRIPTION
# Description

Addresses # (issue)

The downloaded updated files method would incorrectly state it didn't have date inputs when it actually did.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally downloading ICON IVM files as part of mission processing.


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
