### PR TITLE
BUG: Bad bounds date extraction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.X.X] - 2019-12-05
+- Bug Fixes
+  - `files._attach_files` now checks for an empty file list before appending
+
 ## [2.X.X] - 2019-10-16
 - New Features
    - Added new velocity format options to utils.coords.scale_units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `_files._attach_files` now checks for an empty file list before appending
   - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
 
-## [2.X.X] - 2019-10-16
+## [2.1.0] - 2019-11-18
 - New Features
    - Added new velocity format options to utils.coords.scale_units
    - Improved failure messages for utils.coords.scale_units

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.X.X] - 2019-12-05
 - Bug Fixes
-  - `files._attach_files` now checks for an empty file list before appending
+  - `_files._attach_files` now checks for an empty file list before appending
 
 ## [2.X.X] - 2019-10-16
 - New Features

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -233,8 +233,8 @@ class Files(object):
             if self.ignore_empty_files:
                 self._filter_empty_files()
             # extract date information
-            self.start_date = self._sat._filter_datetime_input(files_info.index[0])
-            self.stop_date = self._sat._filter_datetime_input(files_info.index[-1])
+            self.start_date = self._sat._filter_datetime_input(self.files.index[0])
+            self.stop_date = self._sat._filter_datetime_input(self.files.index[-1])
         else:
             self.start_date = None
             self.stop_date = None

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -233,8 +233,12 @@ class Files(object):
             if self.ignore_empty_files:
                 self._filter_empty_files()
             # extract date information
-            self.start_date = self._sat._filter_datetime_input(self.files.index[0])
-            self.stop_date = self._sat._filter_datetime_input(self.files.index[-1])
+            if not self.files.empty:
+                self.start_date = self._sat._filter_datetime_input(self.files.index[0])
+                self.stop_date = self._sat._filter_datetime_input(self.files.index[-1])
+            else:
+                self.start_date = None
+                self.stop_date = None
         else:
             self.start_date = None
             self.stop_date = None


### PR DESCRIPTION
# Description

Addresses # (issue)

The files object is responsible for setting a pysat.Instrument objects date bounds. The code grabbed the first and last file from an unsorted list. I now use the list attached to the Files object.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
Travis and local tests.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
