### PR TITLE
BUG: Improved CDAWeb downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.0] - 2020-4-27
+## [2.2.0] - 2020-5-28
 - New Features
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed old code and incorrect comments from F10.7 support
   - Updated use of numpy.linspace to be compatible with numpy 1.18.
   - Fixed output of orbit_info during print(inst)
+  - Fixed a bug when requesting non-existent files from CDAWeb (#426)
 
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -443,8 +443,8 @@ def list_remote_files(tag, sat_id,
 
     # Deprecations warnings for changing syntax
     if any([year, month, day]):
-        warnings.warn(' '.join(["The year/month/day keywords are deprecated",
-                                "here and will be changed in pysat 3.0.0 to",
+        warnings.warn(' '.join(["The year/month/day keywords have been deprecated",
+                                "and will be removed in pysat 3.0.0.  Instead,",
                                 "use datetime values consistent with the",
                                 "start/stop syntax in the download methods."]),
                       DeprecationWarning, stacklevel=2)
@@ -526,7 +526,7 @@ def list_remote_files(tag, sat_id,
                             full_files.append(link['href'])
     except requests.exceptions.ConnectionError as merr:
         raise type(merr)(' '.join((str(merr), 'pysat -> Request potentially',
-                                   'exceeds the server limit. Please try again',
+                                   'exceeded the server limit. Please try again',
                                    'using a smaller data range.')))
 
     # parse remote filenames to get date information

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -253,6 +253,15 @@ def download(supported_tags, date_array, tag, sat_id,
     # if desired
     local_fname = inst_dict['local_fname']
 
+    if not multi_file_day:
+        # Get list of files from server
+        remote_files = list_remote_files(tag=tag, sat_id=sat_id,
+                                         remote_site=remote_site,
+                                         supported_tags=supported_tags)
+        # Find only requested files that exist remotely
+        date_array = pds.DatetimeIndex(list(set(remote_files.index)
+                                            & set(date_array))).sort_values()
+
     for date in date_array:
         # format files for specific dates and download location
         formatted_remote_fname = remote_fname.format(year=date.year,
@@ -271,6 +280,7 @@ def download(supported_tags, date_array, tag, sat_id,
 
         # perform download
         if not multi_file_day:
+            # standard download
             try:
                 logger.info(' '.join(('Attempting to download file for',
                                       date.strftime('%d %B %Y'))))
@@ -287,7 +297,6 @@ def download(supported_tags, date_array, tag, sat_id,
             except requests.exceptions.RequestException as exception:
                 logger.info(' '.join((exception, '- File not available for',
                                       date.strftime('%d %B %Y'))))
-
         else:
             try:
                 logger.info(' '.join(('Attempting to download files for',

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -441,6 +441,14 @@ def list_remote_files(tag, sat_id,
         warnings.warn("Day keyword requires year and month.  Ignoring day.")
         day = None
 
+    # Deprecations warnings for changing syntax
+    if any([year, month, day]):
+        warnings.warn(' '.join(["The year/month/day keywords are deprecated",
+                                "here and will be changed in pysat 3.0.0 to",
+                                "use datetime values consistent with the",
+                                "start/stop syntax in the download methods."]),
+                      DeprecationWarning, stacklevel=2)
+
     # get a listing of all files
     # determine if we need to walk directories
 

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -498,23 +498,28 @@ def list_remote_files(tag, sat_id,
         n_loops = n_layers + 1
     full_files = []
 
-    for level in range(n_loops):
-        for directory in remote_dirs[level]:
-            temp_url = '/'.join((remote_url.strip('/'), directory))
-            soup = BeautifulSoup(requests.get(temp_url).content, "lxml")
-            links = soup.find_all('a', href=True)
-            for link in links:
-                # If there is room to go down, look for directories
-                if link['href'].count('/') == 1:
-                    remote_dirs[level+1].append(link['href'])
-                else:
-                    # If at the endpoint, add matching files to list
-                    add_file = True
-                    for target in targets:
-                        if link['href'].count(target) == 0:
-                            add_file = False
-                    if add_file:
-                        full_files.append(link['href'])
+    try:
+        for level in range(n_loops):
+            for directory in remote_dirs[level]:
+                temp_url = '/'.join((remote_url.strip('/'), directory))
+                soup = BeautifulSoup(requests.get(temp_url).content, "lxml")
+                links = soup.find_all('a', href=True)
+                for link in links:
+                    # If there is room to go down, look for directories
+                    if link['href'].count('/') == 1:
+                        remote_dirs[level+1].append(link['href'])
+                    else:
+                        # If at the endpoint, add matching files to list
+                        add_file = True
+                        for target in targets:
+                            if link['href'].count(target) == 0:
+                                add_file = False
+                        if add_file:
+                            full_files.append(link['href'])
+    except Exception as merr:
+        raise type(merr)(' '.join((str(merr), 'Request exceeds the server',
+                                   'limit. Please try again using a smaller',
+                                   'data range.')))
 
     # parse remote filenames to get date information
     if delimiter is None:

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -524,10 +524,10 @@ def list_remote_files(tag, sat_id,
                                 add_file = False
                         if add_file:
                             full_files.append(link['href'])
-    except Exception as merr:
-        raise type(merr)(' '.join((str(merr), 'Request exceeds the server',
-                                   'limit. Please try again using a smaller',
-                                   'data range.')))
+    except requests.exceptions.RequestException as merr:
+        raise type(merr)(' '.join((str(merr), 'pysat -> Request potentially',
+                                   'exceeds the server limit. Please try again',
+                                   'using a smaller data range.')))
 
     # parse remote filenames to get date information
     if delimiter is None:

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -524,7 +524,7 @@ def list_remote_files(tag, sat_id,
                                 add_file = False
                         if add_file:
                             full_files.append(link['href'])
-    except requests.exceptions.RequestException as merr:
+    except requests.exceptions.ConnectionError as merr:
         raise type(merr)(' '.join((str(merr), 'pysat -> Request potentially',
                                    'exceeds the server limit. Please try again',
                                    'using a smaller data range.')))

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -93,6 +93,9 @@ supported_tags = {'': {'1min': basic_tag1,
 download = functools.partial(cdw.download,
                              supported_tags,
                              fake_daily_files_from_monthly=True)
+# support listing files currently on CDAWeb
+list_remote_files = functools.partial(cdw.list_remote_files,
+                                      supported_tags=supported_tags)
 
 
 def clean(omni):

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -1,0 +1,44 @@
+import requests
+import warnings
+
+import pytest
+
+import pysat
+from pysat.instruments.methods import nasa_cdaweb as cdw
+
+
+class TestCDAWeb():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.supported_tags = pysat.instruments.cnofs_plp.supported_tags
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.supported_tags
+
+    def test_remote_file_list_connection_error_append(self):
+        """Test that pysat appends suggested help to ConnectionError"""
+        with pytest.raises(Exception) as excinfo:
+            # Giving a bad remote_site address yields similar ConnectionError
+            cdw.list_remote_files(tag='', sat_id='',
+                                  supported_tags=self.supported_tags,
+                                  remote_site='http:/')
+
+        assert excinfo.type is requests.exceptions.ConnectionError
+        # Check that pysat appends the message
+        assert str(excinfo.value).find('pysat -> Request potentially')
+
+    def test_remote_file_list_deprecation_warning(self):
+        """Test generation of deprecation warning for remote_file_list kwargs
+        """
+        warnings.simplefilter("always")
+
+        with warnings.catch_warnings(record=True) as war:
+            # testing with single day since we just need the warning
+            cdw.list_remote_files(tag='', sat_id='',
+                                  supported_tags=self.supported_tags,
+                                  year=2009, month=1, day=1)
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -23,11 +23,11 @@ class TestCDAWeb():
             # Giving a bad remote_site address yields similar ConnectionError
             cdw.list_remote_files(tag='', sat_id='',
                                   supported_tags=self.supported_tags,
-                                  remote_site='http:/fake/')
+                                  remote_site='http:/')
 
         assert excinfo.type is requests.exceptions.ConnectionError
         # Check that pysat appends the message
-        assert str(excinfo.value).find('pysat -> Request potentially')
+        assert str(excinfo.value).find('pysat -> Request potentially') > 0
 
     def test_remote_file_list_deprecation_warning(self):
         """Test generation of deprecation warning for remote_file_list kwargs

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -23,7 +23,7 @@ class TestCDAWeb():
             # Giving a bad remote_site address yields similar ConnectionError
             cdw.list_remote_files(tag='', sat_id='',
                                   supported_tags=self.supported_tags,
-                                  remote_site='http:/')
+                                  remote_site='http:/fake/')
 
         assert excinfo.type is requests.exceptions.ConnectionError
         # Check that pysat appends the message


### PR DESCRIPTION
# Description

Addresses #426.

Summary
- Uses `remote_file_list` to see if files exist before requesting a download for non-`multi_file_day` instruments for cdaweb
- If a connection error is still generated, append the error message to suggest trying a smaller date range
- Included standard `remote_file_list` method for omni data

NOTE: This code can be further simplified, but this requires a breaking change for keywords in `remote_file_list`.  This will be addressed in the pysat 3.0.0 version, and appropriate DeprecationWarnings have been added here.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran the tests outlined in #426 in ipython.

**Test Configuration**:
* Mac OS X 10.15
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
