### PR TITLE
BUG: recognize string variables in parse_delimited_files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Updated use of numpy.linspace to be compatible with numpy 1.18.
   - Fixed output of orbit_info during print(inst)
   - Fixed a bug when requesting non-existent files from CDAWeb (#426)
-  - Improved compatibility of parse_delimited_filenames (#337)
+  - Improved compatibility of parse_delimited_filenames (#439)
 
 
 ## [2.1.0] - 2019-11-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.0] - 2020-5-28
+## [2.2.0] - 2020-6-08
 - New Features
    - Decreased time to load COSMIC GPS data by about 50%
    - Added DE2 Langmuir Probe, NACS, RPA, and WATS instruments
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Updated use of numpy.linspace to be compatible with numpy 1.18.
   - Fixed output of orbit_info during print(inst)
   - Fixed a bug when requesting non-existent files from CDAWeb (#426)
+  - Improved compatibility of parse_delimited_filenames
 
 
 ## [2.1.0] - 2019-11-18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Updated use of numpy.linspace to be compatible with numpy 1.18.
   - Fixed output of orbit_info during print(inst)
   - Fixed a bug when requesting non-existent files from CDAWeb (#426)
-  - Improved compatibility of parse_delimited_filenames
+  - Improved compatibility of parse_delimited_filenames (#337)
 
 
 ## [2.1.0] - 2019-11-18

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -805,7 +805,6 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
     # convert to numpy arrays
     for key in stored.keys():
-        stored[key] = np.array(stored[key]).astype(int)
         if len(stored[key]) == 0:
             stored[key] = None
     # include files in output

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -805,6 +805,12 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
     # convert to numpy arrays
     for key in stored.keys():
+        try:
+            # Assume key value is numeric integer
+            stored[key] = np.array(stored[key]).astype(int)
+        except ValueError:
+            # Store key value as string
+            stored[key] = np.array(stored[key])
         if len(stored[key]) == 0:
             stored[key] = None
     # include files in output

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -38,12 +38,12 @@ Note
 Warnings
 --------
 - Routine was not produced by COSMIC team
-- More recent versions of netCDF4 and numpy limit the casting of some variable 
+- More recent versions of netCDF4 and numpy limit the casting of some variable
   types into others. This issue could prevent data loading for some variables
-  such as 'MSL_Altitude' in the 'sonprf' and 'wetprf' files. The default UserWarning
-  when this occurs is 
-    'UserWarning: WARNING: missing_value not used since it cannot be safely cast 
-    to variable data type'
+  such as 'MSL_Altitude' in the 'sonprf' and 'wetprf' files. The default
+  UserWarning when this occurs is
+    'UserWarning: WARNING: missing_value not used since it cannot be safely
+    cast to variable data type'
 
 """
 
@@ -137,10 +137,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         shift_uts = np.mod(np.arange(len(year)), 1E3) * 1.E-5 + 1.E-5
         uts[idx] += shift_uts
 
-        index = pysat.utils.time.create_datetime_index(year=year[idx], day=day[idx],
+        index = pysat.utils.time.create_datetime_index(year=year[idx],
+                                                       day=day[idx],
                                                        uts=uts[idx])
         if not index.is_unique:
-            raise ValueError('Generated non-unique datetimes for COSMIC within list_files.')
+            raise ValueError(' '.join(('Generated non-unique datetimes for',
+                                       'COSMIC within list_files.')))
         # store sorted file names with unique times in index
         file_list = np.array(stored['files'])[idx]
         file_list = pysat.Series(file_list, index=index)
@@ -382,9 +384,11 @@ def load_files(files, tag=None, sat_id=None, altitude_bin=None):
         # small sub DataFrames
         for i in np.arange(len(output)):
             output[i]['OL_vecs'] = psub_frame.iloc[plengths[i]:plengths[i+1], :]
-            output[i]['OL_vecs'].index = length_arr[:plengths2[i+1]-plengths2[i]]
+            output[i]['OL_vecs'].index = \
+                length_arr[:plengths2[i+1]-plengths2[i]]
             output[i]['OL_pars'] = qsub_frame.iloc[qlengths[i]:qlengths[i+1], :]
-            output[i]['OL_pars'].index = length_arr[:qlengths2[i+1]-qlengths2[i]]
+            output[i]['OL_pars'].index = \
+                length_arr[:qlengths2[i+1]-qlengths2[i]]
 
     # create a single data frame with all bits, then
     # break into smaller frames using views

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -109,7 +109,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     # overloading revision keyword below
     if format_str is None:
         # COSMIC file format string
-        format_str = ''.join(('????.???/*.{year:04d}.{day:03d}',
+        format_str = ''.join(('*.*/*.{year:04d}.{day:03d}',
                               '.{hour:02d}.{minute:02d}.*_nc'))
 
     # process format string to get string to search for

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -129,8 +129,11 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         hour = np.array(stored['hour']).astype(int)
         minute = np.array(stored['minute']).astype(int)
         uts = hour*3600. + minute*60.
+        # do a pre-sort on uts to get files that may conflict with each other
+        # due to multiple spacecraft and antennas
+        # this ensures that we can make the times all unique for the file list
         idx = np.argsort(uts)
-        # adding linearly increasing offsets
+        # adding linearly increasing offsets less than 0.01 s
         shift_uts = np.mod(np.arange(len(year)), 1E3) * 1.E-5 + 1.E-5
         uts[idx] += shift_uts
 
@@ -187,6 +190,7 @@ def load(fnames, tag=None, sat_id=None, altitude_bin=None):
                                             altitude_bin=altitude_bin))
         utsec = output.hour * 3600. + output.minute * 60. + output.second
         # make times unique by adding a unique amount of time less than a second
+        # FIXME: need to switch to xarray so unique time stamps not needed
         if tag != 'scnlv1':
             # add 1E-6 seconds to time based upon occulting_sat_id
             # additional 1E-7 seconds added based upon cosmic ID

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -124,10 +124,10 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
                                                     delimiter='.')
 
     if len(stored['year']) > 0:
-        year = np.array(stored['year']).astype(int)
-        day = np.array(stored['day']).astype(int)
-        hour = np.array(stored['hour']).astype(int)
-        minute = np.array(stored['minute']).astype(int)
+        year = np.array(stored['year'])
+        day = np.array(stored['day'])
+        hour = np.array(stored['hour'])
+        minute = np.array(stored['minute'])
         uts = hour*3600. + minute*60.
         # do a pre-sort on uts to get files that may conflict with each other
         # due to multiple spacecraft and antennas

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -144,19 +144,21 @@ class TestBasics():
         # Note: Can be removed if future instrument that uses delimited
         # filenames is added to routine travis end-to-end testing
         fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',
-                         '_{minute:2d}_{second:2d}_v01_r02.cdf'))
+                         '_{minute:2d}_{second:2d}_{version:3s}_r02.cdf'))
         year = np.ones(6)*2009
         month = np.ones(6)*12
         day = np.array([12, 15, 17, 19, 22, 24])
         hour = np.array([8, 10, 6, 18, 3, 23])
         minute = np.array([8, 10, 6, 18, 3, 59])
         second = np.array([58, 11, 26, 2, 18, 59])
+        version = np.array(['nkj', 'cmv', 'cmm', 'ukl', 'dls', 'rbg'])
         file_list = []
         for i in range(6):
             file_list.append(fname.format(year=year[i].astype(int),
                                           month=month[i].astype(int),
                                           day=day[i], hour=hour[i],
-                                          minute=minute[i], second=second[i]))
+                                          minute=minute[i], second=second[i],
+                                          version=version[i]))
 
         file_dict = pysat._files.parse_delimited_filenames(file_list, fname,
                                                            '_')
@@ -166,7 +168,7 @@ class TestBasics():
         assert np.all(file_dict['hour'] == hour)
         assert np.all(file_dict['minute'] == minute)
         assert np.all(file_dict['day'] == day)
-        assert (file_dict['version'] is None)
+        assert np.all(file_dict['version'] == version)
         assert (file_dict['revision'] is None)
 
     def test_year_doy_files_direct_call_to_from_os(self):

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -144,14 +144,14 @@ class TestBasics():
         # Note: Can be removed if future instrument that uses delimited
         # filenames is added to routine travis end-to-end testing
         fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',
-                         '_{minute:2d}_{second:2d}_{version:3s}_r02.cdf'))
+                         '_{minute:2d}_{second:2d}_{version:2s}_r02.cdf'))
         year = np.ones(6)*2009
         month = np.ones(6)*12
         day = np.array([12, 15, 17, 19, 22, 24])
         hour = np.array([8, 10, 6, 18, 3, 23])
         minute = np.array([8, 10, 6, 18, 3, 59])
         second = np.array([58, 11, 26, 2, 18, 59])
-        version = np.array(['ukl', 'vni', 'cjc', 'lmb', 'nkj', 'mrk'])
+        version = np.array(['v1', 'v2', 'r1', 'r3', 'v5', 'a6'])
         file_list = []
         for i in range(6):
             file_list.append(fname.format(year=year[i].astype(int),

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -151,7 +151,7 @@ class TestBasics():
         hour = np.array([8, 10, 6, 18, 3, 23])
         minute = np.array([8, 10, 6, 18, 3, 59])
         second = np.array([58, 11, 26, 2, 18, 59])
-        version = np.array(['nkj', 'cmv', 'cmm', 'ukl', 'dls', 'rbg'])
+        version = np.array(['ukl', 'vni', 'cjc', 'lmb', 'nkj', 'mrk'])
         file_list = []
         for i in range(6):
             file_list.append(fname.format(year=year[i].astype(int),


### PR DESCRIPTION
# Description

Addresses #337.

`parse_delimited_files` currently assumes all variables must be integers.  Some instruments may use strings.  This improves compatibility with other instrument types to maintain variable type in the routine if integer conversion can't be done.  Adds a `version` variable as a string to the unit tests.

Also changes how this is implemented in the cosmic files.  The existing `shift_uts` variable adds fractional seconds to the time stamp of the file for sorting purposes.  Removed the treatment of GNSS ID as seconds since this is not needed for filenames and is the source of the bug in the issue.

Note that this does not fix potential non-unique timestamps within the data.  A FIXME comment has been added to upgrade to xarray down the line.

Updates for style and PEP8 in cosmic_gps.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
gps = pysat.Instrument('cosmic', 'gps', 'ionPrf', update_files=True)   
gps.files.files
```
should produce a list of COSMIC files similar to:
```
2018-01-07 00:00:00.000009984    2018.007/ionPrf_C006.2018.007.00.00.G18_2016.1...
2018-12-18 00:00:00.000019968    2018.352/ionPrf_C006.2018.352.00.00.G29_2016.1...
2019-01-01 00:12:00.000619776    2009.001/ionPrf_C001.2009.001.00.12.G26_2013.3...
2019-01-01 00:16:00.000859904    2009.001/ionPrf_C002.2009.001.00.16.G24_2013.3...
2019-01-01 00:17:00.000920064    2009.001/ionPrf_C002.2009.001.00.17.G09_2013.3...
                                                       ...                        
2019-12-31 20:13:00.002629888    2018.365/ionPrf_C006.2018.365.20.13.G15_2016.1...
2019-12-31 20:24:00.004070144    2018.365/ionPrf_C006.2018.365.20.24.G24_2016.1...
2019-12-31 20:40:00.005939968    2018.365/ionPrf_C006.2018.365.20.40.G12_2016.1...
2019-12-31 20:44:00.006500096    2018.365/ionPrf_C006.2018.365.20.44.G02_2016.1...
2019-12-31 20:52:00.007369984    2018.365/ionPrf_C006.2018.365.20.52.G06_2016.1...
Length: 16609, dtype: object
```
Note that the timestamp only goes down to minutes, with less than 1/100th of a second added.

**Test Configuration**:
- Mac OS X 10.15.4
- python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
