### PR TITLE
BUG: remote_file_list failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.X.X] - 2019-12-30
+## [2.2.0] - 2019-12-30
 - New Features
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
-   - `_files._attach_files` now checks for an empty file list before appending
-   - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
-   - Fixed loading of COSMIC atmPrf files
-   - Fixed feedback from COSMIC GPS when data not found on remote server
-   - Fixed deprecation warning for pysat.utils.coords.scale_units
+  - `_files._attach_files` now checks for an empty file list before appending
+  - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
+  - Fixed loading of COSMIC atmPrf files
+  - Fixed feedback from COSMIC GPS when data not found on remote server
+  - Fixed deprecation warning for pysat.utils.coords.scale_units
   - Fixed a bug when trying to combine empty f107 lists
+  - Fixed a bug where `remote_file_list` would fail for some instruments.
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
   - `_files._attach_files` now checks for an empty file list before appending
-  - Fixed boolean logic in when checking for start and stop dates in `_instrument.download`
+  - Fixed boolean logic when checking for start and stop dates in `_instrument.download`
   - Fixed loading of COSMIC atmPrf files
   - Fixed feedback from COSMIC GPS when data not found on remote server
   - Fixed deprecation warning for pysat.utils.coords.scale_units

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -526,5 +526,6 @@ def list_remote_files(tag, sat_id,
             mask = mask & (stored_list.index.month == month)
             if day is not None:
                 mask = mask & (stored_list.index.day == day)
+        stored_list = stored_list[mask]
 
-    return stored_list[mask]
+    return stored_list

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -468,7 +468,7 @@ def list_remote_files(tag, sat_id,
     fmt_idx.append(format_str.find('*'))
 
     # Not all characters may exist in a filename.  Remove those that don't.
-    fmt_idx.remove(-1)
+    fmt_idx = [elem for elem in fmt_idx if elem != -1]
 
     # If preamble exists, add to targets
     if fmt_idx:

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -340,7 +340,7 @@ def list_remote_files(tag, sat_id,
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
     sat_id : (string or NoneType)
-        Specifies the satellite ID for a constellation.  Not used.
+        Specifies the satellite ID for a constellation.
         (default=None)
     remote_site : (string or NoneType)
         Remote site to download data from

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -273,7 +273,7 @@ def download(supported_tags, date_array, tag, sat_id,
         if not multi_file_day:
             try:
                 logger.info(' '.join(('Attempting to download file for',
-                            date.strftime('%d %B %Y'))))
+                                      date.strftime('%d %B %Y'))))
                 sys.stdout.flush()
                 remote_path = '/'.join((remote_url.strip('/'),
                                         formatted_remote_fname))

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -273,7 +273,7 @@ def download(supported_tags, date_array, tag, sat_id,
         if not multi_file_day:
             try:
                 logger.info(' '.join(('Attempting to download file for',
-                                date.strftime('%d %B %Y'))))
+                            date.strftime('%d %B %Y'))))
                 sys.stdout.flush()
                 remote_path = '/'.join((remote_url.strip('/'),
                                         formatted_remote_fname))
@@ -283,15 +283,15 @@ def download(supported_tags, date_array, tag, sat_id,
                     logger.info('Finished.')
                 else:
                     logger.info(' '.join(('File not available for',
-                                    date.strftime('%d %B %Y'))))
+                                date.strftime('%d %B %Y'))))
             except requests.exceptions.RequestException as exception:
                 logger.info(' '.join((exception, '- File not available for',
-                                date.strftime('%d %B %Y'))))
+                            date.strftime('%d %B %Y'))))
 
         else:
             try:
                 logger.info(' '.join(('Attempting to download files for',
-                                date.strftime('%d %B %Y'))))
+                            date.strftime('%d %B %Y'))))
                 sys.stdout.flush()
                 remote_files = list_remote_files(tag=tag, sat_id=sat_id,
                                                  remote_site=remote_site,
@@ -315,11 +315,11 @@ def download(supported_tags, date_array, tag, sat_id,
                         i += 1
                     else:
                         logger.info(' '.join(('File not available for',
-                                        date.strftime('%d %B %Y'))))
+                                    date.strftime('%d %B %Y'))))
                 logger.info('Downloaded {i:} of {n:} files.'.format(i=i, n=n))
             except requests.exceptions.RequestException as exception:
                 logger.info(' '.join((exception, '- Files not available for',
-                                date.strftime('%d %B %Y'))))
+                            date.strftime('%d %B %Y'))))
 
 
 def list_remote_files(tag, sat_id,
@@ -488,6 +488,7 @@ def list_remote_files(tag, sat_id,
     else:
         n_loops = n_layers + 1
     full_files = []
+
     for level in range(n_loops):
         for directory in remote_dirs[level]:
             temp_url = '/'.join((remote_url.strip('/'), directory))

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -283,15 +283,15 @@ def download(supported_tags, date_array, tag, sat_id,
                     logger.info('Finished.')
                 else:
                     logger.info(' '.join(('File not available for',
-                                date.strftime('%d %B %Y'))))
+                                          date.strftime('%d %B %Y'))))
             except requests.exceptions.RequestException as exception:
                 logger.info(' '.join((exception, '- File not available for',
-                            date.strftime('%d %B %Y'))))
+                                      date.strftime('%d %B %Y'))))
 
         else:
             try:
                 logger.info(' '.join(('Attempting to download files for',
-                            date.strftime('%d %B %Y'))))
+                                      date.strftime('%d %B %Y'))))
                 sys.stdout.flush()
                 remote_files = list_remote_files(tag=tag, sat_id=sat_id,
                                                  remote_site=remote_site,
@@ -315,11 +315,11 @@ def download(supported_tags, date_array, tag, sat_id,
                         i += 1
                     else:
                         logger.info(' '.join(('File not available for',
-                                    date.strftime('%d %B %Y'))))
+                                              date.strftime('%d %B %Y'))))
                 logger.info('Downloaded {i:} of {n:} files.'.format(i=i, n=n))
             except requests.exceptions.RequestException as exception:
                 logger.info(' '.join((exception, '- Files not available for',
-                            date.strftime('%d %B %Y'))))
+                                      date.strftime('%d %B %Y'))))
 
 
 def list_remote_files(tag, sat_id,

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -495,10 +495,9 @@ def list_remote_files(tag, sat_id,
             soup = BeautifulSoup(requests.get(temp_url).content, "lxml")
             links = soup.find_all('a', href=True)
             for link in links:
-                if level < n_layers:
-                    # If there is room to go down, look for directories
-                    if link['href'].count('/') == 1:
-                        remote_dirs[level+1].append(link['href'])
+                # If there is room to go down, look for directories
+                if link['href'].count('/') == 1:
+                    remote_dirs[level+1].append(link['href'])
                 else:
                     # If at the endpoint, add matching files to list
                     add_file = True


### PR DESCRIPTION
# Description

Addresses #348.

`inst.remote_file_list` failed to produce a list of files for some instruments.  This was due to the method it used to choose the expected file preamble.  This has been fixed and cleaned up.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat     
ivm = pysat.Instrument('cnofs', 'ivm')
ivm.remote_file_list(year=2009, month=1) 
```
should yield 
```
2009-01-01    cnofs_cindi_ivm_500ms_20090101_v01.cdf
2009-01-02    cnofs_cindi_ivm_500ms_20090102_v01.cdf
2009-01-03    cnofs_cindi_ivm_500ms_20090103_v01.cdf
2009-01-04    cnofs_cindi_ivm_500ms_20090104_v01.cdf
2009-01-05    cnofs_cindi_ivm_500ms_20090105_v01.cdf
2009-01-06    cnofs_cindi_ivm_500ms_20090106_v01.cdf
2009-01-07    cnofs_cindi_ivm_500ms_20090107_v01.cdf
2009-01-08    cnofs_cindi_ivm_500ms_20090108_v01.cdf
2009-01-09    cnofs_cindi_ivm_500ms_20090109_v01.cdf
2009-01-10    cnofs_cindi_ivm_500ms_20090110_v01.cdf
2009-01-11    cnofs_cindi_ivm_500ms_20090111_v01.cdf
2009-01-12    cnofs_cindi_ivm_500ms_20090112_v01.cdf
2009-01-13    cnofs_cindi_ivm_500ms_20090113_v01.cdf
2009-01-14    cnofs_cindi_ivm_500ms_20090114_v01.cdf
2009-01-15    cnofs_cindi_ivm_500ms_20090115_v01.cdf
2009-01-16    cnofs_cindi_ivm_500ms_20090116_v01.cdf
2009-01-17    cnofs_cindi_ivm_500ms_20090117_v01.cdf
2009-01-18    cnofs_cindi_ivm_500ms_20090118_v01.cdf
2009-01-19    cnofs_cindi_ivm_500ms_20090119_v01.cdf
2009-01-20    cnofs_cindi_ivm_500ms_20090120_v01.cdf
2009-01-21    cnofs_cindi_ivm_500ms_20090121_v01.cdf
2009-01-22    cnofs_cindi_ivm_500ms_20090122_v01.cdf
2009-01-23    cnofs_cindi_ivm_500ms_20090123_v01.cdf
2009-01-24    cnofs_cindi_ivm_500ms_20090124_v01.cdf
2009-01-25    cnofs_cindi_ivm_500ms_20090125_v01.cdf
2009-01-26    cnofs_cindi_ivm_500ms_20090126_v01.cdf
2009-01-27    cnofs_cindi_ivm_500ms_20090127_v01.cdf
2009-01-28    cnofs_cindi_ivm_500ms_20090128_v01.cdf
2009-01-29    cnofs_cindi_ivm_500ms_20090129_v01.cdf
2009-01-30    cnofs_cindi_ivm_500ms_20090130_v01.cdf
2009-01-31    cnofs_cindi_ivm_500ms_20090131_v01.cdf
dtype: object
```

**Test Configuration**:
* Mac OS 10.14.6
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
