### PR TITLE
ENH: Adds 'altitude' to test instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added Meta.mutable flag to control attribute mutability
   - custom.attach replaces custom.add
   - Unit tests are now pytest compatible
+  - Added altitudes to test instruments
 - Deprecations
   - Removed ssnl
   - Removed utils.stats

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -186,6 +186,10 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
                                        data_range=drange['angle'])
     data['latitude'] = 90.0 * np.cos(angle)
 
+    # create constant altitude at 400 km
+    alt0 = 400.0
+    data['altitude'] = alt0 * np.ones(data['latitude'].shape)
+
     # fake orbit number
     fake_delta = date - (_test_dates[''][''] - pds.DateOffset(years=1))
     data['orbit_num'] = mm_test.generate_fake_data(fake_delta.total_seconds(),
@@ -283,6 +287,7 @@ meta['orbit_num'] = {'units': '',
 
 meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
 meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
+meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
 meta['dummy1'] = {'units': '', 'long_name': 'dummy1'}
 meta['dummy2'] = {'units': '', 'long_name': 'dummy2'}
 meta['dummy3'] = {'units': '', 'long_name': 'dummy3'}

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -118,6 +118,10 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
                                        data_range=drange['angle'])
     data['latitude'] = 90.0 * np.cos(angle)
 
+    # create constant altitude at 400 km
+    alt0 = 400.0
+    data['altitude'] = alt0 * np.ones(data['latitude'].shape)
+
     if malformed_index:
         index = index.tolist()
         # nonmonotonic
@@ -183,6 +187,7 @@ meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time'}
 meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time'}
 meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
 meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
+meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
 series_profile_meta = pysat.Meta()
 series_profile_meta['series_profiles'] = {'units': '', 'long_name': 'series'}
 meta['series_profiles'] = {'meta': series_profile_meta, 'units': '',

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -159,7 +159,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     data['variable_profiles'] = \
         (('time', 'z'),
          data['dummy3'].values[:, np.newaxis] * np.ones((num, 15)))
-    data.coords['profile_height2'] = \
+    data.coords['variable_profile_height'] = \
         (('time', 'z'),
          np.arange(15)[np.newaxis, :]*np.ones((num, 15)))
 

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -119,7 +119,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
                                      data_range=drange['lt'])
     data['slt'] = (('time'), slt)
 
-    # create a fake longitude, resets every 6240 seconds
+    # create a fake longitude of satellite, resets every 6240 seconds
     # sat moves at 360/5820 deg/s, Earth rotates at 360/86400, takes extra time
     # to go around full longitude
     longitude = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
@@ -127,7 +127,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
                                            data_range=drange['lon'])
     data['longitude'] = (('time'), longitude)
 
-    # create latitude signal for testing polar orbits
+    # create fake latitude of satellite for testing polar orbits
     angle = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
                                        period=iperiod['angle'],
                                        data_range=drange['angle'])
@@ -147,7 +147,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     data['dummy3'] = (('time'), mlt_int + long_int * 1000.)
     data['dummy4'] = (('time'), uts)
 
-    # create altitude 'profile' at each location
+    # create altitude 'profile' at each location to simulate remote data
     num = len(data['uts'])
     data['profiles'] = \
         (('time', 'profile_height'),
@@ -162,18 +162,19 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
         (('time', 'z'),
          np.arange(15)[np.newaxis, :]*np.ones((num, 15)))
 
-    # basic image simulation
+    # Create fake image type data, projected to lat / lon at some location
+    # from satellite
     data['images'] = \
         (('time', 'x', 'y'),
          data['dummy3'].values[:,
                                np.newaxis,
                                np.newaxis] * np.ones((num, 17, 17)))
-    data.coords['latitude'] = \
+    data.coords['image_lat'] = \
         (('time', 'x', 'y'),
          np.arange(17)[np.newaxis,
                        np.newaxis,
                        :]*np.ones((num, 17, 17)))
-    data.coords['longitude'] = \
+    data.coords['image_lon'] = \
         (('time', 'x', 'y'),
          np.arange(17)[np.newaxis,
                        np.newaxis,

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -150,15 +150,15 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     # create altitude 'profile' at each location
     num = len(data['uts'])
     data['profiles'] = \
-        (('time', 'altitude_profile'),
+        (('time', 'profile_height'),
          data['dummy3'].values[:, np.newaxis] * np.ones((num, 15)))
-    data.coords['altitude_profile'] = ('altitude_profile', np.arange(15))
+    data.coords['profile_height'] = ('profile_height', np.arange(15))
 
     # profiles that could have different altitude values
     data['variable_profiles'] = \
         (('time', 'z'),
          data['dummy3'].values[:, np.newaxis] * np.ones((num, 15)))
-    data.coords['altitude_profile2'] = \
+    data.coords['profile_height2'] = \
         (('time', 'z'),
          np.arange(15)[np.newaxis, :]*np.ones((num, 15)))
 

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -119,7 +119,7 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
                                      data_range=drange['lt'])
     data['slt'] = (('time'), slt)
 
-    # create a fake longitude of satellite, resets every 6240 seconds
+    # create a fake satellite longitude, resets every 6240 seconds
     # sat moves at 360/5820 deg/s, Earth rotates at 360/86400, takes extra time
     # to go around full longitude
     longitude = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
@@ -127,14 +127,15 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
                                            data_range=drange['lon'])
     data['longitude'] = (('time'), longitude)
 
-    # create fake latitude of satellite for testing polar orbits
+    # create fake satellite latitude for testing polar orbits
     angle = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
                                        period=iperiod['angle'],
                                        data_range=drange['angle'])
     latitude = 90.0 * np.cos(angle)
     data['latitude'] = (('time'), latitude)
 
-    # create constant altitude at 400 km
+    # create constant altitude at 400 km for a satellite that has yet
+    # to experience orbital decay
     alt0 = 400.0
     altitude = alt0 * np.ones(data['latitude'].shape)
     data['altitude'] = (('time'), altitude)

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -148,6 +148,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     data['dummy3'] = (('time'), mlt_int + long_int * 1000.)
     data['dummy4'] = (('time'), uts)
 
+    # Add dummy coords
+    data.coords['x'] = (('x'), np.arange(17))
+    data.coords['y'] = (('y'), np.arange(17))
+    data.coords['z'] = (('z'), np.arange(15))
+
     # create altitude 'profile' at each location to simulate remote data
     num = len(data['uts'])
     data['profiles'] = \

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -134,6 +134,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     latitude = 90.0 * np.cos(angle)
     data['latitude'] = (('time'), latitude)
 
+    # create constant altitude at 400 km
+    alt0 = 400.0
+    altitude = alt0 * np.ones(data['latitude'].shape)
+    data['altitude'] = (('time'), altitude)
+
     # create some fake data to support testing of averaging routines
     mlt_int = data['mlt'].astype(int)
     long_int = (data['longitude'] / 15.).astype(int)
@@ -145,15 +150,15 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     # create altitude 'profile' at each location
     num = len(data['uts'])
     data['profiles'] = \
-        (('time', 'altitude'),
+        (('time', 'altitude_profile'),
          data['dummy3'].values[:, np.newaxis] * np.ones((num, 15)))
-    data.coords['altitude'] = ('altitude', np.arange(15))
+    data.coords['altitude_profile'] = ('altitude_profile', np.arange(15))
 
     # profiles that could have different altitude values
     data['variable_profiles'] = \
         (('time', 'z'),
          data['dummy3'].values[:, np.newaxis] * np.ones((num, 15)))
-    data.coords['altitude2'] = \
+    data.coords['altitude_profile2'] = \
         (('time', 'z'),
          np.arange(15)[np.newaxis, :]*np.ones((num, 15)))
 
@@ -188,6 +193,7 @@ meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time'}
 meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time'}
 meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
 meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
+meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
 series_profile_meta = pysat.Meta()
 series_profile_meta['series_profiles'] = {'units': '', 'long_name': 'series'}
 meta['series_profiles'] = {'meta': series_profile_meta, 'units': '',

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -150,6 +150,11 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     latitude = 90.0 * np.cos(angle)
     data['latitude'] = (('time'), latitude)
 
+    # create constant altitude at 400 km
+    alt0 = 400.0
+    altitude = alt0 * np.ones(data['latitude'].shape)
+    data['altitude'] = (('time'), altitude)
+
     # fake orbit number
     fake_delta = date - pysat.datetime(2008, 1, 1)
     orbit_num = mm_test.generate_fake_data(fake_delta.total_seconds(),
@@ -233,6 +238,7 @@ meta['orbit_num'] = {'units': '',
 
 meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
 meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
+meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
 meta['dummy1'] = {'units': '', 'long_name': 'dummy1'}
 meta['dummy2'] = {'units': '', 'long_name': 'dummy2'}
 meta['dummy3'] = {'units': '', 'long_name': 'dummy3'}


### PR DESCRIPTION
# Description

Closes #410.

- Adds a constant altitude of 400 km to the test instruments.
- Updates `pysat_testing2d_xarray` to use `altitude_profile' and 'altitude_profile2' for the profile data.

Required for pysat/pysatModels#34.

## Type of change

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

via pytest.

Also by 
```
import pysat
test = pysat.Instrument('pysat', 'testing')
test.load(date=pysat.datetime(2009, 1, 1))
print(test)
```
which should result in 'altitude' appearing in the list of variables.  I did this for each of the four satellite objects without error.

**Test Configuration**:
* Mac OS X 10.15.4
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
