### PR TITLE
BUG/TST: Fix for coveralls and conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,7 @@ install:
   - conda activate test-environment
   # Dependencies not available through conda, install through pip
   - pip install pysatCDF >/dev/null
+  - pip install python-coveralls
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat
@@ -39,4 +40,6 @@ install:
 # command to run tests
 script:
  - pytest -vs --cov=pysat/
+
+after_success:
  - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,12 @@ install:
   # Useful for debugging any issues with conda
   - conda info -a
   # Create conda test environment
-  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 pytest-cov pytest-ordering coveralls future
+  - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION numpy scipy pandas xarray requests beautifulsoup4 lxml netCDF4 pytest-cov pytest-ordering future
   - conda activate test-environment
   # Dependencies not available through conda, install through pip
   - pip install pysatCDF >/dev/null
-  - pip install python-coveralls
+  # Get latest coveralls from pip, not conda
+  - pip install coveralls
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,4 @@ install:
 # command to run tests
 script:
  - pytest -vs --cov=pysat/
-
-after_success:
  - coveralls


### PR DESCRIPTION
# Description

The last 30 or so builds of pysat have dropped coveralls reports.  This occurs around the point we switched to using conda.  Conda is installing older (pre-2.0) versions of coveralls, which crash on some of the Travis environments.  This installs coveralls from pip rather than conda to get a working version.

See recent builds here:
https://coveralls.io/github/pysat/pysat

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

If coveralls reports under the checks, it's working.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
