### PR TITLE
ROADMAP: Remove upper limits on pandas for pysat 3.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,6 @@ from setuptools import setup
 # To use a consistent encoding
 import codecs
 import os
-import sys
 
 here = os.path.abspath(os.path.dirname(__file__))
 with codecs.open(os.path.join(here, 'description.txt'), encoding='utf-8') as f:
@@ -20,18 +19,11 @@ with codecs.open(os.path.join(here, version_filename)) as version_file:
 
 # packages to be installed
 # starting with packages common across all setups
-install_requires = ['requests', 'beautifulsoup4',
-                    'lxml', 'netCDF4']
+install_requires = ['requests', 'beautifulsoup4', 'lxml', 'netCDF4']
 # packages with Fortran code
 fortran_install = ['pysatCDF', 'madrigalWeb', 'h5py', 'PyForecastTools']
 # python version specific support libraries
-if sys.version_info.major == 2:
-    install_requires.extend(['xarray<0.12', 'pandas>=0.23, <0.25',
-                             'numpy>=1.12, <1.17', 'scipy<1.3'])
-else:
-    # python 3+
-    install_requires.extend(['xarray', 'pandas>=0.23, <0.25', 'numpy>=1.12',
-                             'scipy'])
+install_requires.extend(['numpy>=1.12', 'scipy', 'pandas>=0.23', 'xarray'])
 
 # flag, True if on readthedocs
 on_rtd = os.environ.get('READTHEDOCS') == 'True'

--- a/setup.py
+++ b/setup.py
@@ -76,11 +76,10 @@ setup(
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # What does your project relate to?


### PR DESCRIPTION
# Description

Addresses ROADMAP

Removes upper limit for pandas.  Travis CI now testing with pandas 1.0.0.  :)

The upper limit was in place due to the `Panel` deprecation, which has been dealt with in this branch.

Since support for python 2.7 is dropped in this version, cleaned up the setup file as well.

Note: Some uncovered areas such as the cosmic instruments may still require local testing.

## Type of change

- requirements change (non-breaking change which adds functionality)

# How Has This Been Tested?

tested via Travis CI

**Test Configuration**:
* Operating system
* Version number
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
