### PR TITLE
BUG: coordinate name

### DIFF
--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -82,8 +82,8 @@ def load(fnames, tag=None, sat_id=None):
     for i, ut in enumerate(uts):
         for j, long in enumerate(longitude):
             slt[i, j] = np.mod(ut / 3600.0 + long / 15.0, 24.0)
-    data['slt'] = (('time', 'longtiude'), slt)
-    data['mlt'] = (('time', 'longtiude'), np.mod(slt+0.2, 24.0))
+    data['slt'] = (('time', 'longitude'), slt)
+    data['mlt'] = (('time', 'longitude'), np.mod(slt+0.2, 24.0))
 
     # Fake 3D data consisting of values between 0 and 21 everywhere
     dummy1 = np.mod(data['uts'] * data['latitude'] * data['longitude'], 21.0)


### PR DESCRIPTION
Coordinate name 'longitude' misspelled for two of the data values.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat

model = pysat.Instrument(inst_module=pysat.instruments.pysat_testmodel)
model.load(yr=2009, doy=1)
mdat='slt'

dims = [kk for kk in model.data.data_vars[mdat].dims]
print(dims)
```

In new version, you get: `['time', 'longitude']`.  In the old version you get `['time', 'longtiude']`

**Test Configuration**:
* Operating system: OS X Mojave
* Version number 3.7
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
