### PR TITLE
BUG: SettingWithCopyWarning in `cnofs_ivm` cleaning routine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed a bug when trying to combine empty f107 lists
   - Fixed a bug where `remote_file_list` would fail for some instruments.
   - Made import of methods more robust
+  - Fixed `SettingWithCopyWarning` in `cnofs_ivm` cleaning routine
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -133,21 +133,21 @@ def clean(inst):
     inst.data = inst[idx, :]
 
     # Second pass, find bad drifts, replace with NaNs
-    idx, = np.where(inst.data.driftMeterflag > max_dm_flag)
+    idx = (inst.data.driftMeterflag > max_dm_flag)
 
     # Also exclude very large drifts and drifts where 100% O+
     if (inst.clean_level == 'clean') | (inst.clean_level == 'dusty'):
         if 'ionVelmeridional' in inst.data.columns:
             # unrealistic velocities
             # This check should be performed at the RPA or IDM velocity level
-            idx2, = np.where(np.abs(inst.data.ionVelmeridional) >= 10000.0)
-            idx = np.unique(np.concatenate((idx, idx2)))
+            idx2 = (np.abs(inst.data.ionVelmeridional) >= 10000.0)
+            idx = (idx | idx2)
 
     if len(idx) > 0:
         drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
                         'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
         for label in drift_labels:
-            inst[label][idx] = np.NaN
+            inst.data.loc[idx, label] = np.NaN
 
     # Check for bad RPA fits in dusty regime.
     # O+ concentration criteria from Burrell, 2012
@@ -155,32 +155,32 @@ def clean(inst):
         # Low O+ concentrations for RPA Flag of 3 are suspect and high O+
         # fractions create a shallow fit region for the ram velocity
         nO = inst.data.ion1fraction * inst.data.Ni
-        idx, = np.where(((inst.data.RPAflag == 3) & (nO <= 3.0e4)) |
-                        (inst.data.ion1fraction >= 1.0))
+        idx = (((inst.data.RPAflag == 3) & (nO <= 3.0e4)) |
+               (inst.data.ion1fraction >= 1.0))
 
         # Only remove data if RPA component of drift is greater than 1%
         unit_vecs = {'ionVelmeridional': 'meridionalunitvectorX',
                      'ionVelparallel': 'parallelunitvectorX',
                      'ionVelzonal': 'zonalunitvectorX'}
         for label in unit_vecs:
-            idx0 = idx[np.where(np.abs(inst[unit_vecs[label]][idx]) >= 0.01)[0]]
-            inst[label][idx0] = np.NaN
+            idx0 = idx & (np.abs(inst[unit_vecs[label]]) >= 0.01)
+            inst.data.loc[idx0, label] = np.NaN
 
         # The RPA component of the ram velocity is always 100%
-        inst.data['ionVelocityX'][idx] = np.NaN
+        inst.data.loc[idx, 'ionVelocityX'] = np.NaN
 
         # Check for bad temperature fits (O+ < 15%), replace with NaNs
         # Criteria from Hairston et al, 2010
-        idx, = np.where(inst.data.ion1fraction < 0.15)
-        inst['ionTemperature'][idx] = np.NaN
+        idx = inst.data.ion1fraction < 0.15
+        inst.data.loc[idx, 'ionTemperature'] = np.NaN
 
         # The ion fractions should always sum to one and never drop below zero
         ifracs = ['ion{:d}fraction'.format(i) for i in np.arange(1, 6)]
         ion_sum = np.sum([inst[label] for label in ifracs], axis=0)
         ion_min = np.min([inst[label] for label in ifracs], axis=0)
-        idx, = np.where((ion_sum != 1.0) | (ion_min < 0.0))
+        idx = ((ion_sum != 1.0) | (ion_min < 0.0))
         for label in ifracs:
-            inst.data[label][idx] = np.NaN
+            inst.data.loc[idx, label] = np.NaN
 
     # basic quality check on drifts and don't let UTS go above 86400.
     idx, = np.where(inst.data.time <= 86400.)

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -147,7 +147,7 @@ def clean(inst):
         drift_labels = ['ionVelmeridional', 'ionVelparallel', 'ionVelzonal',
                         'ionVelocityX', 'ionVelocityY', 'ionVelocityZ']
         for label in drift_labels:
-            inst.data.loc[idx, label] = np.NaN
+            inst[idx, label] = np.NaN
 
     # Check for bad RPA fits in dusty regime.
     # O+ concentration criteria from Burrell, 2012
@@ -164,15 +164,15 @@ def clean(inst):
                      'ionVelzonal': 'zonalunitvectorX'}
         for label in unit_vecs:
             idx0 = idx & (np.abs(inst[unit_vecs[label]]) >= 0.01)
-            inst.data.loc[idx0, label] = np.NaN
+            inst[idx0, label] = np.NaN
 
         # The RPA component of the ram velocity is always 100%
-        inst.data.loc[idx, 'ionVelocityX'] = np.NaN
+        inst[idx, 'ionVelocityX'] = np.NaN
 
         # Check for bad temperature fits (O+ < 15%), replace with NaNs
         # Criteria from Hairston et al, 2010
         idx = inst.data.ion1fraction < 0.15
-        inst.data.loc[idx, 'ionTemperature'] = np.NaN
+        inst[idx, 'ionTemperature'] = np.NaN
 
         # The ion fractions should always sum to one and never drop below zero
         ifracs = ['ion{:d}fraction'.format(i) for i in np.arange(1, 6)]
@@ -180,7 +180,7 @@ def clean(inst):
         ion_min = np.min([inst[label] for label in ifracs], axis=0)
         idx = ((ion_sum != 1.0) | (ion_min < 0.0))
         for label in ifracs:
-            inst.data.loc[idx, label] = np.NaN
+            inst[idx, label] = np.NaN
 
     # basic quality check on drifts and don't let UTS go above 86400.
     idx, = np.where(inst.data.time <= 86400.)


### PR DESCRIPTION
# Description

The clean routines in the `cnofs_ivm` instrument currently use chained assignment.  This results in multiple `SettingWithCopyWarning` messages while loading data.  This pull rewrites the clean routines to avoid chained assignments by using the `inst.data.loc` command.  This also requires the use of `np.where` to be replaced by boolean indices.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By plotting a sample subset of data (same as in #317), as well as checking the number of cleaned parameters in this range.
```
import matplotlib.pyplot as plt
import numpy as np
import pysat


date = pysat.datetime(2009, 4, 10)


def filter_time(inst):
    hour = inst.data.index.hour + inst.data.index.minute/60.0
    ind = ((hour >= 4) & (hour <= 7.5))
    inst.data = inst.data.loc[ind, :]

    return


ivm1 = pysat.Instrument('cnofs', 'ivm', clean_level='clean')
ivm1.custom.add(filter_time, 'modify')
ivm1.load(date=date)

ivm2 = pysat.Instrument('cnofs', 'ivm', clean_level='dusty')
ivm2.custom.add(filter_time, 'modify')
ivm2.load(date=date)

ivm3 = pysat.Instrument('cnofs', 'ivm', clean_level='dirty')
ivm3.custom.add(filter_time, 'modify')
ivm3.load(date=date)

ivm4 = pysat.Instrument('cnofs', 'ivm', clean_level='none')
ivm4.custom.add(filter_time, 'modify')
ivm4.load(date=date)

labels = ['ionVelocityX',
          'ionVelparallel', 'ionVelmeridional', 'ionVelzonal',
          'ionDensity', 'ion1fraction', 'ionTemperature']

fig, ax = plt.subplots(7, 1, sharex=True)

for j in range(7):
    ax[j].plot(ivm4[labels[j]], '+r', label='none')
    ax[j].plot(ivm3[labels[j]], '+m', label='dirty')
    ax[j].plot(ivm2[labels[j]], 'xg', label='dusty')
    ax[j].plot(ivm1[labels[j]], 'sk', label='clean')
    ax[j].set_ylabel(labels[j])

ax[0].legend()
plt.suptitle('C/NOFS IVM -- 10 Apr 2009 -- develop')
plt.tight_layout()

for j in range(7):
    print(labels[j], 
          sum(~np.isnan(ivm1[labels[j]])),
          sum(~np.isnan(ivm2[labels[j]])),
          sum(~np.isnan(ivm3[labels[j]])),
          sum(~np.isnan(ivm4[labels[j]])))
```
**Test Configuration**:
* Mac OS X 10.14.6
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
