### PR TITLE
WRN: Adjust strict_time_flag DeprecationWarning trigger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed model_utils
   - Removed coords.scale_units
   - Removed time.season_date_range
+  - DeprecationWarning for strict_time_flag only triggered if sloppy data is found
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and sat_id behaviour in testing instruments

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -372,14 +372,6 @@ class Instrument(object):
         # store base attributes, used in particular by Meta class
         self._base_attr = dir(self)
 
-        # warn about changes coming in the future
-        if not self.strict_time_flag:
-            warnings.warn('Strict times will eventually be enforced upon all'
-                          ' instruments. (strict_time_flag)', DeprecationWarning,
-                          stacklevel=2)
-
-
-
     def __getitem__(self, key):
         """
         Convenience notation for accessing data; inst['name'] is inst.data.name
@@ -1410,12 +1402,26 @@ class Instrument(object):
         # ensure data is unique and monotonic
         # check occurs after all the data padding loads, or individual load
         # thus it can potentially check issues with padding or with raw data
-        if self.strict_time_flag:
-            if (not self.index.is_monotonic_increasing) or (not self.index.is_unique):
-                raise ValueError('Loaded data is not unique (',not self.index.is_unique,
-                                 ') or not monotonic increasing (',
-                                 not self.index.is_monotonic_increasing,
-                                 ')')
+        if (not self.index.is_monotonic_increasing):
+            if self.strict_time_flag:
+                raise ValueError('Loaded data is not monotonic increasing')
+            else:
+                # warn about changes coming in the future
+                warnings.warn(' '.join(('Strict times will eventually be',
+                                        'enforced upon all instruments.',
+                                        '(strict_time_flag)')),
+                              DeprecationWarning,
+                              stacklevel=2)
+        if (not self.index.is_unique):
+            if self.strict_time_flag:
+                raise ValueError('Loaded data is not unique')
+            else:
+                # warn about changes coming in the future
+                warnings.warn(' '.join(('Strict times will eventually be',
+                                        'enforced upon all instruments.',
+                                        '(strict_time_flag)')),
+                              DeprecationWarning,
+                              stacklevel=2)
 
         # apply default instrument routine, if data present
         if not self.empty:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1402,19 +1402,13 @@ class Instrument(object):
         # ensure data is unique and monotonic
         # check occurs after all the data padding loads, or individual load
         # thus it can potentially check issues with padding or with raw data
-        if (not self.index.is_monotonic_increasing):
+        if (not self.index.is_monotonic_increasing) or (not self.index.is_unique):
             if self.strict_time_flag:
-                raise ValueError('Loaded data is not monotonic increasing')
-            else:
-                # warn about changes coming in the future
-                warnings.warn(' '.join(('Strict times will eventually be',
-                                        'enforced upon all instruments.',
-                                        '(strict_time_flag)')),
-                              DeprecationWarning,
-                              stacklevel=2)
-        if (not self.index.is_unique):
-            if self.strict_time_flag:
-                raise ValueError('Loaded data is not unique')
+                raise ValueError('Loaded data is not unique (',
+                                 not self.index.is_unique,
+                                 ') or not monotonic increasing (',
+                                 not self.index.is_monotonic_increasing,
+                                 ')')
             else:
                 # warn about changes coming in the future
                 warnings.warn(' '.join(('Strict times will eventually be',


### PR DESCRIPTION
# Description

In the name of reducing the impending madness whilst reading the logs, this PR changes the trigger conditions in the develop-3 branch.  This will ultimately be removed upon release, but other codes in the pysat ecosystem rely on this branch for testing.  

The DeprecationWarning is currently triggered upon every instrument instantiation, which has resulted in "some" additional warnings in the test logs.  This PR moves it so that it is only thrown if an instrument violates the strict_flag conditions. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally by comparing warnings on test_instrument.py.  Reduced warnings from 346 to 4.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
