### PR TITLE
BUG: assign no longer allows inplace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed pysat_testing method definition to include mangle_file_dates keyword
   - Added small time offsets (< 1s) to ensure COSMIC files and data have unique times
   - Updates to Travis CI environment
+  - Removed `inplace` use in xarray `assign` function, which is no longer allowed
 
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -244,7 +244,7 @@ def calc_measurement_loc(self):
         if kk in el_keys:
             try:
                 good_dir.append(int(kk))
-            except:
+            except ValueError:
                 logger.warning("unknown direction number [{:}]".format(kk))
 
     # Calculate the geodetic latitude and longitude for each direction
@@ -270,9 +270,7 @@ def calc_measurement_loc(self):
 
         # Assigning as data, to ensure that the number of coordinates match
         # the number of data dimensions
-        self.data = self.data.assign(lat_key=gdlat, lon_key=gdlon)
-        self.data.rename({"lat_key": lat_key, "lon_key": lon_key},
-                         inplace=True)
+        self.data = self.data.assign({lat_key: gdlat, lon_key: gdlon})
 
         # Add metadata for the new data values
         bm_label = "Beam {:d} ".format(dd)

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -117,8 +117,7 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
     if inst.pandas_format:
         inst[slt_name] = pds.Series(slt, index=inst.data.index)
     else:
-        inst.data = inst.data.assign({pysat_slt: (inst.data.coords.keys(),
-                                                  slt)})
+        inst.data = inst.data.assign({slt_name: (inst.data.coords.keys(),slt)})
 
     # Add units to the metadata
     inst.meta[slt_name] = {inst.meta.units_label: 'h',

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -117,9 +117,8 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
     if inst.pandas_format:
         inst[slt_name] = pds.Series(slt, index=inst.data.index)
     else:
-        data = inst.data.assign(pysat_slt=(inst.data.coords.keys(), slt))
-        data.rename({"pysat_slt": slt_name}, inplace=True)
-        inst.data = data
+        inst.data = inst.data.assign({pysat_slt: (inst.data.coords.keys(),
+                                                  slt)})
 
     # Add units to the metadata
     inst.meta[slt_name] = {inst.meta.units_label: 'h',


### PR DESCRIPTION
xarry assign no longer allows inplace, use keyword arguement assignemnt instead.  Also fixed try/except loop that caught everything.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat

jro = pysat.Instrument('jro', 'isr', 'drifts')
jro.custom.add(pysat.instruments.jro_isr.calc_measurement_loc, 'modify')
jro.load(yr=2014, doy=20)
print([kk for kk in jro.data.data_vars.keys()])
```

With success this yields: `['year', 'month', 'day', 'hour', 'min', 'sec', 'recno', 'kindat', 'kinst', 'ut1_unix', 'ut2_unix', 'range', 'gdlatr', 'gdlonr', 'spcst', 'pl', 'cbadn', 'inttms', 'azdir7', 'eldir7', 'azdir8', 'eldir8', 'jro14', 'jro15', 'jro16', 'nwlos', 'vipn2', 'dvipn2', 'vipe1', 'dvipe1', 'vi72', 'dvi72', 'vi82', 'dvi82', 'paiwl', 'pacwl', 'pbiwl', 'pbcwl', 'pciel', 'pccel', 'pdiel', 'pdcel', 'jro10', 'jro11', 'gdlat7', 'gdlon7', 'gdlat8', 'gdlon8']`

With failure, this will either Error or give a deprecation warning (depending on your xarray version).

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.7, xarray version that fails is 0.14.1.  Earlier versions throw dep. error.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
