### PR TITLE
BUG: freq keyword not passed through in season_date_range

### DIFF
--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -138,7 +138,7 @@ def season_date_range(start, stop, freq='D'):
                             "utils.time.create_date_range instead"]),
                   DeprecationWarning, stacklevel=2)
 
-    season = create_date_range(start, stop, freq='D')
+    season = create_date_range(start, stop, freq=freq)
 
     return season
 


### PR DESCRIPTION
# Description

Addresses # (issue)

season_date_range accepts a freq keyword but it is not passed along to the underlying method so it doesn't work as expected.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Direct execution of method.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
