### PR TITLE
STY: Remove relative imports, wildcard imports, and convenience methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-05-13
+## [3.0.0] - 2020-05-14
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -23,6 +23,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed coords.scale_units
   - Removed time.season_date_range
   - DeprecationWarning for strict_time_flag only triggered if sloppy data is found
+  - Remove convenience methods imported from pandas
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and sat_id behaviour in testing instruments
@@ -32,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility
+  - Remove wildcard imports, relative imports
 
 ## [2.2.0] - 2020-2-29
 - New Features

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -101,13 +101,13 @@ else:
 
 from datetime import datetime  # TODO: remove before 3.0 release!
 from pandas import DataFrame  # TODO: remove before 3.0 release!
-from . import utils
-from ._constellation import Constellation
-from ._instrument import Instrument
-from ._meta import Meta
-from ._files import Files
-from ._custom import Custom
-from ._orbits import Orbits
-from . import instruments
+from pysat import utils
+from pysat._constellation import Constellation
+from pysat._instrument import Instrument
+from pysat._meta import Meta
+from pysat._files import Files
+from pysat._custom import Custom
+from pysat._orbits import Orbits
+from pysat import instruments
 
 __all__ = ['instruments', 'utils']

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -99,8 +99,6 @@ else:
         with open(os.path.join(pysat_dir, 'user_modules.txt'), 'w') as f:
             f.write('')
 
-from datetime import datetime  # TODO: remove before 3.0 release!
-from pandas import DataFrame  # TODO: remove before 3.0 release!
 from pysat import utils
 from pysat._constellation import Constellation
 from pysat._instrument import Instrument

--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -16,4 +16,5 @@ __all__ = ['champ_star', 'cnofs_ivm', 'cnofs_plp', 'cnofs_vefi', 'cosmic_gps',
            'pysat_testing', 'pysat_testing_xarray', 'pysat_testing2d',
            'pysat_testing2d_xarray', 'pysat_testmodel']
 
-from . import *
+for inst in __all__:
+    exec("from pysat.instruments import {x}".format(x=inst))

--- a/pysat/instruments/methods/__init__.py
+++ b/pysat/instruments/methods/__init__.py
@@ -5,4 +5,4 @@ specific functions for instruments and classes of instruments.
 Each set of methods is contained within a subpackage of this set.
 """
 
-from . import demeter, general, nasa_cdaweb, sw, testing
+from pysat.instruments.methods import demeter, general, nasa_cdaweb, sw, testing


### PR DESCRIPTION
# Description

Addresses #150 

- Removes the wildcard imports from the various `__init__` files. 
- Specifies absolute paths for imports
- Removes convenience methods from datetime and pandas now that pysatCDF is compliant

## Type of change

Please delete options that are not relevant.

- Style changes

# How Has This Been Tested?

Tested that instruments load properly in ipython.  Travis CI tests.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
