### PR TITLE
TST: limits on travis for python 2.7 tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ before_install:
   # Temporary limits for pysat 2.x, remove in 3.0.0
   - pip install 'pandas<0.25'
   - pip install 'xarray<0.15'
+  - pip install 'pyparsing<3.0.0'
   - pip install 'kiwisolver<1.2.0'
   - pip install 'beautifulsoup4<4.9.0'
   # End of temporary limits

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,12 @@ addons:
 before_install:
   - pip install coveralls
   - pip install future
-  - pip install 'pandas<0.25' # Temporary for pysat 2.x, remove in 3.0.0
-  - pip install 'xarray<0.15' # Temporary for pysat 2.x, remove in 3.0.0
+  # Temporary limits for pysat 2.x, remove in 3.0.0
+  - pip install 'pandas<0.25'
+  - pip install 'xarray<0.15'
+  - pip install 'kiwisolver<1.2.0'
+  - pip install 'beautifulsoup4<4.9.0'
+  # End of temporary limits
   - pip install pysatCDF >/dev/null
   # Travis CI currently not working with cftime > 1.1.1
   - pip install 'cftime==1.1.1'


### PR DESCRIPTION
# Description

New versions of `pyparsing`, `kiwisolver`, and `beautifulsoup4` have been released which do not support tests on python 2.7.  Limiting these in the travis setup and clarifying the block of pip installs that should not go into the develop-3 version.

Discovered in #405, but opening a separate pull to aid in tracking changes.

## Type of change

- Bug fix -- Testing environment (non-breaking change which fixes an issue)

# How Has This Been Tested?

On Travis CI.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
