### PR TITLE
F107 date parsing issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added small time offsets (< 1s) to ensure COSMIC files and data have unique times
   - Updates to Travis CI environment
   - Removed `inplace` use in xarray `assign` function, which is no longer allowed
+  - Removed old code and incorrect comments from F10.7 support
 
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -674,10 +674,6 @@ def rewrite_daily_file(year, outfile, lines):
 
     """
 
-    # Parse text to get the date the prediction was generated
-    date_str = lines.split(':Issued: ')[-1].split('\n')[0]
-    date = pysat.datetime.strptime(date_str, '%H%M UT %d %b %Y')
-
     # get to the solar index data
     if year > 2000:
         raw_data = lines.split('#---------------------------------')[-1]

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -30,9 +30,9 @@ the data with tomorrow's date.
 
 
 
-The forecast data should not be used with the data padding option available
-from pysat.Instrument objects. The 'all' tag shouldn't be used either, no
-other data available to pad with.
+The forecast or prelim data should not be used with the data padding option 
+available from pysat.Instrument objects. The 'all' tag shouldn't be used either, 
+no other data available to pad with.
 
 Warnings
 --------
@@ -243,8 +243,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
         elif tag == 'prelim':
             # files are by year (and quarter). The load routine will load a
-            # year of data and use the appended date to select out appropriate
-            # data.
+            # year of data 
             if format_str is None:
                 format_str = \
                     'f107_prelim_{year:04d}_{month:02d}_v{version:01d}.txt'


### PR DESCRIPTION
# Description

Addresses # 398

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.  Please see ``CONTRIBUTING.md`` for more guidelines.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

    import pysat
    f107 = pysat.Instrument('sw', 'f107', tag='prelim', update_files=True)
    import datetime
    stime = datetime.datetime(2016, 6, 11, 0, 0)
    etime = datetime.datetime(2016, 6, 17, 0, 0)
    f107.download(stime, etime)
    f107.load(date=stime)

works on my local machine. 
macOS 10.15.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
