### PR TITLE
Handle the byte strings and empty strings from instrument meta data properly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Updates to instrument testing objects for consistency
    - Changed madrigal methods to use `madrigalWeb` as a module rather than
      calling it externally
+   - Added warning when FillValue metadata could lead to unexpected results
+     when writing a netCDF4 file
 - Deprecation Warning
   - custom.add will be renamed custom.attach in pysat 3.0.0
 - Documentation

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -436,7 +436,13 @@ class Meta(object):
                         to_be_set = input_data[key][i]
                         if hasattr(to_be_set, '__iter__') and \
                                 not isinstance(to_be_set, basestring):
-                            if isinstance(to_be_set[0], basestring):
+                                   
+                            if not to_be_set:
+                                to_be_set = ' '
+                            
+                            if isinstance(to_be_set[0], basestring) or isinstance(to_be_set, bytes):
+                                if isinstance(to_be_set, bytes):
+                                    to_be_set = to_be_set.decode("utf-8") 
                                 self._data.loc[name, key] = \
                                     '\n\n'.join(to_be_set)
                             else:


### PR DESCRIPTION
NOTE: I don't have write permissions to pysat so I'm simply creating a merge request on the netcdf4-export3 branch. The intention was to fix the level1b issue so I built this fix on top of that branch.

# Description
These fixes in _meta.py will handle unconverted byte strings (e.g. b"example") from bytes to UTF-8 standard strings for python 3. The fix will also convert completely empty metadata to an empty string in the case that processing meta data causes the process to fail.

Addresses # (issue)
Necessary for run of cosmic-2 and full_ivm python 3 branches.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Test A
Produce a fraction of a level2 cosmic-2 file. Using the command line command from cosmic-2 (as if using the project's master branch on python2) will produce the file. 

**Test Configuration**:
* Operating system
Mac 
* Version number
10.14.6
* Any details about your local setup that are relevant
Python 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
