### PR TITLE
ENH/BUG: Updates to NASA CDAWeb methods -- pysat 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-05-14
+## [3.0.0] - 2020-05-30
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -13,6 +13,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Madrigal instruments migrated to pysatMadrigal
   - methods.nasa_cdaweb.list_files moved to methods.general
   - `strict_time_flag` now defaults to True
+  - Use of start / stop notation in remote_file_list
 - Deprecations
   - Removed ssnl
   - Removed utils.stats

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,16 +36,20 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Specify dtype for empty pandas.Series for forward compatibility
   - Remove wildcard imports, relative imports
 
-## [2.2.0] - 2020-2-29
+## [2.2.0] - 2020-5-28
 - New Features
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments
    - Updated `test_files.py` to be pytest compatible
-   - Updates to instrument testing objects for consistency
    - Added check to ensure non-pysat keywords supplied at instantiation
      are supported by underlying data set methods
+   - Updates to instrument testing objects for consistency
    - Changed madrigal methods to use `madrigalWeb` as a module rather than
      calling it externally
+   - Added warning when FillValue metadata could lead to unexpected results
+     when writing a netCDF4 file
+   - Use conda to manage Travis CI test environment
+   - test instruments now part of compiled package for development elsewhere
 - Deprecation Warning
   - custom.add will be renamed custom.attach in pysat 3.0.0
 - Documentation
@@ -65,8 +69,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added small time offsets (< 1s) to ensure COSMIC files and data have unique times
   - Updates to Travis CI environment
   - Removed `inplace` use in xarray `assign` function, which is no longer allowed
+  - Removed old code and incorrect comments from F10.7 support
+  - Updated use of numpy.linspace to be compatible with numpy 1.18.
   - Fixed output of orbit_info during print(inst)
-
+  - Fixed a bug when requesting non-existent files from CDAWeb (#426)
 
 ## [2.1.0] - 2019-11-18
 - New Features

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1445,7 +1445,7 @@ class Instrument(object):
         sys.stdout.flush()
         return
 
-    def remote_file_list(self, year=None, month=None, day=None):
+    def remote_file_list(self, start=None, stop=None):
         """List remote files for chosen instrument.  Default behaviour is
         to return all files.  User may additionally specify a given year,
         year/month, or year/month/day combination to return a subset of
@@ -1453,19 +1453,13 @@ class Instrument(object):
 
         Keywords
         --------
-        year : int or NoneType
-            Selected year to return remote files.  A None value will return
-            all available files.
+        start : (dt.datetime or NoneType)
+            Starting time for file list. A None value will start with the first
+            file found.
             (default=None)
-        month : int or NoneType
-            Selected month to return remote files.  A year must be specified.
-            A None value will return all available files for the year, if year
-            is specified.
-            (default=None)
-        day : int or NoneType
-            Selected day to return remote files.  A year and month must be
-            specified. A None value will return all available files for the
-            year or month, if keywords are specified.
+        stop : (dt.datetime or NoneType)
+            Ending time for the file list.  A None value will stop with the last
+            file found.
             (default=None)
 
         Returns
@@ -1476,7 +1470,7 @@ class Instrument(object):
         """
 
         return self._list_remote_rtn(self.tag, self.sat_id,
-                                     year=year, month=month, day=day)
+                                     start=start, stop=stop)
 
     def remote_date_range(self, year=None, month=None, day=None):
         """Returns fist and last date for remote data.  Default behaviour is

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1472,7 +1472,7 @@ class Instrument(object):
         return self._list_remote_rtn(self.tag, self.sat_id,
                                      start=start, stop=stop)
 
-    def remote_date_range(self, year=None, month=None, day=None):
+    def remote_date_range(self, start=None, stop=None):
         """Returns fist and last date for remote data.  Default behaviour is
         to search all files.  User may additionally specify a given year,
         year/month, or year/month/day combination to return a subset of
@@ -1480,19 +1480,13 @@ class Instrument(object):
 
         Keywords
         --------
-        year : int or NoneType
-            Selected year to return remote files.  A None value will return
-            all available files.
+        start : (dt.datetime or NoneType)
+            Starting time for file list. A None value will start with the first
+            file found.
             (default=None)
-        month : int or NoneType
-            Selected month to return remote files.  A year must be specified.
-            A None value will return all available files for the year, if year
-            is specified.
-            (default=None)
-        day : int or NoneType
-            Selected day to return remote files.  A year and month must be
-            specified. A None value will return all available files for the
-            year or month, if keywords are specified.
+        stop : (dt.datetime or NoneType)
+            Ending time for the file list.  A None value will stop with the last
+            file found.
             (default=None)
 
         Returns
@@ -1502,7 +1496,7 @@ class Instrument(object):
 
         """
 
-        files = self.remote_file_list(year=year, month=month, day=day)
+        files = self.remote_file_list(start=start, stop=stop)
         return [files.index[0], files.index[-1]]
 
     def download_updated_files(self, user=None, password=None, **kwargs):

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -7,7 +7,6 @@ intervention.
 
 from __future__ import absolute_import, division, print_function
 import datetime as dt
-import numpy as np
 import os
 import requests
 import sys
@@ -348,14 +347,6 @@ def list_remote_files(tag, sat_id,
     # naming scheme for files on the CDAWeb server
     format_str = inst_dict['remote_fname']
 
-    # Check for acustom start stop dates.  Set to defaults if NoneType
-    # if start is None:
-    #     start = dt.datetime(1958, 1, 1)
-    # if stop is None:
-    #     stop = dt.datetime.now()
-    # if start == stop:
-    #     stop += dt.timedelta(days=1)
-
     # Break string format into path and filename
     dir_split = os.path.split(format_str)
 
@@ -363,7 +354,6 @@ def list_remote_files(tag, sat_id,
     format_dir = dir_split[0]
     search_dir = pysat._files.construct_searchstring_from_format(format_dir)
     n_layers = len(search_dir['keys'])
-    print(search_dir['keys'])
 
     # only keep file portion of format
     format_str = dir_split[-1]

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -380,21 +380,9 @@ def list_remote_files(tag, sat_id,
                                        subdir.format(day=day)))
                 n_layers -= 1
 
-    # Start with file extention as prime target
-    targets = ['.' + format_str.split('.')[-1]]
-
-    # Extract file preamble as target - those characters left of variables
-    # or wildcards
-    fmt_idx = [format_str.find('{')]
-    fmt_idx.append(format_str.find('?'))
-    fmt_idx.append(format_str.find('*'))
-
-    # Not all characters may exist in a filename.  Remove those that don't.
-    fmt_idx = [elem for elem in fmt_idx if elem != -1]
-
-    # If preamble exists, add to targets
-    if fmt_idx:
-        targets.append(format_str[0:min(fmt_idx)])
+    # Generate list of targets to identify files
+    search_dict = pysat._files.construct_searchstring_from_format(format_str)
+    targets = [x for x in search_dict['string_blocks'] if len(x) > 0]
 
     remote_dirs = []
     for level in range(n_layers + 1):

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -162,7 +162,7 @@ def download(supported_tags, date_array, tag, sat_id,
     try:
         inst_dict = supported_tags[sat_id][tag]
     except KeyError:
-        raise ValueError('Tag name unknown.')
+        raise ValueError('sat_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
     remote_url = remote_site + inst_dict['dir']
@@ -340,7 +340,7 @@ def list_remote_files(tag, sat_id,
     try:
         inst_dict = supported_tags[sat_id][tag]
     except KeyError:
-        raise ValueError('Tag name unknown.')
+        raise ValueError('sat_id / tag combo unknown.')
 
     # path to relevant file on CDAWeb
     remote_url = remote_site + inst_dict['dir']

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -8,8 +8,11 @@ intervention.
 from __future__ import absolute_import, division, print_function
 import datetime as dt
 import numpy as np
+import os
+import requests
 import sys
 
+from bs4 import BeautifulSoup
 import pandas as pds
 
 import pysat
@@ -156,9 +159,6 @@ def download(supported_tags, date_array, tag, sat_id,
                                      supported_tags=supported_tags)
 
     """
-
-    import os
-    import requests
 
     try:
         inst_dict = supported_tags[sat_id][tag]
@@ -322,10 +322,6 @@ def list_remote_files(tag, sat_id,
                               supported_tags=supported_tags)
 
     """
-
-    import os
-    import requests
-    from bs4 import BeautifulSoup
 
     if tag is None:
         tag = ''

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -96,6 +96,9 @@ supported_tags = {'': {'1min': basic_tag1,
 download = functools.partial(cdw.download,
                              supported_tags,
                              fake_daily_files_from_monthly=True)
+# support listing files currently on CDAWeb
+list_remote_files = functools.partial(cdw.list_remote_files,
+                                      supported_tags=supported_tags)
 
 
 def clean(omni):

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -243,6 +243,10 @@ class InstTestClass():
             name = '_'.join((inst.platform, inst.name))
             if hasattr(getattr(self.package, name), 'list_remote_files'):
                 assert callable(inst.remote_file_list)
+                date = inst._test_dates[inst.sat_id][inst.tag]
+                files = inst.remote_file_list(start=date, stop=date)
+                # If test date is correctly chosen, files shoudl exist
+                assert len(files) > 0
             else:
                 pytest.skip("remote_file_list not available")
         except Exception as merr:

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -1,0 +1,29 @@
+import requests
+
+import pytest
+
+import pysat
+from pysat.instruments.methods import nasa_cdaweb as cdw
+
+
+class TestCDAWeb():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+        self.supported_tags = pysat.instruments.cnofs_plp.supported_tags
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.supported_tags
+
+    def test_remote_file_list_connection_error_append(self):
+        """Test that pysat appends suggested help to ConnectionError"""
+        with pytest.raises(Exception) as excinfo:
+            # Giving a bad remote_site address yields similar ConnectionError
+            cdw.list_remote_files(tag='', sat_id='',
+                                  supported_tags=self.supported_tags,
+                                  remote_site='http:/')
+
+        assert excinfo.type is requests.exceptions.ConnectionError
+        # Check that pysat appends the message
+        assert str(excinfo.value).find('pysat -> Request potentially') > 0

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -1,3 +1,4 @@
+import datetime as dt
 import requests
 
 import pytest
@@ -11,13 +12,14 @@ class TestCDAWeb():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.supported_tags = pysat.instruments.cnofs_plp.supported_tags
+        self.kwargs = {'tag': '', 'sat_id': ''}
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.supported_tags
+        del self.supported_tags, self.kwargs
 
     def test_remote_file_list_connection_error_append(self):
-        """Test that pysat appends suggested help to ConnectionError"""
+        """pysat should append suggested help to ConnectionError"""
         with pytest.raises(Exception) as excinfo:
             # Giving a bad remote_site address yields similar ConnectionError
             cdw.list_remote_files(tag='', sat_id='',
@@ -27,3 +29,22 @@ class TestCDAWeb():
         assert excinfo.type is requests.exceptions.ConnectionError
         # Check that pysat appends the message
         assert str(excinfo.value).find('pysat -> Request potentially') > 0
+
+    def test_load_with_empty_file_list(self):
+        """pysat should return empty data if no files are requested"""
+        data, meta = cdw.load(fnames=[])
+        assert len(data) == 0
+        assert meta is None
+
+    @pytest.mark.parametrize("bad_key,bad_val,err_msg",
+                             [("tag", "badval", "Tag name unknown"),
+                              ("sat_id", "badval", "Tag name unknown")])
+    def test_bad_tag_download(self, bad_key, bad_val, err_msg):
+        date_array = [dt.datetime(2019, 1, 1)]
+        self.kwargs[bad_key] = bad_val
+        with pytest.raises(ValueError) as excinfo:
+            cdw.download(supported_tags=self.supported_tags,
+                         date_array=date_array,
+                         tag=self.kwargs['tag'],
+                         sat_id=self.kwargs['sat_id'])
+        assert str(excinfo.value).find('Tag name unknown') >= 0

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -12,7 +12,7 @@ class TestCDAWeb():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.supported_tags = pysat.instruments.cnofs_plp.supported_tags
-        self.kwargs = {'tag': '', 'sat_id': ''}
+        self.kwargs = {'tag': None, 'sat_id': None}
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -37,9 +37,10 @@ class TestCDAWeb():
         assert meta is None
 
     @pytest.mark.parametrize("bad_key,bad_val,err_msg",
-                             [("tag", "badval", "Tag name unknown"),
-                              ("sat_id", "badval", "Tag name unknown")])
-    def test_bad_tag_download(self, bad_key, bad_val, err_msg):
+                             [("tag", "badval", "sat_id / tag combo unknown."),
+                              ("sat_id", "badval",
+                               "sat_id / tag combo unknown.")])
+    def test_bad_kwarg_download(self, bad_key, bad_val, err_msg):
         date_array = [dt.datetime(2019, 1, 1)]
         self.kwargs[bad_key] = bad_val
         with pytest.raises(ValueError) as excinfo:
@@ -47,4 +48,16 @@ class TestCDAWeb():
                          date_array=date_array,
                          tag=self.kwargs['tag'],
                          sat_id=self.kwargs['sat_id'])
-        assert str(excinfo.value).find('Tag name unknown') >= 0
+        assert str(excinfo.value).find(err_msg) >= 0
+
+    @pytest.mark.parametrize("bad_key,bad_val,err_msg",
+                             [("tag", "badval", "sat_id / tag combo unknown."),
+                              ("sat_id", "badval",
+                               "sat_id / tag combo unknown.")])
+    def test_bad_kwarg_list_remote_files(self, bad_key, bad_val, err_msg):
+        self.kwargs[bad_key] = bad_val
+        with pytest.raises(ValueError) as excinfo:
+            cdw.list_remote_files(supported_tags=self.supported_tags,
+                                  tag=self.kwargs['tag'],
+                                  sat_id=self.kwargs['sat_id'])
+        assert str(excinfo.value).find(err_msg) >= 0


### PR DESCRIPTION
# Description

Addresses #436.

- Improves consistency of remote_file_list syntax.  Method now accepts `start` and `stop` as keywords.
- Includes bugfix from pysat 2.2.0 branch (#434).
- Add unit tests for error checks in cdaweb methods
- inlcudes recent updates from pysat 2.2 to the changelog

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

Via procedure outlined in #426.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
