### PR TITLE
Cosmic time bug

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
+  - pip install 'pandas<0.25'
+  - pip install 'xarray<0.15'
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed a bug where `remote_file_list` would fail for some instruments.
   - Made import of methods more robust
   - Fixed `SettingWithCopyWarning` in `cnofs_ivm` cleaning routine
+  - Added time mangling to ensure COSMIC files and data have unique times
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed a bug where `remote_file_list` would fail for some instruments.
   - Made import of methods more robust
   - Fixed `SettingWithCopyWarning` in `cnofs_ivm` cleaning routine
-  - Added time mangling to ensure COSMIC files and data have unique times
+  - Added small time offsets (< 1s) to ensure COSMIC files and data have unique times
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -101,8 +101,6 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     # is added to file times to help ensure there are no file collisions
 
     # overloading revision keyword below
-    # avoiding the use of version since including version triggers pysat
-    # to filter filenames to get most recent version number
     if format_str is None:
         # COSMIC file format string
         if tag == 'scnlv1':


### PR DESCRIPTION
# Description
Fixes non-unique data and file times in COSMIC

Addresses # 363, 364

There can be multiple profiles or files for a given time. The cosmic_gps code was 
updated to provide unique times.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

Added unique time checks within the code itself to self-monitor for issues. Tested
on multiple days and file types, locally.

**Test Configuration**:
* macOS 10.15.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
