### PR TITLE
DOC: typo in badge link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 </div>
 
 # pysat: Python Satellite Data Analysis Toolkit
-[![Build Status](https://travis-ci.org/rstoneback/pysat.svg?branch=master)](https://travis-ci.org/pysat/pysat)
+[![Build Status](https://travis-ci.org/pysat/pysat.svg?branch=master)](https://travis-ci.org/pysat/pysat)
 [![Documentation Status](https://readthedocs.org/projects/pysat/badge/?version=latest)](http://pysat.readthedocs.io/en/latest/?badge=latest)
 [![Coverage Status](https://coveralls.io/repos/github/pysat/pysat/badge.svg?branch=master)](https://coveralls.io/github/pysat/pysat?branch=master)
 [![DOI](https://zenodo.org/badge/33449914.svg)](https://zenodo.org/badge/latestdoi/33449914)


### PR DESCRIPTION
# Description

The Travis badge is still pointing to the old account for the status.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

