### PR TITLE
ENH: include test instruments in main package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Added warning when FillValue metadata could lead to unexpected results
      when writing a netCDF4 file
    - Use conda to manage Travis CI test environment
+   - test instruments now part of compiled package for development elsewhere
 - Deprecation Warning
   - custom.add will be renamed custom.attach in pysat 3.0.0
 - Documentation

--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -11,6 +11,8 @@ __all__ = ['champ_star', 'cnofs_ivm', 'cnofs_plp', 'cnofs_vefi', 'cosmic_gps',
            'demeter_iap', 'dmsp_ivm',
            'icon_ivm', 'icon_euv', 'icon_fuv', 'icon_mighti',
            'iss_fpmu',  'jro_isr', 'omni_hro', 'rocsat1_ivm',
+           'pysat_testing', 'pysat_testing_xarray', 'pysat_testing2d',
+           'pysat_testing2d_xarray', 'pysat_testmodel',
            'sport_ivm', 'superdarn_grdex', 'supermag_magnetometer',
            'sw_dst', 'sw_kp', 'sw_f107', 'timed_saber', 'timed_see',
            'ucar_tiegcm', ]

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -14,6 +14,8 @@ from pysat.instruments.methods import testing as mm_test
 
 platform = 'pysat'
 name = 'testing2d'
+tags = {'': 'Regular testing data set'}
+sat_ids = {'': ['']}
 _test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
 
 

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -15,6 +15,8 @@ from pysat.instruments.methods import testing as mm_test
 platform = 'pysat'
 name = 'testing2D_xarray'
 
+tags = {'': 'Regular testing data set'}
+sat_ids = {'': ['']}
 pandas_format = False
 _test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
 

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -17,6 +17,8 @@ from pysat.instruments.methods import testing as mm_test
 platform = 'pysat'
 name = 'testmodel'
 
+tags = {'': 'Regular testing data set'}
+sat_ids = {'': ['']}
 pandas_format = False
 _test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
 


### PR DESCRIPTION
# Description

Including the test instruments in the main package to help streamline testing for non-pysat packages (ocbpy, etc) that include pysat as part of their unit tests.

Minor updates to structure now that test instruments are checked for tags and sat_ids.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via travis ci

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
