### PR TITLE
ROADMAP: Deprecate custom.add

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
+  - pip install 'pandas<0.25' # Temporary for pysat 2.x, remove in 3.0.0
+  - pip install 'xarray<0.15' # Temporary for pysat 2.x, remove in 3.0.0
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
+  - pip install 'xarray<0.15' # Temporary for pysat 2.x, will remove for 3.0
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
+  - pip install 'pandas<1.0' # Temporary for pysat 2.x, will remove for 3.0
   - pip install 'xarray<0.15' # Temporary for pysat 2.x, will remove for 3.0
   - pip install pysatCDF >/dev/null
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
-  - pip install 'pandas<1.0' # Temporary for pysat 2.x, will remove for 3.0
-  - pip install 'xarray<0.15' # Temporary for pysat 2.x, will remove for 3.0
   - pip install pysatCDF >/dev/null
 
 # command to install dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments
    - Updated `test_files.py` to be pytest compatible
+- Deprecation Warning
+  - custom.add will be renamed custom.attach in pysat 3.0.0
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -5,6 +5,7 @@ try:
     basestring
 except NameError:
     basestring = str
+import warnings
 
 import pandas as pds
 import xarray as xr
@@ -98,6 +99,10 @@ class Custom(object):
 
         - (string/list of strings, numpy array/list of arrays)
         """
+
+        warnings.warn(' '.join(["custom.add is deprecated and will be",
+                                "renamed in pysat 3.0.0 as custom.attach"]),
+                      DeprecationWarning, stacklevel=2)
 
         if isinstance(function, str):
             # convert string to function object

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from nose.tools import raises
 import pandas as pds
@@ -335,3 +336,31 @@ class ConstellationTestBasics(TestBasics):
     def add(self, function, kind='add', at_pos='end', *args, **kwargs):
         """ Add a function to the object's custom queue"""
         self.testConst.data_mod(function, kind, at_pos, *args, **kwargs)
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
+    def test_deprecation_warning_custom_add(self):
+        """Test if custom.add is deprecated"""
+
+        def func():
+            """Fake function to attach"""
+            print('Hi!')
+
+        testInst = pysat.Instrument(platform='pysat', name='testing')
+        with warnings.catch_warnings(record=True) as war:
+            try:
+                testInst.custom.add(func)
+            except AttributeError:
+                # Setting inst to None should produce a AttributeError after
+                # warning is generated
+                pass
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning


### PR DESCRIPTION
# Description

Addresses #361.  Pysat 2.2.0 partner to #378.

- Adds a deprecation warning to `custom.add`.
- Adds temporary caps to travis.yml to play better with pandas and xarray for pysat 2.x.

## Type of change

- Deprecation Warning

# How Has This Been Tested?

Travis CI

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
