### PR TITLE
BUG: DE2 names for wats and nacs - pysat 3.0.0 edition

### DIFF
--- a/pysat/instruments/de2_nacs.py
+++ b/pysat/instruments/de2_nacs.py
@@ -90,7 +90,7 @@ import pysat
 from .methods import nasa_cdaweb as cdw
 
 platform = 'de2'
-name = 'idm'
+name = 'nacs'
 
 tags = {'': '1 s cadence Neutral Atmosphere Composition Spectrometer data'}
 sat_ids = {'': ['']}

--- a/pysat/instruments/de2_wats.py
+++ b/pysat/instruments/de2_wats.py
@@ -87,7 +87,7 @@ import pysat
 from .methods import nasa_cdaweb as cdw
 
 platform = 'de2'
-name = 'idm'
+name = 'wats'
 
 tags = {'': '2 s cadence Wind and Temperature Spectrometer data'}
 sat_ids = {'': ['']}


### PR DESCRIPTION
# Description

Copy and paste failure from initial PR.  de2_nacs and de2_wats mistakenly given `idm` as name.

NOTE: no updates to changelog since the 2.2.0 changes are not released.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Found while writing new unit tests in #391.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
