### PR TITLE
BUG: use coveralls from pip in Travis CI -- pysat 2.2.0 edition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ install:
   - pip install madrigalWeb
   - pip install PyForecastTools
   - pip install pysatCDF >/dev/null
+  # Get latest coveralls from pip, not conda
+  - pip install coveralls
   # set up data directory
   - mkdir /home/travis/build/pysatData
   # install pysat


### PR DESCRIPTION
# Description

Fixes the bug when using conda to install coveralls in Travis CI.  See #429 for more more details.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In currently open PRs, no coveralls reports are listed under the checks.  If this works, coveralls should report below.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
