### PR TITLE
STY: custom input improvement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed time.season_date_range
   - DeprecationWarning for strict_time_flag only triggered if sloppy data is found
   - Remove convenience methods imported from pandas
+  - Changed the default `custom.attatch` input to allow keyword arguement use when additional function input is required
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and sat_id behaviour in testing instruments

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -5,7 +5,12 @@ Tutorial
 Basics
 ------
 
-The core functionality of pysat is exposed through the pysat.Instrument object. The intent of the Instrument object is to offer a single interface for interacting with science data that is independent of measurement platform. The layer of abstraction presented by the Instrument object allows for things to occur in the background that can make science data analysis simpler and more rigorous.
+The core functionality of pysat is exposed through the pysat.Instrument object.
+The intent of the Instrument object is to offer a single interface for
+interacting with science data that is independent of measurement platform. The
+layer of abstraction presented by the Instrument object allows for things to
+occur in the background that can make science data analysis simpler and more
+rigorous.
 
 To begin,
 
@@ -13,7 +18,8 @@ To begin,
 
    import pysat
 
-The data directory pysat looks in for data (pysat_data_dir) needs to be set upon the first import,
+The data directory pysat looks in for data (pysat_data_dir) needs to be set
+upon the first import,
 
 .. code:: python
 
@@ -23,23 +29,35 @@ The data directory pysat looks in for data (pysat_data_dir) needs to be set upon
 
 ----
 
-To create a pysat.Instrument object, select a platform, instrument name, and measurement type to be analyzed from the list of :doc:`supported_instruments`. To work with Magnetometer data from the Vector Electric Field Instrument onboard the Communications/Navigation Outage Forecasting System (C/NOFS), use:
+To create a pysat.Instrument object, select a platform, instrument name, and
+measurement type to be analyzed from the list of :doc:`supported_instruments`.
+To work with Magnetometer data from the Vector Electric Field Instrument
+onboard the Communications/Navigation Outage Forecasting System (C/NOFS), use:
 
 .. code:: python
 
    vefi = pysat.Instrument(platform='cnofs', name='vefi', tag='dc_b')
 
-Behind the scenes pysat uses a python module named cnofs_vefi that understands how to interact with 'dc_b' data. VEFI also measures electric fields in several modes that offer different data products. Though these measurements are not currently supported by the cnofs_vefi module, when they are, they can be selected via the tag string.
+Behind the scenes pysat uses a python module named cnofs_vefi that understands
+how to interact with 'dc_b' data. VEFI also measures electric fields in several
+modes that offer different data products. Though these measurements are not
+currently supported by the cnofs_vefi module, when they are, they can be
+selected via the tag string.
 
-To load measurements from a different instrument on C/NOFS, the Ion Velocity Meter, which measures thermal plasma parameters, use:
+To load measurements from a different instrument on C/NOFS, the Ion Velocity
+Meter, which measures thermal plasma parameters, use:
 
 .. code:: python
 
    ivm = pysat.Instrument(platform='cnofs', name='ivm')
 
-In the background pysat uses the module cnofs_ivm to handle this data. There is only one measurement option from IVM, so no tag string is required.
+In the background pysat uses the module cnofs_ivm to handle this data. There is
+only one measurement option from IVM, so no tag string is required.
 
-Measurements from a constellation of COSMIC satellites are also available. These satellites measure GPS signals as they travel through the atmosphere. A number of different data sets are available from COSMIC, and are also supported by the relevant module.
+Measurements from a constellation of COSMIC satellites are also available.
+These satellites measure GPS signals as they travel through the atmosphere. A
+number of different data sets are available from COSMIC, and are also supported
+by the relevant module.
 
 .. code:: python
 
@@ -50,13 +68,19 @@ Measurements from a constellation of COSMIC satellites are also available. These
 
 
 
-Though the particulars of VEFI magnetometer data, IVM plasma parameters, and COSMIC atmospheric measurements are going to be quite different, the processes demonstrated below with VEFI also apply equally to IVM and COSMIC.
+Though the particulars of VEFI magnetometer data, IVM plasma parameters, and
+COSMIC atmospheric measurements are going to be quite different, the processes
+demonstrated below with VEFI also apply equally to IVM and COSMIC.
 
 **Download**
 
 ----
 
-Let's download some data. VEFI data is hosted by the NASA Coordinated Data Analysis Web (CDAWeb) at http://cdaweb.gsfc.nasa.gov. The proper process for downloading VEFI data is built into the cnofs_vefi module, which is handled by pysat. All we have to do is invoke the .download method attached to the VEFI object, or any other pysat Instrument.
+Let's download some data. VEFI data is hosted by the NASA Coordinated Data
+Analysis Web (CDAWeb) at http://cdaweb.gsfc.nasa.gov. The proper process for
+downloading VEFI data is built into the cnofs_vefi module, which is handled by
+pysat. All we have to do is invoke the .download method attached to the VEFI
+object, or any other pysat Instrument.
 
 .. code:: python
 
@@ -66,9 +90,12 @@ Let's download some data. VEFI data is hosted by the NASA Coordinated Data Analy
    stop = dt.datetime(2009,5,9)
    vefi.download(start, stop)
 
-The data is downloaded to pysat_data_dir/platform/name/tag/, in this case pysat_data_dir/cnofs/vefi/dc_b/. At the end of the download, pysat will update the list of files associated with VEFI.
+The data is downloaded to pysat_data_dir/platform/name/tag/, in this case
+pysat_data_dir/cnofs/vefi/dc_b/. At the end of the download, pysat will update
+the list of files associated with VEFI.
 
-Note that some datasets, like COSMIC, require registration with a username and password.  Pysat supports this as well.
+Note that some datasets, like COSMIC, require registration with a username and
+password.  Pysat supports this as well.
 .. code:: python
 
   # download COSMIC data, which requires username and password
@@ -79,7 +106,8 @@ Note that some datasets, like COSMIC, require registration with a username and p
 
 ----
 
-Data is loaded into vefi using the .load method using year, day of year; date; or filename.
+Data is loaded into vefi using the .load method using year, day of year; date;
+or filename.
 
 .. code:: python
 
@@ -87,7 +115,10 @@ Data is loaded into vefi using the .load method using year, day of year; date; o
    vefi.load(date=start)
    vefi.load(fname='cnofs_vefi_bfield_1sec_20090506_v05.cdf')
 
-When the pysat load routine runs it stores the instrument data into vefi.data. The data structure is a pandas DataFrame_, a highly capable structure with labeled rows and columns. Convenience access to the data is also available at the instrument level.
+When the pysat load routine runs it stores the instrument data into vefi.data.
+The data structure is a pandas DataFrame_, a highly capable structure with
+labeled rows and columns. Convenience access to the data is also available at
+the instrument level.
 
 .. _DataFrame: http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe
 
@@ -107,7 +138,8 @@ When the pysat load routine runs it stores the instrument data into vefi.data. T
 
 See :any:`Instrument` for more.
 
-To load data over a season, pysat provides a convenience function that returns an array of dates over a season. The season need not be continuous.
+To load data over a season, pysat provides a convenience function that returns
+an array of dates over a season. The season need not be continuous.
 
 .. code:: python
 
@@ -123,8 +155,8 @@ To load data over a season, pysat provides a convenience function that returns a
 
    # iterate over season, calculate the mean absolute perturbation in
    # meridional magnetic field
-   for date in date_array:
-	vefi.load(date=date)
+   for vdate in date_array:
+	vefi.load(date=vdate)
 	if not vefi.data.empty:
 	    # isolate data to locations near geographic equator
 	    idx, = np.where((vefi['latitude'] < 5) & (vefi['latitude'] > -5))
@@ -136,7 +168,8 @@ To load data over a season, pysat provides a convenience function that returns a
    mean_dB.plot(title='Mean Absolute Perturbation in Meridional Magnetic Field')
    plt.ylabel('Mean Absolute Perturbation ('+vefi.meta['dB_mer'].units+')')
 
-Note, the numpy.where may be removed using the convenience access to the attached pandas data object.
+Note, the numpy.where may be removed using the convenience access to the
+attached pandas data object.
 
 .. code:: python
 
@@ -154,7 +187,8 @@ is equivalent to
 
 -----
 
-Before data is available in .data it passes through an instrument specific cleaning routine. The amount of cleaning is set by the clean_level keyword,
+Before data is available in .data it passes through an instrument specific
+cleaning routine. The amount of cleaning is set by the clean_level keyword,
 
 .. code:: python
 
@@ -204,19 +238,21 @@ Data may be assigned to the instrument, with or without metadata.
 
    vefi['new_data'] = new_data
 
-The same activities may be performed for other instruments in the same manner. In particular, for measurements from the Ion Velocity Meter and profiles of electron density from COSMIC, use
+The same activities may be performed for other instruments in the same manner.
+In particular, for measurements from the Ion Velocity Meter and profiles of
+electron density from COSMIC, use
 
 .. code:: python
 
    # assignment with metadata
    ivm = pysat.Instrument(platform='cnofs', name='ivm', tag='')
-   ivm.load(date=date)
+   ivm.load(date=start)
    ivm['double_mlt'] = {'data': 2.*inst['mlt'], 'long_name': 'Double MLT',
                         'units': 'hours'}
 
 .. code:: python
 
-   cosmic = pysat.Instrument('cosmic', 'gps', tag='ionprf',  clean_level='clean')
+   cosmic = pysat.Instrument('cosmic', 'gps', tag='ionprf', clean_level='clean')
    start = dt.datetime(2009, 1, 2)
    stop = dt.datetime(2009, 1, 3)
 
@@ -247,16 +283,20 @@ Output for both print statements:
 Custom Functions
 ----------------
 
-Science analysis is built upon custom data processing. To simplify this task and enable instrument independent analysis, custom functions may be attached to the Instrument object. Each function is run automatically when new data is loaded before it is made available in .data.
+Science analysis is built upon custom data processing. To simplify this task and
+enable instrument independent analysis, custom functions may be attached to the
+Instrument object. Each function is run automatically when new data is loaded
+before it is made available in .data.
 
 **Modify Functions**
 
-	The instrument object is passed to function without copying, modify in place.
+	The instrument object is modified within the function, nothing is returned.
 
 .. code:: python
 
-   def custom_func_modify(inst, optional_param=False):
-       inst['double_mlt'] = 2.0 * inst['mlt']
+   def modify_double(inst, data_name='mlt'):
+       inst['double_{:s}'.format(data_name)] = 2.0 * inst[data_name]
+       return
 
 **Add Functions**
 
@@ -264,31 +304,52 @@ Science analysis is built upon custom data processing. To simplify this task and
 
 .. code:: python
 
-   def custom_func_add(inst, optional_param=False):
-       return 2.0 * inst['mlt']
+   def add_double(inst, data_name='mlt'):
+       return 2.0 * inst[data_name]
 
 **Add Function Including Metadata**
 
 .. code:: python
 
-   def custom_func_add(inst, optional_param1=False, optional_param2=False):
-       return {'data': 2.*inst['mlt'], 'name': 'double_mlt',
-               'long_name': 'doubledouble', 'units': 'hours'}
+   def add_multiply(inst, imult, data_name='mlt'):
+       return {'data': imult*inst[data_name],
+               'name': '{:s}x{:d}'.format(data_name, int(imult)),
+               'long_name': '{:s} x {:d}'.format(data_name, int(imult)),
+               'units': inst.meta[data_name].units}
 
 **Attaching Custom Function**
+You can attach custom functions in any order, with the default behavior running
+the custom functions in the order they are specified.  However, you can insert
+a function earlier into the running queue using the `at_pos` keyword arguement.
 
 .. code:: python
 
-   ivm.custom.attach(custom_func_modify, 'modify', optional_param2=True)
-   ivm.load(2009, 1)
-   print(ivm['double_mlt'])
-   ivm.custom.attach(custom_func_add, 'add', optional_param2=True)
-   ivm.bounds = (start, stop)
-   custom_complicated_analysis_over_season(ivm)
+   # Determine the data provided by default
+   ivm.load(date=start)
+   default_data = [cc for cc in ivm.data.columns]
 
-The output of custom_func_modify will always be available from instrument object, regardless of what level the science analysis is performed.
+   # Add custom functions
+   ivm.custom.attach(modify_double, 'modify', kwargs={'data_name': 'mlt'})
+   ivm.custom.attach(add_double, 'add', kwargs={'data_name': 'mlt'})
+   ivm.custom.attach(add_multiply, 'add', args=[3.0],
+                     kwargs={'data_name': 'mlt'}, at_pos=1)
+   ivm.load(date=start)
+   print([cc for cc in ivm.data.columns if cc not in ivm_cols])
+   print("Original Max MLT was: ",
+         np.unique([ivm.data['mlt'].max()/2.0, ivm.data['double_mlt'].max()/2.0,
+                    ivm.data['mltx3'].max()/3.0]))
 
-We can repeat the earlier VEFI example, this time using nano-kernel functionality.
+Note that despite three calculations being made, only two new data columns were
+added.  The `modify_double` function saves the newly calculated data to a new
+data column.  The `add_double` function overwrites the input data column (in
+this example, 'mlt').  The `add_multiply` function supplies a new name as a
+part of the output meta data (the 'name' option in the dictionary), and so a
+new data column is added.  A `kind='add'` custom function can also specify
+a new output data column by modifying the `name` label of the metadata of the
+output data structure (e.g., xarray `name` or pandas.Series `name`).
+
+We can repeat the earlier VEFI example, this time using nano-kernel
+functionality.
 
 .. code:: python
 
@@ -315,8 +376,8 @@ We can repeat the earlier VEFI example, this time using nano-kernel functionalit
 
    # iterate over season, calculate the mean absolute perturbation in
    # meridional magnetic field
-   for date in date_array:
-	vefi.load(date=date)
+   for vdate in date_array:
+	vefi.load(date=vdate)
 	if not vefi.data.empty:
             # compute mean absolute db_Mer using pandas functions and store
             mean_dB[vefi.date] = vefi['dB_mer'].abs().mean(skipna=True)
@@ -325,7 +386,10 @@ We can repeat the earlier VEFI example, this time using nano-kernel functionalit
    mean_dB.plot(title='Mean Absolute Perturbation in Meridional Magnetic Field')
    plt.ylabel('Mean Absolute Perturbation (' + vefi.meta['dB_mer'].units + ')')
 
-Note the same result is obtained. The VEFI instrument object and analysis are performed at the same level, so there is no strict gain by using the pysat nano-kernel in this simple demonstration. However, we can  use the nano-kernel to translate this daily mean into an versatile instrument independent function.
+Note the same result is obtained. The VEFI instrument object and analysis are
+performed at the same level, so there is no strict gain by using the pysat
+nano-kernel in this simple demonstration. However, we can  use the nano-kernel
+to translate this daily mean into an versatile instrument independent function.
 
 **Adding Instrument Independence**
 
@@ -344,8 +408,8 @@ Note the same result is obtained. The VEFI instrument object and analysis are pe
       date_array = pysat.utils.time.create_date_range(start, stop)
 
       # iterate over season, calculate the mean
-      for date in date_array:
-	   inst.load(date=date)
+      for idate in date_array:
+	   inst.load(date=idate)
 	   if not inst.data.empty:
                # compute mean absolute db_Mer using pandas functions and store
                mean_val[inst.date] = inst[data_label].abs().mean(skipna=True)
@@ -371,13 +435,16 @@ Note the same result is obtained. The VEFI instrument object and analysis are pe
    plt.ylabel('Absolute Daily Mean (' + vefi.meta['dB_mer'].units + ')')
 
 
-The pysat nano-kernel lets you modify any data set as needed so that you can get the daily mean you desire, without having to modify the daily_mean function.
+The pysat nano-kernel lets you modify any data set as needed so that you can
+get the daily mean you desire, without having to modify the daily_mean function.
 
-Check the instrument independence using a different instrument. Whatever instrument is supplied may be modified in arbitrary ways by the nano-kernel.
+Check the instrument independence using a different instrument. Whatever
+instrument is supplied may be modified in arbitrary ways by the nano-kernel.
 
 .. code:: python
 
-   cosmic = pysat.Instrument('cosmic', 'gps', tag='ionprf', clean_level='clean', altitude_bin=3)
+   cosmic = pysat.Instrument('cosmic', 'gps', tag='ionprf', clean_level='clean',
+                             altitude_bin=3)
 
    def filter_cosmic(inst):
        inst.data = inst[(inst['edmaxlat'] > -15) & (inst['edmaxlat'] < 15)]
@@ -388,10 +455,11 @@ Check the instrument independence using a different instrument. Whatever instrum
    mean_max_dens = daily_mean(cosmic, start, stop, data_label)
 
    # plot the result using pandas functionality
-   mean_max_dens.plot(title='Absolute Daily Mean of ' + cosmic.meta[data_label].long_name)
-   plt.ylabel('Absolute Daily Mean (' + cosmic.meta[data_label].units + ')')
+   mean_max_dens.plot(title='Absolute Daily Mean of {:s}'.format(cosmic.meta[data_label].long_name))
+   plt.ylabel('Absolute Daily Mean ({:s}).format(cosmic.meta[data_label].units))
 
-daily_mean now works for any instrument, as long as the data to be averaged is 1D. This can be fixed.
+daily_mean now works for any instrument, as long as the data to be averaged is
+1D. This can be fixed.
 
 **Partial Independence from Dimensionality**
 
@@ -407,11 +475,11 @@ daily_mean now works for any instrument, as long as the data to be averaged is 1
        # get list of dates between start and stop
        date_array = pysat.utils.time.create_date_range(start, stop)
        # iterate over season, calculate the mean
-       for date in date_array:
-           inst.load(date=date)
+       for idate in date_array:
+           inst.load(date=idate)
 	   if not inst.data.empty:
-               # compute mean absolute using pandas functions and store
-               # data could be an image, or lower dimension, account for 2D and lower
+               # compute mean absolute using pandas functions and store data
+               # could be an image, or lower dimension, account for 2D and lower
                data = inst[data_label]
                if isinstance(data.iloc[0], pandas.DataFrame):
 	           # 3D data, 2D data at every time
@@ -428,7 +496,15 @@ daily_mean now works for any instrument, as long as the data to be averaged is 1
 
    return mean_val
 
-This code works for 1D, 2D, and 3D datasets, regardless of instrument platform, with only some minor changes from the initial VEFI specific code. In-situ measurements, remote profiles, and remote images. It is true the nested if statements aren't the most elegant. Particularly the 3D case. However this code puts the data into an appropriate structure for pandas to align each of the profiles/images by their respective indices before performing the average. Note that the line to obtain the arithmetic mean is the same in all cases, .mean(axis=0, skipna=True). There is an opportunity here for pysat to clean up the little mess caused by dimensionality.
+This code works for 1D, 2D, and 3D datasets, regardless of instrument platform,
+with only some minor changes from the initial VEFI specific code. In-situ
+measurements, remote profiles, and remote images. It is true the nested if
+statements aren't the most elegant. Particularly the 3D case. However this code
+puts the data into an appropriate structure for pandas to align each of the
+profiles/images by their respective indices before performing the average. Note
+that the line to obtain the arithmetic mean is the same in all cases,
+.mean(axis=0, skipna=True). There is an opportunity here for pysat to clean up
+the little mess caused by dimensionality.
 
 .. code:: python
 
@@ -442,11 +518,11 @@ This code works for 1D, 2D, and 3D datasets, regardless of instrument platform, 
        # get list of dates between start and stop
        date_array = pysat.utils.time.create_date_range(start, stop)
        # iterate over season, calculate the mean
-       for date in date_array:
-           inst.load(date=date)
+       for idate in date_array:
+           inst.load(date=idate)
 	   if not inst.data.empty:
-               # compute mean absolute using pandas functions and store
-               # data could be an image, or lower dimension, account for 2D and lower
+               # compute mean absolute using pandas functions and store data
+               # could be an image, or lower dimension, account for 2D and lower
                data = inst[data_label]
                data = pysat.ssnl.computational_form(data)
                mean_val[inst.date] = data.abs().mean(axis=0, skipna=True)
@@ -468,18 +544,23 @@ The seasonal analysis loop is repeated commonly:
 .. code:: python
 
    date_array = pysat.utils.time.create_date_range(start,stop)
-   for date in date_array:
-       vefi.load(date=date)
+   for vdate in date_array:
+       vefi.load(date=vdate)
        print('Maximum meridional magnetic perturbation ', vefi['dB_mer'].max())
 
-Iteration support is built into the Instrument object to support this and similar cases. The whole VEFI data set may be iterated over on a daily basis using
+Iteration support is built into the Instrument object to support this and
+similar cases. The whole VEFI data set may be iterated over on a daily basis
+using
 
 .. code:: python
 
     for vefi in vefi:
 	print('Maximum meridional magnetic perturbation ', vefi['dB_mer'].max())
 
-Each loop of the python for iteration initiates a vefi.load() for the next date, starting with the first available date. By default the instrument instance will iterate over all available data. To control the range, set the instrument bounds,
+Each loop of the python for iteration initiates a vefi.load() for the next
+date, starting with the first available date. By default the instrument
+instance will iterate over all available data. To control the range, set the
+instrument bounds,
 
 .. code:: python
 
@@ -504,7 +585,11 @@ The output is,
    Returning cnofs vefi dc_b data for 05/12/10
    Maximum meridional magnetic perturbation  26.583
 
-So far, the iteration support has only saved a single line of code, the .load line. However, this line in the examples above is tied to loading by date. What if we wanted to load by file instead? This would require changing the code. However, with the abstraction provided by the Instrument iteration, that is no longer the case.
+So far, the iteration support has only saved a single line of code, the .load
+line. However, this line in the examples above is tied to loading by date. What
+if we wanted to load by file instead? This would require changing the code.
+However, with the abstraction provided by the Instrument iteration, that is no
+longer the case.
 
 .. code:: python
 
@@ -512,7 +597,9 @@ So far, the iteration support has only saved a single line of code, the .load li
    for vefi in vefi:
        print('Maximum meridional magnetic perturbation ', vefi['dB_mer'].max())
 
-For VEFI there is only one file per day so there is no practical difference between the previous example. However, for instruments that have more than one file a day, there is a difference.
+For VEFI there is only one file per day so there is no practical difference
+between the previous example. However, for instruments that have more than one
+file a day, there is a difference.
 
 Building support for this iteration into the mean_day example is easy.
 
@@ -528,15 +615,18 @@ Building support for this iteration into the mean_day example is easy.
 
        for inst in inst:
 	   if not inst.data.empty:
-               # compute mean absolute using pandas functions and store
-               # data could be an image, or lower dimension, account for 2D and lower
+               # compute mean absolute using pandas functions and store data
+               # could be an image, or lower dimension, account for 2D and lower
                data = inst[data_label]
                data = pysat.ssnl.computational_form(data)
                mean_val[inst.date] = data.abs().mean(axis=0, skipna=True)
 
        return mean_val
 
-Since bounds are attached to the Instrument object, the start and stop dates for the season are no longer required as inputs. If a user forgets to specify the bounds, the loop will start on the first day of data and end on the last day.
+Since bounds are attached to the Instrument object, the start and stop dates
+for the season are no longer required as inputs. If a user forgets to specify
+the bounds, the loop will start on the first day of data and end on the last
+day.
 
 .. code:: python
 
@@ -549,14 +639,19 @@ Since bounds are attached to the Instrument object, the start and stop dates for
    	        + vefi.meta['dB_mer'].long_name)
    plt.ylabel('Absolute Daily Mean ('+vefi.meta['dB_mer'].units+')')
 
-The abstraction provided by the iteration support is also used for the next section on orbit data.
+The abstraction provided by the iteration support is also used for the next
+section on orbit data.
 
 
 
 Orbit Support
 -------------
 
-Pysat has functionality to determine orbits on the fly from loaded data. These orbits will span day breaks as needed (generally). Information about the orbit needs to be provided at initialization. The 'index' is the name of the data to be used for determining orbits, and 'kind' indicates type of orbit. See :any:`pysat.Orbits` for latest inputs.
+Pysat has functionality to determine orbits on the fly from loaded data. These
+orbits will span day breaks as needed (generally). Information about the orbit
+needs to be provided at initialization. The 'index' is the name of the data to
+be used for determining orbits, and 'kind' indicates type of orbit.
+See :any:`pysat.Orbits` for latest inputs.
 
 There are several orbits to choose from,
 
@@ -568,22 +663,27 @@ longitude      Uses negative gradients to delineate orbits
 polar	       Uses sign changes to delineate orbits
 ===========   ================
 
-Changes in universal time are also used to delineate orbits. Pysat compares any gaps to the supplied orbital period, nominally assumed to be 97 minutes. As orbit periods aren't constant, a 100% success rate is not be guaranteed.
+Changes in universal time are also used to delineate orbits. Pysat compares any
+gaps to the supplied orbital period, nominally assumed to be 97 minutes. As
+orbit periods aren't constant, a 100% success rate is not be guaranteed.
 
 This section of pysat is still under development.
 
 .. code:: python
 
    info = {'index': 'mlt', 'kind': 'local time'}
-   ivm = pysat.Instrument(platform='cnofs', name='ivm', orbit_info=info, clean_level='None')
+   ivm = pysat.Instrument(platform='cnofs', name='ivm', orbit_info=info,
+                          clean_level='None')
 
-Orbit determination acts upon data loaded in the ivm object, so to begin we must load some data.
+Orbit determination acts upon data loaded in the ivm object, so to begin we
+must load some data.
 
 .. code:: python
 
    ivm.load(date=start)
 
-Orbits may be selected directly from the attached .orbit class. The data for the orbit is stored in .data.
+Orbits may be selected directly from the attached .orbit class. The data for
+the orbit is stored in .data.
 
 .. code:: ipython
 
@@ -593,7 +693,10 @@ Orbits may be selected directly from the attached .orbit class. The data for the
    Returning cnofs ivm  data for 12/28/12
    Loaded Orbit:1
 
-Note that getting the first orbit caused pysat to load the day previous, and then back to the current day. Orbits are one indexed though this will change. Pysat is checking here if the first orbit for 12/28/2012 actually started on 12/27/2012. In this case it does.
+Note that getting the first orbit caused pysat to load the day previous, and
+then back to the current day. Orbits are one indexed though this will change.
+Pysat is checking here if the first orbit for 12/28/2012 actually started on
+12/27/2012. In this case it does.
 
 .. code:: ipython
 
@@ -633,7 +736,8 @@ Let's go back an orbit.
    2012-12-27 23:05:13.584000    23.998516
    Name: mlt, dtype: float32
 
-pysat loads the previous day, as needed, and returns the last orbit for 12/27/2012 that does not (or should not) extend into 12/28.
+pysat loads the previous day, as needed, and returns the last orbit for
+12/27/2012 that does not (or should not) extend into 12/28/2012.
 
 If we continue to iterate orbits using
 
@@ -641,7 +745,8 @@ If we continue to iterate orbits using
 
    ivm.orbits.next()
 
-eventually the next day will be loaded to try and form a complete orbit. You can skip the iteration and just go for the last orbit of a day,
+eventually the next day will be loaded to try and form a complete orbit. You
+can skip the iteration and just go for the last orbit of a day,
 
 .. code:: ipython
 
@@ -670,14 +775,18 @@ eventually the next day will be loaded to try and form a complete orbit. You can
    2012-12-29 00:40:17.119000    23.997608
    Name: mlt, dtype: float32
 
-Pysat loads the next day of data to see if the last orbit on 12/28/12 extends into 12/29/12, which it does. Note that the last orbit of 12/28/12 is the same as the first orbit of 12/29/12. Thus, if we ask for the next orbit,
+Pysat loads the next day of data to see if the last orbit on 12/28/12 extends
+into 12/29/12, which it does. Note that the last orbit of 12/28/12 is the same
+as the first orbit of 12/29/12. Thus, if we ask for the next orbit,
 
 .. code:: ipython
 
    In[] : ivm.orbits.next()
    Loaded Orbit:2
 
-pysat will indicate it is the second orbit of the day. Going back an orbit gives us orbit 16, but referenced to a different day. Earlier, the same orbit was labeled orbit 1.
+pysat will indicate it is the second orbit of the day. Going back an orbit
+gives us orbit 16, but referenced to a different day. Earlier, the same orbit
+was labeled orbit 1.
 
 .. code:: ipython
 
@@ -685,7 +794,8 @@ pysat will indicate it is the second orbit of the day. Going back an orbit gives
    Returning cnofs ivm  data for 12/28/12
    Loaded Orbit:16
 
-Orbit iteration is built into ivm.orbits just like iteration by day is built into ivm.
+Orbit iteration is built into ivm.orbits just like iteration by day is built
+into ivm.
 
 .. code:: python
 
@@ -698,16 +808,22 @@ Orbit iteration is built into ivm.orbits just like iteration by day is built int
 Iteration and Instrument Independent Analysis
 ---------------------------------------------
 
-Now we can generalize daily_mean into two functions, one that averages by day, the other by  orbit. Strictly speaking, the daily_mean above already does this with the right input.
+Now we can generalize daily_mean into two functions, one that averages by day,
+the other by  orbit. Strictly speaking, the daily_mean above already does this
+with the right input.
 
 .. code:: python
 
    mean_daily_val = daily_mean(vefi, 'dB_mer')
    mean_orbit_val = daily_mean(vefi.orbits, 'dB_mer')
 
-However, the output of the by_orbit attempt gets rewritten for most orbits since the output from daily_mean is stored by date. Though this could be fixed, supplying an instrument object/iterator in one case and an orbit iterator in the other might be a bit inconsistent. Even if not, let's try another route.
+However, the output of the by_orbit attempt gets rewritten for most orbits since
+the output from daily_mean is stored by date. Though this could be fixed,
+supplying an instrument object/iterator in one case and an orbit iterator in
+the other might be a bit inconsistent. Even if not, let's try another route.
 
-We also don't want to maintain two code bases that do almost the same thing. So instead, let's create three functions, two of which simply call a hidden third.
+We also don't want to maintain two code bases that do almost the same thing. So
+instead, let's create three functions, two of which simply call a hidden third.
 
 **Iteration Independence**
 
@@ -738,26 +854,43 @@ We also don't want to maintain two code bases that do almost the same thing. So 
        for inst in iterator:
 	      if not inst.data.empty:
                   # compute mean absolute using pandas functions and store
-                  # data could be an image, or lower dimension, account for 2D and lower
+                  # data could be an image, or lower dimension, account for 2D
+		  # and lower
                   data = inst[data_label]
                   data.dropna(inplace=True)
 
                   if by_orbit:
-                      date = inst.data.index[0]
+                      idate = inst.data.index[0]
                   else:
-                      date = inst.date
+                      idate = inst.date
 
                   data = pysat.ssnl.computational_form(data)
-                  mean_val[date] = data.abs().mean(axis=0, skipna=True)
+                  mean_val[idate] = data.abs().mean(axis=0, skipna=True)
 
        del iterator
        return mean_val
 
-The addition of a few more lines to the daily_mean function adds support for averages by orbit, or by day, for any platform with data 3D or less. The date issue and the type of iteration are solved with simple if else checks. From a practical perspective, the code doesn't really deviate from the first solution of simply passing in vefi.orbits, except for the fact that the .orbits switch is 'hidden' in the code. NaN values are also dropped from the data. If the first element is a NaN, it isn't handled by the simple instance check.
+The addition of a few more lines to the daily_mean function adds support for
+averages by orbit, or by day, for any platform with data 3D or less. The date
+issue and the type of iteration are solved with simple if else checks. From a
+practical perspective, the code doesn't really deviate from the first solution
+of simply passing in vefi.orbits, except for the fact that the .orbits switch
+is 'hidden' in the code. NaN values are also dropped from the data. If the first
+element is a NaN, it isn't handled by the simple instance check.
 
-A name change and a couple more dummy functions separates out the orbit vs daily iteration clearly, without having multiple codebases. Iteration by file and by date are handled by the same Instrument iterator, controlled by the settings in Instrument.bounds. A by_file_mean was not created because bounds could be set by date and then by_file_mean applied. Of course this could set up to produce an error. However, the settings on Instrument.bounds controls the iteration type between files and dates, so we maintain this view with the expressed calls. Similarly, the orbit iteration is a separate iterator, with a separate call. This technique above is used by other seasonal analysis routines in pysat.
+A name change and a couple more dummy functions separates out the orbit vs daily
+iteration clearly, without having multiple codebases. Iteration by file and by
+date are handled by the same Instrument iterator, controlled by the settings in
+Instrument.bounds. A by_file_mean was not created because bounds could be set
+by date and then by_file_mean applied. Of course this could set up to produce
+an error. However, the settings on Instrument.bounds controls the iteration
+type between files and dates, so we maintain this view with the expressed
+calls. Similarly, the orbit iteration is a separate iterator, with a separate
+call. This technique above is used by other seasonal analysis routines in pysat.
 
-You may notice that the mean call could also easily be replaced by a median, or even a mode. We might also want to return the standard deviation, or appropriate measure. Perhaps another level of generalization is needed?
+You may notice that the mean call could also easily be replaced by a median, or
+even a mode. We might also want to return the standard deviation, or appropriate
+measure. Perhaps another level of generalization is needed?
 
 Summary Flow Charts
 -------------------
@@ -767,7 +900,10 @@ Summary Flow Charts
 Verbosity
 ---------
 
-Pysat uses Python's standard `logging tools <https://docs.python.org/3/library/logging.html>`_ to control the verbosity of output. By default, only logger.warning messages are shown. For more detailed instrument output, you may change the logging level.
+Pysat uses Python's standard
+`logging tools <https://docs.python.org/3/library/logging.html>`_ to control
+the verbosity of output. By default, only logger.warning messages are shown.
+For more detailed instrument output, you may change the logging level.
 
 .. code:: python
 

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -110,7 +110,7 @@ class Custom(object):
         pos_list.append('end')
 
         if at_pos not in pos_list:
-            logger.warning(''.join(['unknown position specified, includuing ',
+            logger.warning(''.join(['unknown position specified, including ',
                                     'function at end of current list']))
             at_pos = 'end'
 

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -163,14 +163,14 @@ class Custom(object):
                                 sat[newData['data'].columns] = newData
                             # if a series is returned, add it as a column
                             elif isinstance(newData['data'], pds.Series):
-                                # look for name attached to series first
-                                if newData['data'].name is not None:
-                                    sat[newData['data'].name] = newData
-                                # look if name is provided as part of dict
-                                # returned from function
-                                elif 'name' in newData.keys():
+                                # Look if name is provided as part of dict
+                                # returned from function first
+                                if 'name' in newData.keys():
                                     name = newData.pop('name')
                                     sat[name] = newData
+                                # look for name attached to Series second
+                                elif newData['data'].name is not None:
+                                    sat[newData['data'].name] = newData
                                 # couldn't find name information
                                 else:
                                     raise ValueError(

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -6,13 +6,15 @@ try:
 except NameError:
     basestring = str
 
+import numpy as np
 import pandas as pds
 import xarray as xr
 
+from pysat import logger
+
 
 class Custom(object):
-    """
-    Applies a queue of functions when instrument.load called.
+    """ Applies a queue of functions when instrument.load called.
 
     Nano-kernel functionality enables instrument objects that are
     'set and forget'. The functions are always run whenever
@@ -42,19 +44,18 @@ class Custom(object):
     ----
     User should interact with Custom through pysat.Instrument instance's
     attribute, instrument.custom
+
     """
 
     def __init__(self):
-        # create a list object to store functions
+        # create hidden lists to store custom functions, their return type,
+        # argument input, and keyword argument input
         self._functions = []
-        # type of function stored (add/modify/pass on data)
         self._kind = []
-        # arguments to functions
         self._args = []
-        # keyword arguments to functions
         self._kwargs = []
 
-    def attach(self, function, kind='add', at_pos='end', *args, **kwargs):
+    def attach(self, function, kind='modify', at_pos='end', args=[], kwargs={}):
         """Attach a function to custom processing queue.
 
         Custom functions are applied automatically to associated
@@ -62,26 +63,30 @@ class Custom(object):
 
         Parameters
         ----------
-            function : string or function object
-                name of function or function object to be added to queue
+        function : string or function object
+            name of function or function object to be added to queue
+        kind : {'add', 'modify', 'pass}
+            add
+                Adds data returned from function to instrument object.
+                A copy of pysat instrument object supplied to routine.
+            modify
+                pysat instrument object supplied to routine. Any and all
+                changes to object are retained.
+            pass
+                A copy of pysat object is passed to function. No
+                data is accepted from return.
+            (default='modify')
 
-            kind : {'add', 'modify', 'pass}
-                add
-                    Adds data returned from function to instrument object.
-                    A copy of pysat instrument object supplied to routine.
-                modify
-                    pysat instrument object supplied to routine. Any and all
-                    changes to object are retained.
-                pass
-                    A copy of pysat object is passed to function. No
-                    data is accepted from return.
-
-            at_pos : string or int
-                insert at position. (default, insert at end).
-            args : extra arguments
-                extra arguments are passed to the custom function (once)
-            kwargs : extra keyword arguments
-                extra keyword args are passed to the custom function (once)
+        at_pos : string or int
+            Accepts string 'end' or a number that will be used to determine
+            the insertion order if multiple custom functions are attached
+            to an Instrument object. (default='end').
+        args : list or tuple
+            Ordered arguments following the instrument object input that are
+            required by the custom function (default=[])
+        kwargs : dict
+            Dictionary of keyword arguements required by the custom function
+            (default={})
 
         Note
         ----
@@ -97,32 +102,47 @@ class Custom(object):
         - pandas Series, .name required
 
         - (string/list of strings, numpy array/list of arrays)
+
         """
 
+        # Test the positioning input
+        pos_list = list(np.arange(0, len(self._functions), 1))
+        pos_list.append('end')
+
+        if at_pos not in pos_list:
+            logger.warning(''.join(['unknown position specified, includuing ',
+                                    'function at end of current list']))
+            at_pos = 'end'
+
+        # Convert string to function object, if necessary
         if isinstance(function, str):
-            # convert string to function object
             function = eval(function)
 
+        # If the position is 'end' or greater
         if (at_pos == 'end') | (at_pos == len(self._functions)):
             # store function object
             self._functions.append(function)
             self._args.append(args)
             self._kwargs.append(kwargs)
             self._kind.append(kind.lower())
-        elif at_pos < len(self._functions):
+        else:
             # user picked a specific location to insert
             self._functions.insert(at_pos, function)
             self._args.insert(at_pos, args)
             self._kwargs.insert(at_pos, kwargs)
             self._kind.insert(at_pos, kind)
-        else:
-            raise TypeError('Must enter an index between 0 and %i' %
-                            len(self._functions))
 
     def _apply_all(self, sat):
         """
         Apply all of the custom functions to the satellite data object.
+
+        Parameters
+        ----------
+        sat : pysat.Instrument
+            Instrument object
+
         """
+
         if len(self._functions) > 0:
             for func, arg, kwarg, kind in zip(self._functions, self._args,
                                               self._kwargs, self._kind):
@@ -153,9 +173,10 @@ class Custom(object):
                                     sat[name] = newData
                                 # couldn't find name information
                                 else:
-                                    raise ValueError('Must assign a name to ' +
-                                                     'Series or return a ' +
-                                                     '"name" in dictionary.')
+                                    raise ValueError(
+                                        ''.join(['Must assign a name to ',
+                                                 'Series or return a ',
+                                                 '"name" in dictionary.']))
                             # xarray returned
                             elif isinstance(newData['data'], xr.DataArray):
                                 sat[newData['data'].name] = newData['data']

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -1,8 +1,39 @@
+import logging
+from io import StringIO
 import numpy as np
 import pandas as pds
 import pytest
 
 import pysat
+
+class TestLogging():
+    def setup(self):
+        """Runs before every method to create a clean testing setup.
+        """
+        self.testInst = pysat.Instrument('pysat', 'testing', tag='10',
+                                         clean_level='clean')
+        self.out = ''
+        self.log_capture = StringIO()
+        pysat.logger.addHandler(logging.StreamHandler(self.log_capture))
+        pysat.logger.setLevel(logging.WARNING)
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing.
+        """
+        del self.testInst, self.out, self.log_capture
+
+    def test_custom_pos_warning(self):
+        """Test for logging warning if inappropriate position specified
+        """
+        def custom1(inst):
+            inst.data['doubleMLT'] = 2.0 * inst.data.mlt
+            return 5.0 * inst.data['mlt']
+
+        self.testInst.custom.attach(custom1, 'add', at_pos=3)
+        self.out = self.log_capture.getvalue()
+
+        assert self.out.find(
+            "unknown position specified, including function at end") >= 0
 
 
 class TestBasics():

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -7,22 +7,20 @@ import pysat
 
 class TestBasics():
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
+        """Runs before every method to create a clean testing setup.
+        """
         self.testInst = pysat.Instrument('pysat', 'testing', tag='10',
                                          clean_level='clean')
+        self.testInst.load(2008, 1)
+        self.ncols = len(self.testInst.data.columns)
 
     def teardown(self):
-        """Runs after every method to clean up previous testing."""
-        del self.testInst
-
-    def attach(self, function, kind='add', at_pos='end', *args, **kwargs):
-        """Adds a function to the object's custom queue"""
-        self.testInst.custom.attach(function, kind, at_pos, *args, **kwargs)
+        """Runs after every method to clean up previous testing.
+        """
+        del self.testInst, self.ncols
 
     def test_single_modifying_custom_function_error(self):
-        """Test if custom function works correctly. Modify function that
-        returns pandas object. Modify function returns an object which will
-        produce an Error.
+        """Test for error when custom function loaded as modify returns a value
         """
         def custom1(inst):
             inst.data['doubleMLT'] = 2.0 * inst.data.mlt
@@ -33,69 +31,63 @@ class TestBasics():
             self.testInst.load(2009, 1)
 
     def test_single_adding_custom_function(self):
-        """Test if custom function works correctly. Add function that returns
-        pandas object.
+        """Test successful use of custom function loaded as add
         """
         def custom1(inst):
             d = 2.0 * inst['mlt']
             d.name = 'doubleMLT'
             return d
 
-        self.attach(custom1, 'add')
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
-        assert (self.testInst['doubleMLT'].values == 2.0 *
-                self.testInst['mlt'].values).all()
+        assert (self.testInst['doubleMLT'].values == 2.0
+                * self.testInst['mlt'].values).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_single_adding_custom_function_wrong_times(self):
-        """Only the data at the correct time should be accepted, otherwise it
-        returns nan
+        """Test index alignment with add type custom function
         """
+        if not self.testInst.pandas_format:
+            pytest.skip('pandas specific test for time index')
+
         def custom1(inst):
             new_index = inst.index+pds.DateOffset(milliseconds=500)
             d = pds.Series(2.0 * inst['mlt'], index=new_index)
             d.name = 'doubleMLT'
-            print(new_index)
             return d
 
-        self.attach(custom1, 'add')
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
-        ans = (self.testInst['doubleMLT'].isnull()).all()
-        if self.testInst.pandas_format:
-            assert ans
-        else:
-            print("Warning! Xarray doesn't enforce the same times on all " +
-                  "parameters in dataset.")
+        assert (self.testInst['doubleMLT'].isnull()).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_single_adding_custom_function_that_modifies_passed_data(self):
-        """Test if custom function works correctly. Add function that returns
-        pandas object but modifies passed satellite object.
-        Changes to passed object should not propagate back.
+        """Ensure in-function instrument modifications don't propagate with add
         """
         def custom1(inst):
             inst.data['doubleMLT'] = 2.0 * inst.data.mlt
             inst['mlt'] = 0.
             return inst.data.doubleMLT
 
-        self.attach(custom1, 'add')
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert (self.testInst.data['doubleMLT'] == 2.0 *
                 self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_function_tuple_return_style(self):
-        """Test if custom function works correctly. Add function that returns
-        name and numpy array.
+        """Test success of add function that returns name and numpy array.
         """
         def custom1(inst):
             return ('doubleMLT', 2.0 * inst.data.mlt.values)
+
         self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
-        print(self.testInst['doubleMLT'])
-        print(2.0 * self.testInst['mlt'])
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_multiple_custom_functions_tuple_return_style(self):
-        """Test if multiple custom functions that add data work correctly. Add
-        function that returns name and numpy array.
+        """Test success of add function with multiple name/array pairs
         """
         def custom1(inst):
             return (['doubleMLT', 'tripleMLT'], [2.0 * inst.data.mlt.values,
@@ -106,57 +98,63 @@ class TestBasics():
                 self.testInst['mlt']).all()
         assert (self.testInst.data['tripleMLT'] == 3.0 *
                 self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 2
 
     def test_add_function_tuple_return_style_too_few_elements(self):
-        """Test if custom function works correctly. Add function that returns
-        name and numpy array.
+        """Test failure of add function that too few array elements
         """
+        if not self.testInst.pandas_format:
+            pytest.skip('pandas specific test for time index')
+
         def custom1(inst):
             return ('doubleMLT', 2.0 * inst.data.mlt.values[0:-5])
 
-        if not self.testInst.pandas_format:
-            pytest.skip(' '.join(('xarray does not enforce the same number',
-                                  'of elements on all params in dataset.')))
         self.testInst.custom.attach(custom1, 'add')
         with pytest.raises(ValueError):
             self.testInst.load(2009, 1)
 
     def test_add_function_tuple_return_style_too_many_elements(self):
-        """Test if custom function works correctly. Add function that returns
-        name and numpy array.
+        """Test failure of add function that too many array elements
         """
+        if not self.testInst.pandas_format:
+            pytest.skip('pandas specific test for time index')
+
         def custom1(inst):
             return ('doubleMLT', np.arange(2.0 * len(inst.data.mlt)))
 
-        if not self.testInst.pandas_format:
-            pytest.skip(' '.join(('xarray does not enforce the same number',
-                                  'of elements on all params in dataset.')))
         self.testInst.custom.attach(custom1, 'add')
         with pytest.raises(ValueError):
             self.testInst.load(2009, 1)
 
     def test_add_dataframe(self):
+        """Test add function success with pandas DataFrame return
+        """
         def custom1(inst):
             out = pds.DataFrame({'doubleMLT': inst.data.mlt * 2,
-                                   'tripleMLT': inst.data.mlt * 3},
-                                  index=inst.index)
+                                 'tripleMLT': inst.data.mlt * 3},
+                                index=inst.index)
             return out
-        self.attach(custom1, 'add')
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert (self.testInst.data['doubleMLT'] == 2.0 *
                 self.testInst['mlt']).all()
         assert (self.testInst.data['tripleMLT'] == 3.0 *
                 self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 2
 
     def test_add_dataframe_w_meta(self):
+        """Test add function success with pandas DataFrame and MetaData return
+        """
         def custom1(inst):
             out = pds.DataFrame({'doubleMLT': inst.data.mlt * 2,
-                                   'tripleMLT': inst.data.mlt * 3},
-                                  index=inst.index)
+                                 'tripleMLT': inst.data.mlt * 3},
+                                index=inst.index)
             return {'data': out,
                     'long_name': ['doubleMLTlong', 'tripleMLTlong'],
                     'units': ['hours1', 'hours2']}
-        self.attach(custom1, 'add')
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert self.testInst.meta['doubleMLT'].units == 'hours1'
         assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
@@ -164,46 +162,60 @@ class TestBasics():
         assert self.testInst.meta['tripleMLT'].long_name == 'tripleMLTlong'
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
         assert (self.testInst['tripleMLT'] == 3.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 2
 
     def test_add_series_w_meta(self):
+        """Test add function success with pandas Series return
+        """
         def custom1(inst):
             out = pds.Series(inst.data.mlt * 2,
                                index=inst.index)
             out.name = 'doubleMLT'
             return {'data': out, 'long_name': 'doubleMLTlong',
                     'units': 'hours1'}
-        self.attach(custom1, 'add')
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert self.testInst.meta['doubleMLT'].units == 'hours1'
         assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_series_w_meta_missing_long_name(self):
+        """Test add function success with Series and allowable partial MetaData
+        """
         def custom1(inst):
             out = pds.Series(2.0 * inst.data.mlt.values,
                                index=inst.index)
             out.name = 'doubleMLT'
-            return {'data': out,
-                    'units': 'hours1'}
-        self.attach(custom1, 'add')
+            return {'data': out, 'units': 'hours1'}
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert self.testInst.meta['doubleMLT'].units == 'hours1'
         assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLT'
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_series_w_meta_name_in_dict(self):
+        """Test add function success with pandas Series and MetaData return
+        """
         def custom1(inst):
             out = pds.Series(2.0 * inst.data.mlt.values,
                                index=inst.index)
             return {'data': out, 'long_name': 'doubleMLTlong',
                     'units': 'hours1', 'name': 'doubleMLT'}
-        self.attach(custom1, 'add')
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert self.testInst.meta['doubleMLT'].units == 'hours1'
         assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_series_w_meta_no_name_error(self):
+        """Test add function failure with Series and required MetaData missing
+        """
         def custom1(inst):
             out = pds.Series({'doubleMLT': inst.data.mlt * 2},
                                index=inst.index)
@@ -211,43 +223,55 @@ class TestBasics():
             return {'data': out, 'long_name': 'doubleMLTlong',
                     'units': 'hours1'}
 
-        self.attach(custom1, 'add')
+        self.testInst.custom.attach(custom1, 'add')
         with pytest.raises(ValueError):
             self.testInst.load(2009, 1)
 
     def test_add_numpy_array_w_meta_name_in_dict(self):
+        """Test add function success with array and MetaData
+        """
         def custom1(inst):
             out = 2.*inst['mlt'].values
             return {'data': out, 'long_name': 'doubleMLTlong',
                     'units': 'hours1', 'name': 'doubleMLT'}
-        self.attach(custom1, 'add')
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert self.testInst.meta['doubleMLT'].units == 'hours1'
         assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_numpy_array_w_meta_no_name_in_dict_error(self):
+        """Test add function failure with array and required MetaData missing
+        """
         def custom1(inst):
             out = (inst.data.mlt * 2).values
             return {'data': out, 'long_name': 'doubleMLTlong',
                     'units': 'hours1'}
 
-        self.attach(custom1, 'add')
+        self.testInst.custom.attach(custom1, 'add')
         with pytest.raises(ValueError):
             self.testInst.load(2009, 1)
 
     def test_add_list_w_meta_name_in_dict(self):
+        """Test add function success with list and full MetaData
+        """
         def custom1(inst):
             out = (inst.data.mlt * 2).values.tolist()
             return {'data': out, 'long_name': 'doubleMLTlong',
                     'units': 'hours1', 'name': 'doubleMLT'}
-        self.attach(custom1, 'add')
+
+        self.testInst.custom.attach(custom1, 'add')
         self.testInst.load(2009, 1)
         assert self.testInst.meta['doubleMLT'].units == 'hours1'
         assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
         assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
 
     def test_add_list_w_meta_no_name_in_dict_error(self):
+        """Test add function failure with list and required MetaData missing
+        """
         def custom1(inst):
             out = (inst.data.mlt * 2).values.tolist()
             return {'data': out, 'long_name': 'doubleMLTlong',
@@ -258,26 +282,49 @@ class TestBasics():
             self.testInst.load(2009, 1)
 
     def test_clear_functions(self):
-        def custom1(inst):
-            out = (inst.data.mlt * 2).values
+        """Test successful clearance of custom functions
+        """
+        def custom1(inst, imult, out_units='hours'):
+            out = (inst.data.mlt * imult).values
             return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1', 'name': 'doubleMLT'}
-        self.testInst.custom.attach(custom1, 'add')
+                    'units': out_units, 'name': 'doubleMLT'}
+
+        self.testInst.custom.attach(custom1, 'add', args=[2],
+                                    kwargs={"out_units": "hours1"})
+        # Test to see that the custom function was attached
+        assert len(self.testInst.custom._functions) == 1
+        assert len(self.testInst.custom._kind) == 1
+        assert len(self.testInst.custom._args) == 1
+        assert len(self.testInst.custom._kwargs) == 1
+        
         self.testInst.custom.clear()
+        # Test to see that the custom function was cleared
         assert self.testInst.custom._functions == []
         assert self.testInst.custom._kind == []
+        assert self.testInst.custom._args == []
+        assert self.testInst.custom._kwargs == []
 
     def test_pass_functions(self):
+        """ Test success of pass function, will not modify or add to instrument
+        """
         def custom1(inst):
             out = (inst.data.mlt * 2).values
             return
 
         self.testInst.custom.attach(custom1, 'pass')
-        self.testInst.load(2009, 1)
+        # Test to see that the custom function was attached
+        assert len(self.testInst.custom._functions) == 1
+        assert len(self.testInst.custom._kind) == 1
+        assert len(self.testInst.custom._args) == 1
+        assert len(self.testInst.custom._kwargs) == 1
 
-        assert True
+        self.testInst.load(2009, 1)
+        # Test that the number of data columns is the same
+        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols
 
     def test_pass_functions_no_return_allowed_error(self):
+        """Test error when a pass function returns a value
+        """
         def custom1(inst):
             out = (inst.data.mlt * 2).values
             return {'data': out, 'long_name': 'doubleMLTlong',
@@ -288,6 +335,8 @@ class TestBasics():
             self.testInst.load(2009, 1)
 
     def test_add_multiple_functions_one_not_at_end(self):
+        """Test for error if custom functions are run in the wrong order
+        """
         def custom1(inst):
             out = (inst.data.mlt * 2).values
             return {'data': out, 'long_name': 'doubleMLTlong',
@@ -311,32 +360,37 @@ class TestBasics():
         with pytest.raises(AttributeError):
             self.testInst.load(2009, 1)
 
-
+# Repeate the above tests with xarray
 class TestBasicsXarray(TestBasics):
     def setup(self):
-        """Runs before every method to create a clean testing setup."""
+        """Runs before every method to create a clean testing setup.
+        """
         self.testInst = pysat.Instrument('pysat', 'testing_xarray', tag='10',
                                          clean_level='clean')
+        self.testInst.load(2008, 1)
+        self.ncols = len([kk for kk in self.testInst.data.keys()])
 
     def teardown(self):
-        """Runs after every method to clean up previous testing."""
+        """Runs after every method to clean up previous testing.
+        """
         del self.testInst
 
 
+# Repeat the above tests with a Constellation
 class ConstellationTestBasics(TestBasics):
     def setup(self):
-        """Runs before every method to create a clean testing setup"""
-        insts = []
-        for i in range(5):
-            insts.append(pysat.Instrument('pysat', 'testing', tag='10',
-                                          clean_level='clean'))
-
-        self.testConst = pysat.Constellation(insts)
+        """Runs before every method to create a clean testing setup
+        """
+        self.testConst = pysat.Constellation([
+            pysat.Instrument('pysat', 'testing', tag='10', clean_level='clean')
+            for i in range(5)])
 
     def teardown(self):
-        """ Runs after every method to clean up previous testing"""
+        """ Runs after every method to clean up previous testing
+        """
         del self.testConst
 
-    def add(self, function, kind='add', at_pos='end', *args, **kwargs):
-        """ Add a function to the object's custom queue"""
-        self.testConst.data_mod(function, kind, at_pos, *args, **kwargs)
+    def add(self, function, kind='add', at_pos='end', args=[], kwargs={}):
+        """ Add a function to the object's custom queue
+        """
+        self.testConst.data_mod(function, kind, at_pos, args, kwargs)

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -285,12 +285,13 @@ class TestBasics():
         """Test successful clearance of custom functions
         """
         def custom1(inst, imult, out_units='hours'):
-            out = (inst.data.mlt * imult).values
-            return {'data': out, 'long_name': 'doubleMLTlong',
+            return {'data': (inst.data.mlt * imult).values,
+                    'long_name': 'doubleMLTlong',
                     'units': out_units, 'name': 'doubleMLT'}
 
         self.testInst.custom.attach(custom1, 'add', args=[2],
                                     kwargs={"out_units": "hours1"})
+
         # Test to see that the custom function was attached
         assert len(self.testInst.custom._functions) == 1
         assert len(self.testInst.custom._kind) == 1
@@ -337,26 +338,21 @@ class TestBasics():
     def test_add_multiple_functions_one_not_at_end(self):
         """Test for error if custom functions are run in the wrong order
         """
-        def custom1(inst):
-            out = (inst.data.mlt * 2).values
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1', 'name': 'doubleMLT'}
+        def custom1(inst, imult):
+            out = (inst.data.mlt * imult).values
+            return {'data': out, 'long_name': 'MLT x {:d}'.format(int(imult)),
+                    'units': 'hours', 'name': 'MLTx{:d}'.format(int(imult))}
 
-        def custom2(inst):
-            out = (inst.data.mlt * 3).values
-            return {'data': out, 'long_name': 'tripleMLTlong',
-                    'units': 'hours1', 'name': 'tripleMLT'}
+        def custom2(inst, imult):
+            out = (inst.data.MLTx2 * imult).values
+            return {'data': out, 'long_name': 'MLT x {:d}'.format(int(imult)),
+                    'units': 'hours', 'name': 'MLTx{:d}'.format(int(imult))}
 
-        def custom3(inst):
-            out = (inst.data.tripleMLT * 2).values
-            return {'data': out, 'long_name': 'quadMLTlong',
-                    'units': 'hours1', 'name': 'quadMLT'}
-
-        self.testInst.custom.attach(custom1, 'add')
-        self.testInst.custom.attach(custom2, 'add')
+        self.testInst.custom.attach(custom1, 'add', args=[4])
+        self.testInst.custom.attach(custom1, 'add', args=[2])
         # if this runs correctly, an error will be thrown
         # since the data required by custom3 won't be present yet
-        self.testInst.custom.attach(custom3, 'add', at_pos=1)
+        self.testInst.custom.attach(custom2, 'add', at_pos=1, args=[2])
         with pytest.raises(AttributeError):
             self.testInst.load(2009, 1)
 

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -628,7 +628,7 @@ class TestOrbitsGappyData2(TestGeneralOrbitsMLT):
                                          seconds=int(seconds)) -
                           pds.DateOffset(seconds=20)])
 
-        self.testInst.custom.attach(filter_data2, 'modify', times=times)
+        self.testInst.custom.attach(filter_data2, kwargs={'times': times})
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -655,7 +655,7 @@ class TestOrbitsGappyData2Xarray(TestGeneralOrbitsMLT):
                                          seconds=int(seconds)) -
                           pds.DateOffset(seconds=20)])
 
-        self.testInst.custom.attach(filter_data2, 'modify', times=times)
+        self.testInst.custom.attach(filter_data2, kwargs={'times': times})
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""


### PR DESCRIPTION
Improved the custom function input by:
- improving inline comments,
- adding and fixing style of docstrings,
- changing `attach` input to use keyword arguments for function inputs,
- changed the default `kind` to "modify", since that is the most frequently used option,
- changed "add" data saving to take the dict key "name" before the dict key "data" metadata,
- added an input check for the position specifier that defaults to placing
   placing the function at the end if appropriate input isn't provided,
- changed style of a ValueError statement construction to conform with
   pysat norms,
- streamlined existing `test_custom.py` unit tests,
- added unit test to cover new logging output, and
- updated documentation to reflect new behaviour.

Addresses #428 

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

```
import datetime as dt
import pysat

stime = dt.datetime(2014, 4, 22)
def rename_fad(inst, old_name, new_name='best_drift'):
    inst.data[new_name] = inst.data[old_name]
    return

cindi = pysat.Instrument('cnofs', 'ivm')
cindi.custom.attach(rename_fad, args=['ionVelparallel'], kwargs={'new_name': 'v_par'})
cindi.load(date=stime)
cindi.data['v_par']
```

**Test Configuration**:
* Operating system - OSX Mojave
* Version number - Python 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
