### PR TITLE
NetCDF Export NaN metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Added warning when FillValue metadata could lead to unexpected results
      when writing a netCDF4 file
    - Use conda to manage Travis CI test environment
+   - Added NaN filter for metadata when writing netCDF4 files
 - Deprecation Warning
   - custom.add will be renamed custom.attach in pysat 3.0.0
 - Documentation

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2291,18 +2291,7 @@ class Instrument(object):
                         new_dict = self._filter_netcdf4_metadata(new_dict,
                                                                  coltype,
                                                                  export_nan=export_nan)
-                        # remove any metadata with a value of nan not present in
-                        # export_nan
-                        filtered_dict = new_dict.copy()
-                        for key, value in new_dict.items():
-                            try:
-                                if np.isnan(value):
-                                    if key not in export_nan:
-                                        filtered_dict.pop(key)
-                            except TypeError:
-                                # if typerror thrown, it's not nan
-                                pass
-                        cdfkey.setncatts(filtered_dict)
+                        cdfkey.setncatts(new_dict)
                     except KeyError as err:
                         logger.info(' '.join((str(err), '\n',
                                         ', '.join(('Unable to find MetaData for',

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2257,15 +2257,16 @@ class Instrument(object):
                         new_dict = self._filter_netcdf4_metadata(new_dict,
                                                                  coltype)
                         # remove any metadata with a value of nan not present in _export_nan
+                        filtered_dict = new_dict.copy()
                         for key, value in new_dict.items():
                             try:
                                 if np.isnan(value):
                                     if key not in self.meta._export_nan:
-                                        new_dict.pop(key)
+                                        filtered_dict.pop(key)
                             except TypeError:
-                                #if typerror thrown, it's not nan
+                                # if typerror thrown, it's not nan
                                 pass
-                        cdfkey.setncatts(new_dict)
+                        cdfkey.setncatts(filtered_dict)
                     except KeyError as err:
                         logger.info(' '.join((str(err), '\n',
                                         ', '.join(('Unable to find MetaData for',

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2256,6 +2256,15 @@ class Instrument(object):
                         new_dict['Var_Type'] = 'data'
                         new_dict = self._filter_netcdf4_metadata(new_dict,
                                                                  coltype)
+                        # remove any metadata with a value of nan not present in _export_nan
+                        for key, value in new_dict.items():
+                            try:
+                                if np.isnan(value):
+                                    if key not in self.meta._export_nan:
+                                        new_dict.pop(key)
+                            except TypeError:
+                                #if typerror thrown, it's not nan
+                                pass
                         cdfkey.setncatts(new_dict)
                     except KeyError as err:
                         logger.info(' '.join((str(err), '\n',

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -82,7 +82,8 @@ class Meta(object):
         String used to label fill value in storage. Defaults to 'fill' per
         netCDF4 standard
     export_nan: list
-        List of labels that should be exported even if their value is nan. By default, metadate with a value of nan will be exluded from export.
+        List of labels that should be exported even if their value is nan.
+        By default, metadata with a value of nan will be exluded from export.
 
 
     Notes
@@ -180,7 +181,7 @@ class Meta(object):
                  scale_label='scale', min_label='value_min',
                  max_label='value_max', fill_label='fill',
                  export_nan=[]):
-        
+
         # set mutability of Meta attributes
         self.mutable = True
 
@@ -401,7 +402,7 @@ class Meta(object):
 
 
     def __setattr__(self, name, value):
-        """Conditionally sets attributes based on self.mutable flag 
+        """Conditionally sets attributes based on self.mutable flag
         @properties are assumed to be mutable.
         We avoid recursively setting properties using
         method from https://stackoverflow.com/a/15751135

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -81,6 +81,8 @@ class Meta(object):
     fill_label : str
         String used to label fill value in storage. Defaults to 'fill' per
         netCDF4 standard
+    export_nan: list
+        List of labels that should be exported even if their value is nan. By default, metadate with a value of nan will be exluded from export.
 
 
     Notes
@@ -176,7 +178,8 @@ class Meta(object):
                  name_label='long_name', notes_label='notes',
                  desc_label='desc', plot_label='label', axis_label='axis',
                  scale_label='scale', min_label='value_min',
-                 max_label='value_max', fill_label='fill'):
+                 max_label='value_max', fill_label='fill',
+                 export_nan=[]):
         
         # set mutability of Meta attributes
         self.mutable = True
@@ -192,6 +195,11 @@ class Meta(object):
         self._min_label = min_label
         self._max_label = max_label
         self._fill_label = fill_label
+        # by default metadata with a value of nan will not be exported
+        # unless the name is in the _export_nan list. Initialize the list
+        # with the fill label, since it is reasonable to assume that a fill
+        # value of nan would be intended to be exported
+        self._export_nan = [fill_label] + export_nan
         # init higher order (nD) data structure container, a dict
         self._ho_data = {}
         # use any user provided data to instantiate object with data

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1050,7 +1050,7 @@ class TestBasics():
         assert self.testInst.hey == greeting
 
     # test for NaN in metadata and writing to file
-    def test_nan_metadata_filtered_netcdf4(self):
+    def test_nan_metadata_filtered_netcdf4_via_meta_attribute(self):
         """check that metadata set to NaN is excluded from netcdf"""
         # create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting
@@ -1080,7 +1080,7 @@ class TestBasics():
         assert 'non_nan_export' not in f['test_nan_variable'].ncattrs()
         assert 'extra_check' in f['test_nan_variable'].ncattrs()
 
-    def test_nan_metadata_filtered_netcdf4(self):
+    def test_nan_metadata_filtered_netcdf4_via_method(self):
         """check that metadata set to NaN is excluded from netcdf via nc call"""
         # create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1079,3 +1079,30 @@ class TestBasics():
         assert 'test_nan_export' in f['test_nan_variable'].ncattrs()
         assert 'non_nan_export' not in f['test_nan_variable'].ncattrs()
         assert 'extra_check' in f['test_nan_variable'].ncattrs()
+
+    def test_nan_metadata_filtered_netcdf4(self):
+        """check that metadata set to NaN is excluded from netcdf via nc call"""
+        # create an instrument object that has a meta with some
+        # variables allowed to be nan within metadata when exporting
+        self.testInst.load(2009, 1)
+        # create new variable
+        self.testInst['test_nan_variable'] = 1.
+        # assign additional metadata
+        self.testInst.meta['test_nan_variable'] = {'test_nan_export':np.nan,
+                                                   'no_nan_export':np.nan,
+                                                   'extra_check': 1.}
+        # write the file
+        pysat.tests.test_utils.prep_dir(self.testInst)
+        outfile = os.path.join(self.testInst.files.data_path,
+                               'pysat_test_ncdf.nc')
+        export_nan = self.testInst.meta._export_nan + ['test_nan_export']
+        self.testInst.to_netcdf4(outfile, export_nan=export_nan)
+
+        # load file back and test metadata is as expected
+        f = netCDF4.Dataset(outfile)
+
+        pysat.tests.test_utils.remove_files(self.testInst)
+
+        assert 'test_nan_export' in f['test_nan_variable'].ncattrs()
+        assert 'non_nan_export' not in f['test_nan_variable'].ncattrs()
+        assert 'extra_check' in f['test_nan_variable'].ncattrs()

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1,12 +1,15 @@
 """
 tests the pysat meta object and code
 """
-import pysat
-import pandas as pds
+import os
+import netCDF4
 from nose.tools import raises
-import pysat.instruments.pysat_testing
 import numpy as np
+import pandas as pds
 
+import pysat
+import pysat.instruments.pysat_testing
+import pysat.tests.test_utils
 
 class TestBasics():
     def setup(self):
@@ -1046,3 +1049,33 @@ class TestBasics():
         self.testInst.load(2009, 1)
         assert self.testInst.hey == greeting
 
+    # test for NaN in metadata and writing to file
+    def test_nan_metadata_filtered_netcdf4(self):
+        """check that metadata set to NaN is excluded from netcdf"""
+        # create an instrument object that has a meta with some
+        # variables allowed to be nan within metadata when exporting
+        self.testInst.load(2009, 1)
+        # normally this parameter would be set at instrument code level
+        self.testInst.meta.mutable = True
+        self.testInst.meta._export_nan += ['test_nan_export']
+        self.testInst.meta.mutable = False
+        # create new variable
+        self.testInst['test_nan_variable'] = 1.
+        # assign additional metadata
+        self.testInst.meta['test_nan_variable'] = {'test_nan_export':np.nan,
+                                                   'no_nan_export':np.nan,
+                                                   'extra_check': 1.}
+        # write the file
+        pysat.tests.test_utils.prep_dir(self.testInst)
+        outfile = os.path.join(self.testInst.files.data_path,
+                               'pysat_test_ncdf.nc')
+        self.testInst.to_netcdf4(outfile)
+
+        # load file back and test metadata is as expected
+        f = netCDF4.Dataset(outfile)
+
+        pysat.tests.test_utils.remove_files(self.testInst)
+
+        assert 'test_nan_export' in f['test_nan_variable'].ncattrs()
+        assert 'non_nan_export' not in f['test_nan_variable'].ncattrs()
+        assert 'extra_check' in f['test_nan_variable'].ncattrs()


### PR DESCRIPTION
# Description

Addresses issue where exported netCDF files contain unnecessary metadata. Due to the nature of the pandas, if a metadata parameter is added, it will be added to all variables. This may not always be the desired behavior. If no value is assigned to the parameter, it will be assigned nan. Thus, we can remove these parameters by not exporting metadata parameters with a value of nan. If a parameter does need to be exported with a value of nan, the name of the parameter must be added to the export_nan list that is now a part of the meta object.

Please include a summary of the change and which issue is fixed. Please also
include relevant motivation and context. List any dependencies that are required
for this change.  Please see ``CONTRIBUTING.md`` for more guidelines.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Tested with COSMIC-2 GSW L2 and L1b export.

**Test Configuration**:
* Operating system Ubuntu
* Version number 18.04
* Any details about your local setup that are relevant

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``master``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
