### PR TITLE
ENH: preserving metadata attributes upon load and adding mutable flag

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -375,42 +375,6 @@ class Instrument(object):
                           stacklevel=2)
 
 
-    def __setattr__(self, name, value):
-        """Moves instrument attributes onto meta attributes
-
-        If the attribute is not in _base_attrs, add to meta attributes.
-        For all other cases, store as an instrument attribute.
-        """
-
-        if '_base_attr' in dir(self):
-            if name not in self._base_attr:
-                # set attribute on meta
-                if name[0] != '_':
-                    object.__setattr__(self.meta, name, value)
-                else:
-                    object.__setattr__(self, name, value)
-            else:
-                object.__setattr__(self, name, value)
-        else:
-            object.__setattr__(self, name, value)
-
-
-    def __getattr__(self, name):
-        """Gets instrument attributes from meta attributes
-
-        Usually, python only calls __getattr__ if name does not already
-        exist in the instrument, so we only need to check
-        the meta object. However, __copy__ calls __getattr__, so we still have
-        to check for invalid attributes manually.
-        """
-        if name not in self.__dict__:
-            try:
-                return getattr(self.meta, name)
-            except:
-                raise AttributeError("No attribute {}".format(name))
-
-        return getattr(self.meta, name)
-
     def __getitem__(self, key):
         """
         Convenience notation for accessing data; inst['name'] is inst.data.name
@@ -1425,6 +1389,7 @@ class Instrument(object):
 
         # transfer any extra attributes in meta to the Instrument object
         self.meta.transfer_attributes_to_instrument(self)
+        self.meta.mutable = False
         sys.stdout.flush()
         return
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -303,28 +303,6 @@ class TestBasics():
     #
     #--------------------------------------------------------------------------
 
-    def test_create_custom_attribute(self):
-        # check attribute attached to meta
-        self.testInst.my_attr = 'my value'
-        assert self.testInst.my_attr is self.testInst.meta.my_attr
-        assert 'my_attr' not in dir(self.testInst)
-
-        # check underscores attached to instrument
-        self.testInst._nometa = 'non meta value'
-        assert self.testInst._nometa == 'non meta value'
-        assert '_nometa' in dir(self.testInst)
-        assert '_nometa' not in dir(self.testInst.meta)
-
-        # check if underscore stays attached to meta
-        self.testInst.meta._mine = 'stay here'
-        assert self.testInst._mine is self.testInst.meta._mine
-        assert '_mine' not in dir(self.testInst)
-
-        # see if a base attr attached to instrument
-        self.testInst.pad = 1
-        assert self.testInst.pad == 1
-        assert 'pad' in dir(self.testInst)
-        assert 'pad' not in dir(self.testInst.meta)
 
 
     @raises(AttributeError)

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1017,3 +1017,32 @@ class TestBasics():
         assert (self.meta['NEW21'].units == 'hey2')
         assert (self.meta['NEW21'].long_name == 'boo2')
         assert (self.meta['NEW21'].YoYoYO == 'yolo')
+
+
+    @raises(AttributeError)
+    def test_meta_immutable(self):
+        assert self.meta.mutable
+
+        greeting = '...listen!'
+        self.meta.hey = greeting
+        assert self.meta.hey == greeting
+
+        self.meta.mutable = False
+        self.meta.hey = greeting
+
+
+    def test_meta_mutable_properties(self):
+        """check that @properties are always mutable"""
+        m = pysat.Meta()
+        m.mutable = False
+        m.data = pds.DataFrame()
+        m.ho_data = {}
+        m.units_label = 'nT'
+        m.name_label = 'my name'
+
+    def test_inst_attributes_not_overridden(self):
+        greeting = '... listen!'
+        self.testInst.hey = greeting
+        self.testInst.load(2009, 1)
+        assert self.testInst.hey == greeting
+

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -428,8 +428,8 @@ class TestBasicNetCDF4():
         assert (np.all((test_inst.data == loaded_inst).all()))
         assert np.all(test_list)
 
-    def test_netcdf_attribute_override(self):
-        """Test that attributes in netcdf file may be overridden"""
+    def test_netcdf_prevent_attribute_override(self):
+        """Test that attributes will not be overridden by default"""
         self.testInst.load(2009, 1)
 
         try:
@@ -437,7 +437,19 @@ class TestBasicNetCDF4():
         except AttributeError:
             pass
 
-        fname = 'output.nc'
+        # instrument meta attributes immutable upon load
+        assert self.testInst.meta.mutable == False
+        try:
+            self.testInst.meta.bespoke = True
+        except AttributeError:
+            pass
+
+
+    def test_netcdf_attribute_override(self):
+        """Test that attributes in netcdf file may be overridden"""
+        self.testInst.load(2009, 1)
+
+        self.testInst.meta.mutable = True
         self.testInst.meta.bespoke = True
 
         self.testInst.meta.transfer_attributes_to_instrument(self.testInst)
@@ -445,6 +457,7 @@ class TestBasicNetCDF4():
         # ensure custom meta attribute assigned to instrument
         assert self.testInst.bespoke
 
+        fname = 'output.nc'
         outfile = os.path.join(self.testInst.files.data_path, fname)
         self.testInst.to_netcdf4(outfile)
 
@@ -453,24 +466,3 @@ class TestBasicNetCDF4():
         # custom attribute correctly read from file
         assert meta.bespoke
 
-        # assign metadata to new instrument
-        inst = pysat.Instrument()
-
-        inst.data = data
-        inst.meta = meta
-
-
-        meta.transfer_attributes_to_instrument(inst)
-
-        fname2 = 'output2.nc'
-        outfile2 = os.path.join(self.testInst.files.data_path, fname2)
-
-        inst.bespoke = False
-        inst.myattr = True
-
-        inst.to_netcdf4(outfile2)
-
-        data2, meta2 = pysat.utils.load_netcdf4(outfile2)
-
-        assert meta2.myattr
-        assert not meta2.bespoke


### PR DESCRIPTION
# Description

Develop version of #377 

* Removed `__setattr__` and `__getattr__`, which implicitly moved  Instrument attributes onto attached Meta object.
* Added `__setattr__` method to Meta. 

## Type of change

- New Feature 
- This change requires a documentation update

# How Has This Been Tested?


###  test_meta.py:TestBasics.test_meta_immutable (added)
checks that Meta.mutable flag prevents new attributes from being added

### test_meta.py:TestBasics.test_meta_mutable_properties (added)
checks that meta's `@properties` will work regardless of `mutable` flag

### test_meta.py:test_inst_attributes_not_overridden (added)
Checks that instrument attributes are not overridden on load

### tests_instrument.py:test_create_custom_attribute (removed)
removed tests checking implicit move of attributes from `inst.<attr>` to `inst.meta.<attr>`

### test_utils.py:test_netcdf_prevent_attribute_override (added)
tests that instrument's meta is made immutable upon load.

### test_utils.py:test_netcdf_attribute_override (modified)
overrides the default behavior by setting inst.meta.mutable=True. Removed part of this test related to implicit transfer of `inst.<attr>` to `inst.meta.<attr>`


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
