### PR TITLE
ROADMAP: Add deprecation warnings for constellation analysis operations

### DIFF
--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -1,5 +1,6 @@
 import collections
 import importlib
+import warnings
 import numpy as np
 import pandas as pds
 
@@ -175,6 +176,12 @@ class Constellation(object):
             dictionary with keys 'median', 'count', 'avg_abs_dev', and
             'bin' (the values of the bin edges.)
         """
+
+        warnings.warn(' '.join(["constellation.add is deprecated and will be",
+                                "removed in pysat 3.0.0. This functionality",
+                                "will be added to pysatSeasons in the"
+                                "future."]),
+                      DeprecationWarning, stacklevel=2)
 
         # TODO Update for 2.7 compatability.
         if isinstance(data_label, str):
@@ -386,6 +393,12 @@ class Constellation(object):
 
         return { 'data': data_df, 'start':start, 'end':end }
         """
+
+        warnings.warn(' '.join(["constellation.difference is deprecated and",
+                                "will be removed in pysat 3.0.0. This",
+                                "functionality will be added to pysatSeasons"
+                                "in the future."]),
+                      DeprecationWarning, stacklevel=2)
 
         labels = [dl1 for dl1, dl2 in data_labels] + \
             ['1_' + b[0] for b in bounds] + ['2_' + b[1] for b in bounds] + \

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -1,3 +1,4 @@
+import warnings
 from nose.tools import raises
 import numpy as np
 
@@ -280,3 +281,58 @@ class TestDataMod:
         ans = (self.testConst[0].data['doubleMLT'].values ==
                2. * self.testConst[0].data.mlt.values).all()
         assert ans
+
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+
+        instruments = [pysat.Instrument(platform='pysat', name='testing',
+                                        sat_id='10', clean_level='clean')
+                       for i in range(2)]
+        self.testC = pysat.Constellation(instruments)
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
+        del self.testC
+
+    def test_deprecation_warning_add(self):
+        """Test if constellation.add is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            try:
+                # initiate function with NoneTypes since function does not
+                # need to run for DeprecationWarning to be thrown
+                # ==> Save time in unit tests
+                _ = self.testC.add(bounds1=None, label1=None, bounds2=None,
+                                   label2=None, bin3=None, label3=None,
+                                   data_label=None)
+            except ValueError:
+                # Setting data_label to None should produce a ValueError after
+                # warning is generated
+                pass
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_difference(self):
+        """Test if constellation.difference is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            try:
+                # initiate function with NoneTypes since function does not
+                # need to run for DeprecationWarning to be thrown
+                # ==> Save time in unit tests
+                _ = self.testC.difference(self.testC[0], self.testC[1],
+                                          bounds=None, data_labels=None,
+                                          cost_function=None)
+            except TypeError:
+                # Setting data_labels to None should produce a TypeError after
+                # warning is generated
+                pass
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -137,8 +137,7 @@ class TestAdditionSimilarInstruments:
         """
         self.testC = pysat.Constellation(name='test_add_similar')
         self.refC = pysat.Constellation([pysat.Instrument('pysat', 'testing',
-                                                          tag='ascend',
-                                                          clean_level='clean')])
+                                                          tag='ascend')])
 
     def teardown(self):
         del self.testC

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -305,13 +305,13 @@ class TestDeprecation():
             try:
                 # initiate function with NoneTypes since function does not
                 # need to run for DeprecationWarning to be thrown
-                # ==> Save time in unit tests
-                _ = self.testC.add(bounds1=None, label1=None, bounds2=None,
-                                   label2=None, bin3=None, label3=None,
-                                   data_label=None)
-            except ValueError:
                 # Setting data_label to None should produce a ValueError after
                 # warning is generated
+                # ==> Save time in unit tests
+                self.testC.add(bounds1=None, label1=None, bounds2=None,
+                               label2=None, bin3=None, label3=None,
+                               data_label=None)
+            except ValueError:
                 pass
 
         assert len(war) >= 1
@@ -324,13 +324,13 @@ class TestDeprecation():
             try:
                 # initiate function with NoneTypes since function does not
                 # need to run for DeprecationWarning to be thrown
-                # ==> Save time in unit tests
-                _ = self.testC.difference(self.testC[0], self.testC[1],
-                                          bounds=None, data_labels=None,
-                                          cost_function=None)
-            except TypeError:
                 # Setting data_labels to None should produce a TypeError after
                 # warning is generated
+                # ==> Save time in unit tests
+                self.testC.difference(self.testC[0], self.testC[1],
+                                      bounds=None, data_labels=None,
+                                      cost_function=None)
+            except TypeError:
                 pass
 
         assert len(war) >= 1


### PR DESCRIPTION
# Description

Follow-up to #353 

As part of the removal of seasonal functions in the pysat 3.0.0 roadmap, the functions `add` and `difference` were removed from the `Constellation` class, with the understanding that this functionality would migrate to pysatSeasons.  This PR add deprecation warnings to the 2.2.0 develop branch to warn users of the upcoming shift.

## Type of change

- Deprecation Warning (non-breaking change)

# How Has This Been Tested?

In ipython, try calling these functions to see if a DeprecationWarning is raised.

Also, `pytest -vs pysat/tests/test_constellation.py`

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
