### PR TITLE
BUG: numpy 1.18 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added small time offsets (< 1s) to ensure COSMIC files and data have unique times
   - Updates to Travis CI environment
   - Removed `inplace` use in xarray `assign` function, which is no longer allowed
+  - Updated use of numpy.linspace to be compatible with numpy 1.18.
 
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/tests/test_ssnl_ave.py
+++ b/pysat/tests/test_ssnl_ave.py
@@ -24,7 +24,7 @@ class TestBasics():
     def test_basic_seasonal_median2D(self):
         """ Test the basic seasonal 2D median"""
         self.testInst.bounds = self.bounds1
-        results = avg.median2D(self.testInst, [0., 360., 24.], 'longitude',
+        results = avg.median2D(self.testInst, [0., 360., 24], 'longitude',
                                [0., 24, 24], 'mlt',
                                ['dummy1', 'dummy2', 'dummy3'])
         dummy_val = results['dummy1']['median']
@@ -103,7 +103,7 @@ class TestDeprecation():
 
         with warnings.catch_warnings(record=True) as war:
             try:
-                avg.median1D(None, [0., 360., 24.],
+                avg.median1D(None, [0., 360., 24],
                              'longitude', ['dummy1'])
             except ValueError:
                 # Setting inst to None should produce a ValueError after
@@ -118,8 +118,8 @@ class TestDeprecation():
 
         with warnings.catch_warnings(record=True) as war:
             try:
-                avg.median2D(None, [0., 360., 24.], 'longitude',
-                             [0., 24., 24.], 'mlt', ['dummy1'])
+                avg.median2D(None, [0., 360., 24], 'longitude',
+                             [0., 24., 24], 'mlt', ['dummy1'])
             except ValueError:
                 # Setting inst to None should produce a ValueError after
                 # warning is generated
@@ -189,7 +189,7 @@ class TestFrameProfileAverages():
     def test_basic_seasonal_2Dmedian(self):
         """ Test the basic seasonal 2D median"""
 
-        results = avg.median2D(self.testInst, [0., 360., 24.], 'longitude',
+        results = avg.median2D(self.testInst, [0., 360., 24], 'longitude',
                                [0., 24, 24], 'mlt', [self.dname])
 
         # iterate over all
@@ -236,7 +236,7 @@ class TestSeriesProfileAverages():
 
     def test_basic_seasonal_median2D(self):
         """ Test basic seasonal 2D median"""
-        results = avg.median2D(self.testInst, [0., 360., 24.], 'longitude',
+        results = avg.median2D(self.testInst, [0., 360., 24], 'longitude',
                                [0., 24, 24], 'mlt', [self.dname])
 
         # iterate over all
@@ -283,10 +283,10 @@ class TestConstellation:
         for i in self.testC.instruments:
             i.bounds = self.bounds
         self.testI.bounds = self.bounds
-        resultsC = avg.median2D(self.testC, [0., 360., 24.], 'longitude',
+        resultsC = avg.median2D(self.testC, [0., 360., 24], 'longitude',
                                 [0., 24, 24], 'mlt',
                                 ['dummy1', 'dummy2', 'dummy3'])
-        resultsI = avg.median2D(self.testI, [0., 360., 24.], 'longitude',
+        resultsI = avg.median2D(self.testI, [0., 360., 24], 'longitude',
                                 [0., 24, 24], 'mlt',
                                 ['dummy1', 'dummy2', 'dummy3'])
         medC1 = resultsC['dummy1']['median']
@@ -339,7 +339,7 @@ class TestHeterogenousConstellation:
         """ Test the seasonal 2D median of a heterogeneous constellation """
         for inst in self.testC:
             inst.bounds = self.bounds
-        results = avg.median2D(self.testC, [0., 360., 24.], 'longitude',
+        results = avg.median2D(self.testC, [0., 360., 24], 'longitude',
                                [0., 24, 24], 'mlt',
                                ['dummy1', 'dummy2', 'dummy3'])
         dummy_val = results['dummy1']['median']
@@ -542,7 +542,7 @@ class TestInstMed1D():
                                     112023., 111562., 112023., 111412.,
                                     111780., 111320., 111780., 111320.],
                           'avg_abs_dev': np.zeros(shape=24),
-                          'median': np.linspace(0.0, 23.0, 24.0)},
+                          'median': np.linspace(0.0, 23.0, 24)},
                          'dummy2':
                          {'count': [111780., 111320., 111780., 111320.,
                                     111780., 111320., 111780., 111320.,


### PR DESCRIPTION
# Description

With numpy 1.18, `linspace` no longer accepts a float value for the number of steps, but requires an integer.  This currently only affects some tests in `test_ssnl_ave`, which are fixed here.  This does not affect pysat 3.0, as these routines have been removed.  This is addressed in pysat/pysatSeasons#17.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via unit tests, since these are what are broken.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
