### PR TITLE
BUG/TST: Fixed display of orbital info in print(inst) / expand unit testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
+  - Fixed output of orbit_info during print(inst)
 - Maintenance
   - Specify dtype for pandas.Series(None) for forward compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed description of tag and sat_id behaviour in testing instruments
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
-  - Fixed output of orbit_info during print(inst)
 - Maintenance
   - Specify dtype for pandas.Series(None) for forward compatibility
 
@@ -58,6 +57,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added small time offsets (< 1s) to ensure COSMIC files and data have unique times
   - Updates to Travis CI environment
   - Removed `inplace` use in xarray `assign` function, which is no longer allowed
+  - Fixed output of orbit_info during print(inst)
 
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -349,6 +349,7 @@ class Instrument(object):
                 # default provided by instrument module
                 orbit_info = self.orbit_info
         self.orbits = _orbits.Orbits(self, **orbit_info)
+        self.orbit_info = orbit_info
 
         # Create empty placeholder for meta translation table
         # gives information about how to label metadata for netcdf export
@@ -909,7 +910,7 @@ class Instrument(object):
 
         output_str += '\nOrbit Settings' + '\n'
         output_str += '--------------' + '\n'
-        if self.orbit_info is None:
+        if self.orbits.orbit_index is None:
             output_str += 'Orbit properties not set.\n'
         else:
             output_str += 'Orbit Kind: ' + self.orbit_info['kind'] + '\n'

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -325,8 +325,20 @@ class TestBasics():
     #
     # --------------------------------------------------------------------------
     def test_basic_repr(self):
-        print(self.testInst)
-        assert True
+        """Check for lines from each decision point in repr"""
+        output = self.testInst.__str__()
+        assert isinstance(output, str)
+        assert output.find('pysat Instrument object') > 0
+        # No custom functions
+        assert output.find('No functions applied') > 0
+        # No orbital info
+        assert output.find('Orbit properties not set') > 0
+        # Files exist for test inst
+        assert output.find('Date Range:') > 0
+        # No loaded data
+        assert output.find('No loaded data') > 0
+        assert output.find('Number of variables:') < 0
+        assert output.find('dummy') < 0
 
     def test_repr_w_orbit(self):
         re_load(pysat.instruments.pysat_testing)
@@ -339,27 +351,36 @@ class TestBasics():
                                     update_files=True,
                                     orbit_info=orbit_info)
 
+        output = testInst.__str__()
+        # Check that orbit info is passed through
+        assert output.find('Orbit properties not set') < 0
+        assert output.find('Orbit Kind:') > 0
+        assert output.find('Loaded Orbit Number: None') > 0
+        # Activate orbits, check that message has changed
         testInst.load(2009, 1)
         testInst.orbits.next()
-        print(testInst)
-        assert True
+        output = testInst.__str__()
+        assert output.find('Loaded Orbit Number: None') < 0
+        assert output.find('Loaded Orbit Number: ') > 0
 
     def test_repr_w_padding(self):
         self.testInst.pad = pds.DateOffset(minutes=5)
-        print(self.testInst)
-        assert True
+        output = self.testInst.__str__()
+        assert output.find('DateOffset: minutes=5') > 0
 
     def test_repr_w_custom_func(self):
         def testfunc(self):
             pass
         self.testInst.custom.attach(testfunc, 'modify')
-        print(self.testInst)
-        assert True
+        output = self.testInst.__str__()
+        assert output.find('testfunc') > 0
 
     def test_repr_w_load_data(self):
         self.testInst.load(2009, 1)
-        print(self.testInst)
-        assert True
+        output = self.testInst.__str__()
+        assert output.find('No loaded data') < 0
+        assert output.find('Number of variables:') > 0
+        assert output.find('dummy') > 0
 
     # --------------------------------------------------------------------------
     #


### PR DESCRIPTION
# Description

When using `print(inst)` on a pysat instument with orbital information, the printout always responds with 'Orbit properties not set', regardless of instrument settings.  This fixes that so the expected behaviour is maintained.

This also expands the unit tests for the repr functions to check that the appropriate output is generated for each path through the function.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
info = {'index': 'mlt', 'kind': 'local time', period=97}
testInst = pysat.Instrument('pysat', 'testing', orbit_info=info)
testInst.load(2009, 1)
testInst.orbits.next()
print(testInst)
```
In the fix, orbtial info is displayed under 'Orbit Settings'.  In the old version, 'Orbit properties not set' is displayed incorrectly.

**Test Configuration**:
* Mac OS X 10.15.4
* Python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
