### PR TITLE
TST: pytest compatibility for test_files.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,16 +2,17 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.X.X] - 2019-12-27
+## [2.2.0] - 2019-12-31
 - New Features
    - Decreased time to load COSMIC GPS data by about 50%
+   - Updated `test_files.py` to be pytest compatible
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
-   - `_files._attach_files` now checks for an empty file list before appending
-   - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
-   - Fixed loading of COSMIC atmPrf files
-   - Fixed feedback from COSMIC GPS when data not found on remote server
+  - `_files._attach_files` now checks for an empty file list before appending
+  - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
+  - Fixed loading of COSMIC atmPrf files
+  - Fixed feedback from COSMIC GPS when data not found on remote server
   - Fixed a bug when trying to combine empty f107 lists
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -12,6 +12,7 @@ from pysat import data_dir as data_dir
 
 from pysat import logger
 
+
 class Files(object):
     """Maintains collection of files for instrument object.
 
@@ -151,8 +152,9 @@ class Files(object):
                                                  sat_id=self._sat.sat_id)
         # ensure we have a path for pysat data directory
         if data_dir == '':
-            raise RuntimeError(" ".join(("pysat's data_dir is None. Set a directory",
-                                         "using pysat.utils.set_data_dir.")))
+            raise RuntimeError(" ".join(("pysat's data_dir is None. Set a",
+                                         "directory using",
+                                         "pysat.utils.set_data_dir.")))
         # make sure path always ends with directory seperator
         self.data_path = os.path.join(data_dir, self.sub_dir_path)
         if self.data_path[-2] == os.path.sep:
@@ -201,7 +203,6 @@ class Files(object):
                   'empty files from Instrument list.')))
             self.files = self.files.iloc[keep_index]
 
-
     def _attach_files(self, files_info):
         """Attach results of instrument list_files routine to Instrument object
 
@@ -223,7 +224,8 @@ class Files(object):
                 estr = '{:s}information.\nKeeping one of each '.format(estr)
                 estr = '{:s}of the duplicates, dropping the rest.'.format(estr)
                 logger.warning(estr)
-                logger.warning(files_info.index[files_info.index.duplicated()].unique())
+                ind = files_info.index.duplicated()
+                logger.warning(files_info.index[ind].unique())
 
                 idx = np.unique(files_info.index, return_index=True)
                 files_info = files_info.iloc[idx[1]]
@@ -235,8 +237,10 @@ class Files(object):
                 self._filter_empty_files()
             # extract date information
             if not self.files.empty:
-                self.start_date = self._sat._filter_datetime_input(self.files.index[0])
-                self.stop_date = self._sat._filter_datetime_input(self.files.index[-1])
+                self.start_date = \
+                    self._sat._filter_datetime_input(self.files.index[0])
+                self.stop_date = \
+                    self._sat._filter_datetime_input(self.files.index[-1])
             else:
                 self.start_date = None
                 self.stop_date = None
@@ -415,7 +419,7 @@ class Files(object):
                 try:
                     # Assume key is integer (including list or slice)
                     out = self.files.iloc[key]
-                except:
+                except TypeError:
                     # Assume key is something else
                     out = self.files.loc[key]
             except IndexError as err:
@@ -442,7 +446,7 @@ class Files(object):
         else:
             try:
                 return self.files.iloc[key]
-            except:
+            except TypeError:
                 return self.files.loc[key]
 
     def get_file_array(self, start, end):

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -45,7 +45,8 @@ def remove_files(inst=None):
 
 
 # create year doy file set
-def create_files(inst, start, stop, freq=None, use_doy=True, root_fname=None, content = None):
+def create_files(inst, start, stop, freq=None, use_doy=True, root_fname=None,
+                 content=None):
 
     if freq is None:
         freq = '1D'
@@ -108,7 +109,8 @@ class TestNoDataDir():
 
     @raises(Exception)
     def test_no_data_dir(self):
-        inst = pysat.Instrument()
+        _ = pysat.Instrument()
+
 
 class TestBasics():
 
@@ -139,7 +141,6 @@ class TestBasics():
         except:
             pass
         del self.testInst
-
 
     def test_parse_delimited_filename(self):
         """Check ability to parse delimited files"""
@@ -451,7 +452,7 @@ class TestInstrumentWithFiles():
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname,
-                     content = 'test')
+                     content='test')
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
@@ -473,12 +474,10 @@ class TestInstrumentWithFiles():
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname,
-                     content = 'test')
+                     content='test')
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
-
-
 
     def test_refresh_on_unchanged_files(self):
         start = pysat.datetime(2007, 12, 31)

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -91,11 +91,9 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
 class TestNoDataDir():
 
-    def __init__(self, temporary_file_list=False):
-        self.temporary_file_list = temporary_file_list
-
     def setup(self):
         """Runs before every method to create a clean testing setup."""
+        self.temporary_file_list = False
         # store current pysat directory
         self.saved_data_path = pysat.data_dir
 
@@ -114,8 +112,7 @@ class TestNoDataDir():
 
 class TestBasics():
 
-    def __init__(self, temporary_file_list=False):
-        self.temporary_file_list = temporary_file_list
+    temporary_file_list = False
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
@@ -369,14 +366,13 @@ class TestBasics():
 
 
 class TestBasicsNoFileListStorage(TestBasics):
-    def __init__(self, temporary_file_list=True):
-        self.temporary_file_list = temporary_file_list
+
+    temporary_file_list = True
 
 
 class TestInstrumentWithFiles():
 
-    def __init__(self, temporary_file_list=False):
-        self.temporary_file_list = temporary_file_list
+    temporary_file_list = False
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
@@ -660,8 +656,8 @@ class TestInstrumentWithFiles():
 
 
 class TestInstrumentWithFilesNoFileListStorage(TestInstrumentWithFiles):
-    def __init__(self, temporary_file_list=True):
-        self.temporary_file_list = temporary_file_list
+
+    temporary_file_list = True
 
 
 # create year doy file set with multiple versions
@@ -725,8 +721,8 @@ def list_versioned_files(tag=None, sat_id=None, data_path=None,
 
 
 class TestInstrumentWithVersionedFiles():
-    def __init__(self, temporary_file_list=False):
-        self.temporary_file_list = temporary_file_list
+
+    temporary_file_list = False
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
@@ -982,5 +978,5 @@ class TestInstrumentWithVersionedFiles():
 
 
 class TestInstrumentWithVersionedFilesNoFileListStorage(TestInstrumentWithVersionedFiles):
-    def __init__(self, temporary_file_list=True):
-        self.temporary_file_list = temporary_file_list
+
+    temporary_file_list = True


### PR DESCRIPTION
# Description

Addresses roadmap: migration to `pytest`.

`pytest` does not import tests from classes with an `init` constructor.  This branch rewrites `test_files.py` to avoid these constructors.

Additionally, scrubs `files.py` to be PEP8 compliant, including whitespace, line length, and bare except statements (both should detect `TypeError`).

## Type of change

- Style change (non-breaking change which fixes an issue)

# How Has This Been Tested?

Compared test outputs of both nose and pytest for this file.

```
nosetests -vs pysat/tests/test_files.py
```
yields
```
Ran 67 tests in 17.612s

OK
```
Likewise,
```
pytest -vs pysat/tests/test_files.py
```
yields
```
================================== 67 passed, 227 warnings in 19.57s ===================================
```
All tests are run, all have passed.

**Test Configuration**:
* Mac OS X 10.14.6
* python 3.7.3

# Notes
`test_instruments.py` still needs to be updated for full pytest compatibility.  However, this needs a significant rewrite anyway (see #327).  Required changes will be documented there.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
