### PR TITLE
BUG: Deprecation Warning in utils.coords.scale_units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
    - Fixed loading of COSMIC atmPrf files
    - Fixed feedback from COSMIC GPS when data not found on remote server
+   - Fixed deprecation warning for pysat.utils.coords.scale_units
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -141,8 +141,8 @@ def scale_units(out_unit, in_unit):
     import warnings
     from pysat import utils
 
-    warnings.warn(' '.join(["utils.computational_form is deprecated, use",
-                            "pysat.ssnl.computational_form instead"]),
+    warnings.warn(' '.join(["utils.coords.scale_units is deprecated, use",
+                            "pysat.utils.scale_units instead"]),
                   DeprecationWarning, stacklevel=2)
     unit_scale = utils.scale_units(out_unit, in_unit)
 


### PR DESCRIPTION
# Description

Found a typo in the `utils.coords.scale_units` deprecation warning left over from copy-paste.  Updating to match the current function.

Note that since this function is deprecated and will be removed in python 3.0.0, a twin is not required.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
 pysat.utils.coords.scale_units('km', 'm') 
```

Output from develop (wrong): 
```
/Users/jklenzing/anaconda3/bin/ipython:1: DeprecationWarning: utils.computational_form is deprecated, use pysat.ssnl.computational_form instead
```

Output from this branch (correct):
```
/Users/jklenzing/anaconda3/bin/ipython:1: DeprecationWarning: utils.coords.scale_units is deprecated, use pysat.utils.scale_units instead
```

**Test Configuration**:
* python 3.7.3
* Mac Os 10.14.6

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
