### PR TITLE
STY: Robust import from methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,18 +2,19 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.X.X] - 2019-12-30
+## [2.2.0] - 2019-12-31
 - New Features
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
-   - `_files._attach_files` now checks for an empty file list before appending
-   - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
-   - Fixed loading of COSMIC atmPrf files
-   - Fixed feedback from COSMIC GPS when data not found on remote server
+  - `_files._attach_files` now checks for an empty file list before appending
+  - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
+  - Fixed loading of COSMIC atmPrf files
+  - Fixed feedback from COSMIC GPS when data not found on remote server
   - Fixed a bug when trying to combine empty f107 lists
+  - Made import of methods more robust
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -58,7 +58,7 @@ import numpy as np
 
 import pysat
 
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 platform = 'cnofs'
 name = 'ivm'

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -58,7 +58,7 @@ import numpy as np
 
 import pysat
 
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 platform = 'cnofs'
 name = 'ivm'

--- a/pysat/instruments/cnofs_plp.py
+++ b/pysat/instruments/cnofs_plp.py
@@ -57,7 +57,7 @@ import functools
 import numpy as np
 
 import pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 platform = 'cnofs'
 name = 'plp'

--- a/pysat/instruments/cnofs_plp.py
+++ b/pysat/instruments/cnofs_plp.py
@@ -57,7 +57,7 @@ import functools
 import numpy as np
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 platform = 'cnofs'
 name = 'plp'

--- a/pysat/instruments/cnofs_vefi.py
+++ b/pysat/instruments/cnofs_vefi.py
@@ -58,7 +58,7 @@ import functools
 import numpy as np
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 platform = 'cnofs'
 name = 'vefi'

--- a/pysat/instruments/cnofs_vefi.py
+++ b/pysat/instruments/cnofs_vefi.py
@@ -58,7 +58,7 @@ import functools
 import numpy as np
 
 import pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 platform = 'cnofs'
 name = 'vefi'

--- a/pysat/instruments/demeter_iap.py
+++ b/pysat/instruments/demeter_iap.py
@@ -40,7 +40,7 @@ import pandas as pds
 import numpy as np
 
 import pysat
-from .methods import demeter
+from pysat.methods import demeter
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/demeter_iap.py
+++ b/pysat/instruments/demeter_iap.py
@@ -40,7 +40,7 @@ import pandas as pds
 import numpy as np
 
 import pysat
-from pysat.methods import demeter
+from pysat.instruments.methods import demeter
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -51,8 +51,8 @@ import numpy as np
 import pandas as pds
 
 import pysat
-from pysat.methods import madrigal as mad_meth
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import madrigal as mad_meth
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -51,8 +51,8 @@ import numpy as np
 import pandas as pds
 
 import pysat
-from .methods import madrigal as mad_meth
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import madrigal as mad_meth
+from pysat.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -33,7 +33,7 @@ import pandas as pds
 import warnings
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -33,7 +33,7 @@ import pandas as pds
 import warnings
 
 import pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -42,7 +42,7 @@ import pandas as pds
 import warnings
 
 import pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -42,7 +42,7 @@ import pandas as pds
 import warnings
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/iss_fpmu.py
+++ b/pysat/instruments/iss_fpmu.py
@@ -28,7 +28,7 @@ import numpy as np
 
 import pysat
 
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 platform = 'iss'
 name = 'fpmu'

--- a/pysat/instruments/iss_fpmu.py
+++ b/pysat/instruments/iss_fpmu.py
@@ -28,7 +28,7 @@ import numpy as np
 
 import pysat
 
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 platform = 'iss'
 name = 'fpmu'

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -37,8 +37,8 @@ import functools
 import numpy as np
 
 import pysat
-from .methods import madrigal as mad_meth
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import madrigal as mad_meth
+from pysat.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -37,8 +37,8 @@ import functools
 import numpy as np
 
 import pysat
-from pysat.methods import madrigal as mad_meth
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import madrigal as mad_meth
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -53,7 +53,7 @@ import numpy as np
 import pandas as pds
 
 import pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -53,7 +53,7 @@ import numpy as np
 import pandas as pds
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -31,7 +31,7 @@ import warnings
 
 import pysat
 
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 platform = 'rocsat1'
 name = 'ivm'

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -31,7 +31,7 @@ import warnings
 
 import pysat
 
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 platform = 'rocsat1'
 name = 'ivm'

--- a/pysat/instruments/templates/madrigal_pandas.py
+++ b/pysat/instruments/templates/madrigal_pandas.py
@@ -80,8 +80,8 @@ from __future__ import absolute_import
 
 import functools
 import pysat
-from pysat.methods import madrigal as mad_meth
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import madrigal as mad_meth
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/templates/madrigal_pandas.py
+++ b/pysat/instruments/templates/madrigal_pandas.py
@@ -80,8 +80,8 @@ from __future__ import absolute_import
 
 import functools
 import pysat
-from .methods import madrigal as mad_meth
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import madrigal as mad_meth
+from pysat.methods import nasa_cdaweb as cdw
 
 import logging
 logger = logging.getLogger(__name__)

--- a/pysat/instruments/templates/template_cdaweb_instrument.py
+++ b/pysat/instruments/templates/template_cdaweb_instrument.py
@@ -45,7 +45,7 @@ import pandas as pds
 import pysat
 
 # CDAWeb methods prewritten for pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 # the platform and name strings associated with this instrument
 # need to be defined at the top level

--- a/pysat/instruments/templates/template_cdaweb_instrument.py
+++ b/pysat/instruments/templates/template_cdaweb_instrument.py
@@ -45,7 +45,7 @@ import pandas as pds
 import pysat
 
 # CDAWeb methods prewritten for pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 # the platform and name strings associated with this instrument
 # need to be defined at the top level

--- a/pysat/instruments/timed_saber.py
+++ b/pysat/instruments/timed_saber.py
@@ -55,7 +55,7 @@ import functools
 
 import pysat
 # CDAWeb methods prewritten for pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 # the platform and name strings associated with this instrument
 # need to be defined at the top level

--- a/pysat/instruments/timed_saber.py
+++ b/pysat/instruments/timed_saber.py
@@ -55,7 +55,7 @@ import functools
 
 import pysat
 # CDAWeb methods prewritten for pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 # the platform and name strings associated with this instrument
 # need to be defined at the top level

--- a/pysat/instruments/timed_see.py
+++ b/pysat/instruments/timed_see.py
@@ -41,7 +41,7 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-from pysat.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
 
 # include basic instrument info
 platform = 'timed'

--- a/pysat/instruments/timed_see.py
+++ b/pysat/instruments/timed_see.py
@@ -41,7 +41,7 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.methods import nasa_cdaweb as cdw
 
 # include basic instrument info
 platform = 'timed'


### PR DESCRIPTION
# Description

Followup from #346.  

Replaces `from .methods import ...` with `from pysat.instruments.methods import ...` throughout.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via importing pysat and loading a cdaweb instrument.

**Test Configuration**:
* Mac OS 10.14.6
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
