### PR TITLE
removing Instrument to Meta attribute assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [3.0.0] - 2019-12-31
 - New Features
   - Added registry module for registering custom external instruments
+  - Added Meta.mutable flag to control attribute mutability
 - Deprecations
   - Removed ssnl
   - Removed utils.stats
@@ -12,6 +13,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and sat_id behaviour in testing instruments
+- Bug Fix
+  - Fixed custom instrument attribute persistence upon load
 
 ## [2.2.0] - 2019-12-31
 - New Features

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1407,6 +1407,7 @@ class Instrument(object):
 
         # transfer any extra attributes in meta to the Instrument object
         self.meta.transfer_attributes_to_instrument(self)
+        self.meta.mutable = False
         sys.stdout.flush()
         return
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -372,41 +372,6 @@ class Instrument(object):
                           stacklevel=2)
 
 
-    def __setattr__(self, name, value):
-        """Moves instrument attributes onto meta attributes
-
-        If the attribute is not in _base_attrs, add to meta attributes.
-        For all other cases, store as an instrument attribute.
-        """
-
-        if '_base_attr' in dir(self):
-            if name not in self._base_attr:
-                # set attribute on meta
-                if name[0] != '_':
-                    object.__setattr__(self.meta, name, value)
-                else:
-                    object.__setattr__(self, name, value)
-            else:
-                object.__setattr__(self, name, value)
-        else:
-            object.__setattr__(self, name, value)
-
-
-    def __getattr__(self, name):
-        """Gets instrument attributes from meta attributes
-
-        Usually, python only calls __getattr__ if name does not already
-        exist in the instrument, so we only need to check
-        the meta object. However, __copy__ calls __getattr__, so we still have
-        to check for invalid attributes manually.
-        """
-        if name not in self.__dict__:
-            try:
-                return getattr(self.meta, name)
-            except:
-                raise AttributeError("No attribute {}".format(name))
-
-        return getattr(self.meta, name)
 
     def __getitem__(self, key):
         """

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -387,6 +387,10 @@ class Meta(object):
                     default_nan, default_nan]
         self._data.loc[input_name, labels] = defaults
 
+
+    # def __setattr__(self, name, value):
+    #     raise NotImplementedError
+
     def __setitem__(self, names, input_data):
         """Convenience method for adding metadata."""
 

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -177,7 +177,7 @@ class Meta(object):
                  desc_label='desc', plot_label='label', axis_label='axis',
                  scale_label='scale', min_label='value_min',
                  max_label='value_max', fill_label='fill',
-                 is_mutable = True):
+                 mutable = True):
 
         # # set mutability of object attributes
         # super().__setattr__('_mutable', mutable)
@@ -224,7 +224,7 @@ class Meta(object):
         # establish attributes intrinsic to object, before user can
         # add any
         self._base_attr = dir(self)
-        self.mutable = is_mutable
+        self.mutable = mutable
 
 
     @property

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -177,10 +177,9 @@ class Meta(object):
                  desc_label='desc', plot_label='label', axis_label='axis',
                  scale_label='scale', min_label='value_min',
                  max_label='value_max', fill_label='fill',
-                 mutable = True):
+                 ):
 
-        # # set mutability of object attributes
-        # super().__setattr__('_mutable', mutable)
+        # set mutability of Meta attributes
         self.mutable = True
 
         # set units and name labels directly
@@ -224,7 +223,6 @@ class Meta(object):
         # establish attributes intrinsic to object, before user can
         # add any
         self._base_attr = dir(self)
-        self.mutable = mutable
 
 
     @property

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -400,7 +400,7 @@ class Meta(object):
 
 
     def __setattr__(self, name, value):
-        """Conditionally sets attributes based on _mutable property
+        """Conditionally sets attributes based on self.mutable flag 
 
         @properties are assumed to be mutable.
 
@@ -408,26 +408,29 @@ class Meta(object):
         method from https://stackoverflow.com/a/15751135
         """
 
-        # _mutable handled explicitly to avoid recursion
+        # mutable handled explicitly to avoid recursion
         if name != 'mutable':
+
+            # check if this attribute is a property
             propobj = getattr(self.__class__, name, None)
             if isinstance(propobj, property):
-                # print("setting attr {} using property's fset".format(name))
+                # check if the property is settable
                 if propobj.fset is None:
                     raise AttributeError("can't set attribute - property has no fset")
 
-                # temporarily make mutable
+                # make mutable in case fset needs it to be
                 mutable_tmp = self.mutable
                 self.mutable = True
 
                 # set the property
                 propobj.fset(self, value)
 
-                # restore mutability
+                # restore mutability flag
                 self.mutable = mutable_tmp
             else:
+                # a normal attribute
                 if self.mutable:
-                    # print("setting attr {}".format(name))
+                    # use Object to avoid recursion
                     super(Meta, self).__setattr__(name, value)
                 else:
                     raise AttributeError("cannot set attribute - object's attributes are immutable")

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -415,14 +415,14 @@ class Meta(object):
             if isinstance(propobj, property):
                 # print("setting attr {} using property's fset".format(name))
                 if propobj.fset is None:
-                    raise AttributeError("can't set attribute")
+                    raise AttributeError("can't set attribute - property has no fset")
                 propobj.fset(self, value)
             else:
                 if self.mutable:
                     # print("setting attr {}".format(name))
                     super(Meta, self).__setattr__(name, value)
                 else:
-                    print("can't set attribute - Meta object attributes are immutable")
+                    raise AttributeError("cannot set attribute - object's attributes are immutable")
         else:
             super(Meta, self).__setattr__(name, value)
         

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1013,8 +1013,9 @@ class Meta(object):
         # get list of instrument objects attributes first
         # to check if a duplicate
 
-        # instrument attributes are now inst.meta attributes
-        inst_attr = dir(inst.meta)
+        # instrument attributes stay with instrument
+        inst_attr = dir(inst)
+        
         for key in transfer_key:
             if key not in banned:
                 if key not in inst_attr:

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -414,7 +414,8 @@ class Meta(object):
             if isinstance(propobj, property):
                 # check if the property is settable
                 if propobj.fset is None:
-                    raise AttributeError("can't set attribute - property has no fset")
+                    raise AttributeError(''.join("can't set attribute - ",
+                                        "property has no fset"))
 
                 # make mutable in case fset needs it to be
                 mutable_tmp = self.mutable
@@ -431,7 +432,8 @@ class Meta(object):
                     # use Object to avoid recursion
                     super(Meta, self).__setattr__(name, value)
                 else:
-                    raise AttributeError("cannot set attribute - object's attributes are immutable")
+                    raise AttributeError(''.join("cannot set attribute - ",
+                                "object's attributes are immutable"))
         else:
             super(Meta, self).__setattr__(name, value)
         

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -432,8 +432,8 @@ class Meta(object):
                     # use Object to avoid recursion
                     super(Meta, self).__setattr__(name, value)
                 else:
-                    raise AttributeError(''.join("cannot set attribute - ",
-                                "object's attributes are immutable"))
+                    raise AttributeError(''.join(("cannot set attribute - ",
+                                                    "object's attributes are immutable")))
         else:
             super(Meta, self).__setattr__(name, value)
         

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -289,34 +289,12 @@ class TestBasics():
             assert np.all(self.testInst.index ==
                           self.testInst.data.indexes['time'])
 
-    #--------------------------------------------------------------------------
-    #
-    # Test custom attributes
-    #
-    #--------------------------------------------------------------------------
+    # #--------------------------------------------------------------------------
+    # #
+    # # Test custom attributes
+    # #
+    # #--------------------------------------------------------------------------
 
-    def test_create_custom_attribute(self):
-        # check attribute attached to meta
-        self.testInst.my_attr = 'my value'
-        assert self.testInst.my_attr is self.testInst.meta.my_attr
-        assert 'my_attr' not in dir(self.testInst)
-
-        # check underscores attached to instrument
-        self.testInst._nometa = 'non meta value'
-        assert self.testInst._nometa == 'non meta value'
-        assert '_nometa' in dir(self.testInst)
-        assert '_nometa' not in dir(self.testInst.meta)
-
-        # check if underscore stays attached to meta
-        self.testInst.meta._mine = 'stay here'
-        assert self.testInst._mine is self.testInst.meta._mine
-        assert '_mine' not in dir(self.testInst)
-
-        # see if a base attr attached to instrument
-        self.testInst.pad = 1
-        assert self.testInst.pad == 1
-        assert 'pad' in dir(self.testInst)
-        assert 'pad' not in dir(self.testInst.meta)
 
 
     @raises(AttributeError)

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1028,16 +1028,7 @@ class TestBasics():
         assert self.meta.hey == greeting
 
         self.meta.mutable = False
-        
         self.meta.hey = greeting
-    
-    @raises(AttributeError)
-    def test_meta_immutable_kwarg(self):
-        meta_immutable = pysat.Meta(mutable = False)
-
-        assert not meta_immutable.mutable
-
-        meta_immutable.hey = '...listen!'
         
 
     def test_meta_mutable_properties(self):

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1032,13 +1032,19 @@ class TestBasics():
         
 
     def test_meta_mutable_properties(self):
-        m = pysat.Meta(mutable = False)
-
+        """check that @properties are always mutable"""
+        m = pysat.Meta()
+        m.mutable = False
         m.data = pds.DataFrame()
         m.ho_data = {}
         m.units_label = 'nT'
         m.name_label = 'my name'
 
+    def test_inst_attributes_not_overridden(self):
+        greeting = '... listen!'
+        self.testInst.hey = greeting
+        self.testInst.load(2009, 1)
+        assert self.testInst.hey == greeting
 
 
 

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1018,8 +1018,9 @@ class TestBasics():
         assert (self.meta['NEW21'].long_name == 'boo2')
         assert (self.meta['NEW21'].YoYoYO == 'yolo')
 
-
-    def test_meta_mutable(self):
+    
+    @raises(AttributeError)
+    def test_meta_immutable(self):
         assert self.meta.mutable
 
         greeting = '...listen!'
@@ -1027,19 +1028,17 @@ class TestBasics():
         assert self.meta.hey == greeting
 
         self.meta.mutable = False
-        try:
-          self.hey = greeting
-        except AttributeError:
-          pass
-
+        
+        self.meta.hey = greeting
+    
+    @raises(AttributeError)
+    def test_meta_immutable_kwarg(self):
         meta_immutable = pysat.Meta(mutable = False)
 
         assert not meta_immutable.mutable
 
-        try:
-          self.hey = greeting
-        except AttributeError:
-          pass
+        meta_immutable.hey = '...listen!'
+        
 
     def test_meta_mutable_properties(self):
         m = pysat.Meta(mutable = False)

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1017,3 +1017,38 @@ class TestBasics():
         assert (self.meta['NEW21'].units == 'hey2')
         assert (self.meta['NEW21'].long_name == 'boo2')
         assert (self.meta['NEW21'].YoYoYO == 'yolo')
+
+
+    def test_meta_mutable(self):
+        assert self.meta.mutable
+
+        greeting = '...listen!'
+        self.meta.hey = greeting
+        assert self.meta.hey == greeting
+
+        self.meta.mutable = False
+        try:
+          self.hey = greeting
+        except AttributeError:
+          pass
+
+        meta_immutable = pysat.Meta(mutable = False)
+
+        assert not meta_immutable.mutable
+
+        try:
+          self.hey = greeting
+        except AttributeError:
+          pass
+
+    def test_meta_mutable_properties(self):
+        m = pysat.Meta(mutable = False)
+
+        m.data = pds.DataFrame()
+        m.ho_data = {}
+        m.units_label = 'nT'
+        m.name_label = 'my name'
+
+
+
+


### PR DESCRIPTION
# Description
 
Addressing # 374

* Removed `__setattr__` and `__getattr__`, which implicitly moved  Instrument attributes onto attached Meta object.
* Added `__setattr__` method to Meta. 

## Type of change

- New Feature 
- This change requires a documentation update

# How Has This Been Tested?


###  test_meta.py:TestBasics.test_meta_immutable (added)
checks that Meta.mutable flag prevents new attributes from being added

### test_meta.py:TestBasics.test_meta_mutable_properties (added)
checks that meta's `@properties` will work regardless of `mutable` flag

### test_meta.py:test_inst_attributes_not_overridden (added)
Checks that instrument attributes are not overridden on load

### tests_instrument.py:test_create_custom_attribute (removed)
removed tests checking implicit move of attributes from `inst.<attr>` to `inst.meta.<attr>`

### test_utils.py:test_netcdf_prevent_attribute_override (added)
tests that instrument's meta is made immutable upon load.

### test_utils.py:test_netcdf_attribute_override (modified)
overrides the default behavior by setting inst.meta.mutable=True. Removed part of this test related to implicit transfer of `inst.<attr>` to `inst.meta.<attr>`


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
