### PR TITLE
ENH: Keyword Check at Instantiation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
+  - pip install 'pandas<0.25'
+  - pip install 'xarray<0.15'
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,13 +25,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed a bug where `remote_file_list` would fail for some instruments.
   - Made import of methods more robust
   - Fixed `SettingWithCopyWarning` in `cnofs_ivm` cleaning routine
-<<<<<<< HEAD
-  - Fixed method definition
   - Fixed cosmic load method definition to include altitude_bin
   - Fixed pysat_testing method definition to include mangle_file_dates keyword
-=======
   - Updates to Travis CI environment
->>>>>>> develop
+
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments
    - Updated `test_files.py` to be pytest compatible
+   - Added check to ensure non-pysat keywords supplied at instantiation
+     are supported by underlying data set methods
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
@@ -19,6 +21,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed a bug where `remote_file_list` would fail for some instruments.
   - Made import of methods more robust
   - Fixed `SettingWithCopyWarning` in `cnofs_ivm` cleaning routine
+  - Fixed method definition
+  - Fixed cosmic load method definition to include altitude_bin
+  - Fixed pysat_testing method definition to include mangle_file_dates keyword
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2636,22 +2636,27 @@ def _get_supported_keywords(load_func):
     if sys.version_info.major == 2:
         args, varargs, varkw, defaults = inspect.getargspec(load_func)
     else:
-        args, varargs, varkw, defaults = inspect.signature(load_func)
+        sig = inspect.getfullargspec(load_func)
+        # args are first
+        args = sig.args
 
-    if defaults:
-        args = args[-len(defaults):]
-
-     # account for keywords already set since input was a partial function
+    pop_list = []
+    # account for keywords that exist for every load function
+    pre_kws = ['fnames', 'sat_id', 'tag']
+    # account for keywords already set since input was a partial function
     if existing_kws is not None:
-        pop_list = []
-        for i, arg in enumerate(args):
-            if arg in existing_kws:
-                pop_list.append(i)
-        # go backwards so we don't mess with the location of data we
-        # are trying to remove
-        if len(pop_list) > 0:
-            for pop in pop_list.reverse():
-                args.pop(pop)
+        pre_kws.extend(existing_kws.keys())
+    # remove pre-existing keywords from output
+    # first identify locations
+    for i, arg in enumerate(args):
+        if arg in pre_kws:
+            pop_list.append(i)
+    # remove identified locations
+    # go backwards so we don't mess with the location of data we
+    # are trying to remove
+    if len(pop_list) > 0:
+        for pop in pop_list[::-1]:
+            args.pop(pop)
 
     # *args and **kwargs are not required, so ignore them.
     return args

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2649,8 +2649,9 @@ def _get_supported_keywords(load_func):
                 pop_list.append(i)
         # go backwards so we don't mess with the location of data we
         # are trying to remove
-        for pop in pop_list.reverse():
-            args.pop(pop)
+        if len(pop_list) > 0:
+            for pop in pop_list.reverse():
+                args.pop(pop)
 
     # *args and **kwargs are not required, so ignore them.
     return args

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -7,8 +7,8 @@ try:
 except NameError:
     basestring = str
 
-import inspect
 import functools
+import inspect
 import string
 import os
 import copy

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -7,16 +7,17 @@ try:
 except NameError:
     basestring = str
 
+import copy
 import functools
 import inspect
-import string
 import os
-import copy
+import string
 import sys
-import pandas as pds
-import numpy as np
-import xarray as xr
 import warnings
+
+import numpy as np
+import pandas as pds
+import xarray as xr
 
 from . import _custom
 from . import _files

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -141,7 +141,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         return pysat.Series(None)
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, sat_id=None, altitude_bin=None):
     """Load COSMIC GPS files.
 
     Parameters
@@ -152,6 +152,9 @@ def load(fnames, tag=None, sat_id=None):
         tag or None (default=None)
     sat_id : (str or NoneType)
         satellite id or None (default=None)
+    altitude_bin : integer
+        Number of kilometers to bin altitude profiles by when loading.
+        Currently only supported for tag='ionprf'.
 
     Returns
     -------
@@ -162,12 +165,18 @@ def load(fnames, tag=None, sat_id=None):
 
     """
 
+    # input check
+    if altitude_bin is not None:
+        if tag != 'ionprf':
+            raise ValueError('altitude_bin only supported for "tag=ionprf"')
+
     num = len(fnames)
     # make sure there are files to read
     if num != 0:
         # call separate load_files routine, segemented for possible
         # multiprocessor load, not included and only benefits about 20%
-        output = pysat.DataFrame(load_files(fnames, tag=tag, sat_id=sat_id))
+        output = pysat.DataFrame(load_files(fnames, tag=tag, sat_id=sat_id,
+                                            altitude_bin=altitude_bin))
         utsec = output.hour * 3600. + output.minute * 60. + output.second
         output.index = \
             pysat.utils.time.create_datetime_index(year=output.year,

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -168,7 +168,8 @@ def load(fnames, tag=None, sat_id=None, altitude_bin=None):
     # input check
     if altitude_bin is not None:
         if tag != 'ionprf':
-            raise ValueError('altitude_bin only supported for "tag=ionprf"')
+            estr = 'altitude_bin keyword only supported for "tag=ionprf"'
+            raise ValueError(estr)
 
     num = len(fnames)
     # make sure there are files to read

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -136,7 +136,7 @@ def default(inst):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, file_date_range=None,
-         malformed_index=False, **kwargs):
+         malformed_index=False, mangle_file_dates=False, **kwargs):
     """ Loads the test files
 
     Parameters
@@ -160,10 +160,13 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         (default=None)
     file_date_range : (pds.date_range or NoneType)
         Range of dates for files or None, if this optional arguement is not
-        used
+        used. Shift actually performed by the init function.
         (default=None)
     malformed_index : bool (default=False)
         If True, time index for simulation will be non-unique and non-monotonic
+    mangle_file_dates : bool
+        If True, the loaded file list time index is shifted by 5-minutes.
+        This shift is actually performed by the init function.
     **kwargs : Additional keywords
         Additional keyword arguments supplied at pyast.Instrument instantiation
         are passed here

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -51,6 +51,14 @@ class TestBasics():
             (test_date == self.testInst.date)
 
     @raises(Exception)
+    def test_basic_instrument_bad_keyword(self):
+        """Checks for error when instantiating with bad load_rtn keywords"""
+        testInst = pysat.Instrument(platform='pysat', name='testing',
+                                    sat_id='10',
+                                    clean_level='clean',
+                                    unsupported_keyword_yeah=True)
+
+    @raises(Exception)
     def test_basic_instrument_load_yr_no_doy(self):
         self.testInst.load(2009)
 


### PR DESCRIPTION
# Description

Resolves # 292

pysat passes non-pysat keywords provided at instantiation to the underlying load routine for a particular data set. If a user mis-typed a pysat keyword it would get lost without user notice. Now, if a non-pysat keyword is provided and if that keyword is not supported by the underlying load routine an error is raised. By supported that means in the method signature.

The altitude_bin keyword was not properly supported by the cosmic_gps routine. Fixed.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?


Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

    import pysat
    # produces exception
    gps = pysat.Instrument('cosmic', 'gps', 'ionprf', update_files=True, altitude_bin=10, test_check='yo')
    # this loads files 
    gps = pysat.Instrument('cosmic', 'gps', 'ionprf', update_files=True, altitude_bin=10)
    gps.load(2013, 1)
    # produces exception
    gps = pysat.Instrument('cosmic', 'gps', 'scnlv1', update_files=True, altitude_bin=10)
    gps.load(2013, 1)

**Test Configuration**:
* MacOS 10.12.6
* Python 2.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
