### PR TITLE
MAINT: empty pds.Series in sw_kp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
 - Maintenance
-  - Specify dtype for pandas.Series(None) for forward compatibility
+  - Specify dtype for empty pandas.Series for forward compatibility
 
 ## [2.2.0] - 2020-2-29
 - New Features

--- a/pysat/instruments/sw_kp.py
+++ b/pysat/instruments/sw_kp.py
@@ -140,7 +140,7 @@ def load(fnames, tag=None, sat_id=None):
         # each column increments UT by three hours
         # produce a single data series that has Kp value monotonically
         # increasing in time with appropriate datetime indices
-        s = pds.Series()
+        s = pds.Series(dtype='float64')
         for i in np.arange(8):
             temp = pds.Series(data.iloc[:, i].values,
                               index=data.index+pds.DateOffset(hours=int(3*i)))


### PR DESCRIPTION
# Description

Addresses #417. Follow on to #419.

Found one more use of an empty pds.Series in the code that I missed in the last pull. This use works for either 'float64' or 'object'.  Since numbers ultimately go in, using 'float64'. 

Also found multiple uses of `pds.Series()` in the demo codes as well.  Tested those using both options, no breaking changes in code.  Since these are not run in the unit tests, leaving them alone for now.

## Type of change

- Maintenance fix (non-breaking change for continuity in future versions of pandas)

# How Has This Been Tested?

via pytest locally and on Travis.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
