### PR TITLE
Meta fix

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1371,6 +1371,13 @@ class Instrument(object):
         else:
             self.data, meta = self._load_data(date=self.date, fid=self._fid)
             if not self.empty:
+                cur_meta = dir(self.meta)
+                new_meta = dir(meta)
+                xtra_meta = [item for item in cur_meta if item not in new_meta]
+                if xtra_meta:
+                    for key in xtra_meta:
+                        xmet_attr = self.meta.__getattribute__(key)
+                        meta.__setattr__(key, xmet_attr)
                 self.meta = meta
 
         # check if load routine actually returns meta

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -318,6 +318,11 @@ class TestBasics():
         assert 'pad' in dir(self.testInst)
         assert 'pad' not in dir(self.testInst.meta)
 
+    def test_custom_attribute_retained_on_load(self):
+        self.testInst.my_attr = 'my value'
+        self.testInst.load(2009, 2)
+        assert 'my_attr' in dir(self.testInst.meta)
+
 
     @raises(AttributeError)
     def test_retrieve_bad_attribute(self):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -319,6 +319,7 @@ class TestBasics():
         assert 'pad' not in dir(self.testInst.meta)
 
     def test_custom_attribute_retained_on_load(self):
+        # check attribute remains attached to meta after loading data
         self.testInst.my_attr = 'my value'
         self.testInst.load(2009, 2)
         assert 'my_attr' in dir(self.testInst.meta)


### PR DESCRIPTION
# Description
Small pull request that adds a feature and a unit test.
Now when data is loaded, user defined meta data is transferred to the Meta object from the load before reassigning the loaded meta object to the instrument object.

Currently ssnl fails a lot of unit tests, but this is true of the vanilla develop branch and I think is being addressed in the develop 3 branch.

Addresses #374 

Issue #374 found a bug where user created attributes stored in meta would be lost after loading data. This was due to the fact that meta was replaced completely on load with the meta object from the meta that the instrument specific load function returned.
This fix, which may be clunky or implemented poorly, takes the user defined attributes and transfers them over to the instrument specific meta and then reassigns the instrument meta data similar to the existing behavior.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Issue #374 includes the manual test used to debug, however a unit test has been added that fails using the develop branch, and passes using this branch.


**Test Configuration**:
* CentOS7
* pysat V2.1.0 develop branch and meta_fix branch from my Fork
* Barebones conda envirnoment with only the dependencies for pysat installed
* only tested in python 3.7

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
