### PR TITLE
MAINT: specify dtype in pds.Series(None)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
+  - Specify dtype for pandas.Series(None) for forward compatibility
 
 ## [2.2.0] - 2020-2-29
 - New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
+- Maintenance
   - Specify dtype for pandas.Series(None) for forward compatibility
 
 ## [2.2.0] - 2020-2-29

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -123,7 +123,7 @@ class Files(object):
         self.home_path = os.path.join(os.path.expanduser('~'), '.pysat')
         self.start_date = None
         self.stop_date = None
-        self.files = pds.Series(None)
+        self.files = pds.Series(None, dtype='object')
         # location of stored files
         self.stored_file_name = ''.join((self._sat.platform, '_',
                                          self._sat.name, '_', self._sat.tag,
@@ -648,7 +648,7 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
         else:
             return pds.Series(files, index=index)
     else:
-        return pds.Series(None)
+        return pds.Series(None, dtype='object')
 
 
 def parse_fixed_width_filenames(files, format_str):

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -159,7 +159,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     else:
         logger.info('Found no files, check your path or download them.')
-        return pysat.Series(None)
+        return pysat.Series(None, dtype='object')
 
 
 def load(fnames, tag=None, sat_id=None, altitude_bin=None):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -462,7 +462,7 @@ class TestBasics():
                                                    index=self.testInst.index)
         assert np.all(self.testInst['doubleMLT'] == 2.*self.testInst['mlt'])
 
-        self.testInst['blankMLT'] = pds.Series(None)
+        self.testInst['blankMLT'] = pds.Series(None, dtype='float64')
         assert np.all(np.isnan(self.testInst['blankMLT']))
 
     def test_setting_pandas_dataframe_by_names(self):


### PR DESCRIPTION
# Description

Addresses #417 

With pandas 2.0 (probably released next year), the default dtype for pandas.Series(None) will shift from 'float64' to 'object'.  Getting ahead of the code to make sure nothing breaks.

This pull specifies a dtype in the four instances we invoke an empty series.  Three of these are associated with file lists, so object is chosen as the default.  The fourth is part of a unit test that expects a number, so this is tagged as float64 (it breaks if this is specified as an object).

## Type of change

- Non-breaking change to maintain code

# How Has This Been Tested?

Tested via pytest.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
