### PR TITLE
TST: Unit tests for `remote_file_list` and `remote_date_range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-05-30
+## [3.0.0] - 2020-06-19
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -37,6 +37,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility
   - Remove wildcard imports, relative imports
+  - Improve unit testing coverage of instrument functions
 
 ## [2.2.0] - 2020-06-08
 - New Features

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -346,7 +346,7 @@ class Files(object):
         if not info.empty:
             if self.ignore_empty_files:
                 self._filter_empty_files()
-            logger.info('Found {ll:d} of them.'.format(ll=len(info)))
+            logger.info('Found {ll:d} files locally.'.format(ll=len(info)))
         else:
             estr = "Unable to find any files that match the supplied template."
             estr += " If you have the necessary files please check pysat "

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -7,7 +7,7 @@ import pandas as pds
 
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                file_date_range=None, test_dates=None):
-    """Produce a fake list of files spanning two years
+    """Produce a fake list of files spanning three years
 
     Parameters
     ----------
@@ -21,7 +21,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         file format string (default=None)
     file_date_range : (pds.date_range)
         File date range. The default mode generates a list of 3 years of daily
-        files (1 year back, 1 year forward) based on the test_dates passed
+        files (1 year back, 2 years forward) based on the test_dates passed
         through below.  Otherwise, accepts a range of files specified by the
         user.
         (default=None)
@@ -39,7 +39,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
     # Determine the appropriate date range for the fake files
     if file_date_range is None:
         start = test_dates[''][''] - pds.DateOffset(years=1)
-        stop = (test_dates[''][''] + pds.DateOffset(years=1)
+        stop = (test_dates[''][''] + pds.DateOffset(years=2)
                 - pds.DateOffset(days=1))
         file_date_range = pds.date_range(start, stop)
 
@@ -54,8 +54,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
 
 def list_remote_files(tag=None, sat_id=None, data_path=None, format_str=None,
                       start=None, stop=None, test_dates=None):
-    """Produce a fake list of files spanning three years to simulate new data
-    files on a remote server
+    """Produce a fake list of files spanning three years and one month to
+    simulate new data files on a remote server
 
     Parameters
     ----------
@@ -72,8 +72,8 @@ def list_remote_files(tag=None, sat_id=None, data_path=None, format_str=None,
         test_date
         (default=None)
     stop : (dt.datetime or NoneType)
-        Ending time for the file list.  A None value will stop 2 years after
-        test_date
+        Ending time for the file list.  A None value will stop 2 years 1 month
+        after test_date
         (default=None)
     test_dates : (dt.datetime)
         Pass the _test_date object through from the test instrument files
@@ -89,7 +89,7 @@ def list_remote_files(tag=None, sat_id=None, data_path=None, format_str=None,
         start = test_dates[''][''] - pds.DateOffset(years=1)
     if stop is None:
         stop = (test_dates[''][''] + pds.DateOffset(years=2)
-                - pds.DateOffset(days=1))
+                - pds.DateOffset(days=1) + pds.DateOffset(months=1))
     file_date_range = pds.date_range(start, stop)
 
     return list_files(tag=tag, sat_id=sat_id, data_path=data_path,

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -7,7 +7,7 @@ import pandas as pds
 
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                file_date_range=None, test_dates=None):
-    """Produce a fake list of files spanning three years
+    """Produce a fake list of files spanning two years
 
     Parameters
     ----------
@@ -21,7 +21,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         file format string (default=None)
     file_date_range : (pds.date_range)
         File date range. The default mode generates a list of 3 years of daily
-        files (1 year back, 2 years forward) based on the test_dates passed
+        files (1 year back, 1 year forward) based on the test_dates passed
         through below.  Otherwise, accepts a range of files specified by the
         user.
         (default=None)
@@ -34,10 +34,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
 
     """
 
+    if data_path is None:
+        data_path = ''
     # Determine the appropriate date range for the fake files
     if file_date_range is None:
         start = test_dates[''][''] - pds.DateOffset(years=1)
-        stop = (test_dates[''][''] + pds.DateOffset(years=2)
+        stop = (test_dates[''][''] + pds.DateOffset(years=1)
                 - pds.DateOffset(days=1))
         file_date_range = pds.date_range(start, stop)
 
@@ -48,6 +50,51 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
              for date in index]
 
     return pds.Series(names, index=index)
+
+
+def list_remote_files(tag=None, sat_id=None, data_path=None, format_str=None,
+                      start=None, stop=None, test_dates=None):
+    """Produce a fake list of files spanning three years to simulate new data
+    files on a remote server
+
+    Parameters
+    ----------
+    tag : (str)
+        pysat instrument tag (default=None)
+    sat_id : (str)
+        pysat satellite ID tag (default=None)
+    data_path : (str)
+        pysat data path (default=None)
+    format_str : (str)
+        file format string (default=None)
+    start : (dt.datetime or NoneType)
+        Starting time for file list. A None value will start 1 year before
+        test_date
+        (default=None)
+    stop : (dt.datetime or NoneType)
+        Ending time for the file list.  A None value will stop 2 years after
+        test_date
+        (default=None)
+    test_dates : (dt.datetime)
+        Pass the _test_date object through from the test instrument files
+
+    Returns
+    -------
+    Series of filenames indexed by file time
+
+    """
+
+    # Determine the appropriate date range for the fake files
+    if start is None:
+        start = test_dates[''][''] - pds.DateOffset(years=1)
+    if stop is None:
+        stop = (test_dates[''][''] + pds.DateOffset(years=2)
+                - pds.DateOffset(days=1))
+    file_date_range = pds.date_range(start, stop)
+
+    return list_files(tag=tag, sat_id=sat_id, data_path=data_path,
+                      format_str=format_str, file_date_range=file_date_range,
+                      test_dates=test_dates)
 
 
 def download(date_array, tag, sat_id, data_path=None, user=None,
@@ -191,8 +238,8 @@ def define_period():
 
     """
 
-    period = {'lt': 5820, # 97 minutes
-              'lon': 6240, # 104 minutes
+    period = {'lt': 5820,  # 97 minutes
+              'lon': 6240,  # 104 minutes
               'angle': 5820}
 
     return period

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -235,6 +235,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)
+list_remote_files = functools.partial(mm_test.list_remote_files,
+                                      test_dates=_test_dates)
 download = functools.partial(mm_test.download)
 
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -180,6 +180,8 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)
+list_remote_files = functools.partial(mm_test.list_remote_files,
+                                      test_dates=_test_dates)
 download = functools.partial(mm_test.download)
 
 

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -193,6 +193,8 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)
+list_remote_files = functools.partial(mm_test.list_remote_files,
+                                      test_dates=_test_dates)
 download = functools.partial(mm_test.download)
 
 

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -186,6 +186,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)
+list_remote_files = functools.partial(mm_test.list_remote_files,
+                                      test_dates=_test_dates)
 download = functools.partial(mm_test.download)
 
 

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -97,6 +97,8 @@ def load(fnames, tag=None, sat_id=None):
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)
+list_remote_files = functools.partial(mm_test.list_remote_files,
+                                      test_dates=_test_dates)
 download = functools.partial(mm_test.download)
 
 meta = pysat.Meta()

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -199,20 +199,17 @@ class TestBasics():
         files = self.testInst.files.files
         remote_files = self.testInst.remote_file_list()
         # Capture the log to see if this works
-        default_level = pysat.logger.getEffectiveLevel()
-        pysat.logger.setLevel(logging.DEBUG)
-        log_capture_string = io.StringIO()
-        ch = logging.StreamHandler(log_capture_string)
-        ch.setLevel(logging.DEBUG)
-        pysat.logger.addHandler(ch)
+        fh = logging.FileHandler('test.log')
+        fh.setLevel(logging.DEBUG)
+        pysat.logger.addHandler(fh)
         # Now that we can capture the log, run the function
         self.testInst.download_updated_files()
         # Pull the contents back into a string and close the stream
-        log_contents = log_capture_string.getvalue()
-        log_capture_string.close()
-        pysat.logger.setLevel(default_level)
+        text_log = open('test.log')
+        log_contents = text_log.readlines()
+        text_log.close()
         # Check the log output for correct operation
-        for message in log_contents.split('\n'):
+        for message in log_contents:
             if message.find('files locally') >= 0:
                 Nlocal = [int(s) for s in re.findall(r'\d+', message)]
             if message.find('that are new or updated') >= 0:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -175,6 +175,23 @@ class TestBasics():
         assert (test_date == dt.datetime(2009, 1, 3))
         assert (test_date == self.testInst.date)
 
+    def test_list_files(self):
+        files = self.testInst.files.files
+        assert isinstance(files, pds.Series)
+
+    def test_remote_file_list(self):
+        files = self.testInst.remote_file_list(start=dt.datetime(2009, 1, 1),
+                                               stop=dt.datetime(2009, 1, 31))
+        assert files.index[0] == dt.datetime(2009, 1, 1)
+        assert files.index[-1] == dt.datetime(2009, 1, 31)
+
+    def test_remote_date_range(self):
+        files = self.testInst.remote_date_range(start=dt.datetime(2009, 1, 1),
+                                                stop=dt.datetime(2009, 1, 31))
+        assert len(files) == 2
+        assert files[0] == dt.datetime(2009, 1, 1)
+        assert files[-1] == dt.datetime(2009, 1, 31)
+
     # --------------------------------------------------------------------------
     #
     # Test date helpers

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2,7 +2,6 @@
 # Test some of the basic _core functions
 import datetime as dt
 from importlib import reload as re_load
-import io
 import logging
 import numpy as np
 import re
@@ -194,31 +193,6 @@ class TestBasics():
         assert len(files) == 2
         assert files[0] == dt.datetime(2009, 1, 1)
         assert files[-1] == dt.datetime(2009, 1, 31)
-
-    def test_download_updated_files(self):
-        files = self.testInst.files.files
-        remote_files = self.testInst.remote_file_list()
-        # Capture the log to see if this works
-        fh = logging.FileHandler('test.log')
-        fh.setLevel(logging.DEBUG)
-        pysat.logger.addHandler(fh)
-        # Now that we can capture the log, run the function
-        self.testInst.download_updated_files()
-        # Pull the contents back into a string and close the stream
-        text_log = open('test.log')
-        log_contents = text_log.readlines()
-        text_log.close()
-        # Check the log output for correct operation
-        for message in log_contents:
-            if message.find('files locally') >= 0:
-                Nlocal = [int(s) for s in re.findall(r'\d+', message)]
-            if message.find('that are new or updated') >= 0:
-                Nnew = [int(s) for s in re.findall(r'\d+', message)]
-
-        assert len(Nlocal) == 1
-        assert Nlocal[0] == len(files)
-        assert len(Nnew) == 1
-        assert Nnew[0] == len(remote_files) - len(files)
 
     # --------------------------------------------------------------------------
     #


### PR DESCRIPTION
# Description

Supports unit tests for several uncovered functions in `pysat._instrument`.  All tests use the testing instruments to simulate the usage of `remote_file_list` and `remote_file_range`
- Adds a `remote_file_list` function to the testing instruments to simulate a slightly longer list of files on the remote server
- Cleans up a few style issues

NOTE: the original intent of this pull was to cover `download_updated_files`.  However, the function can be run but not tested, as the only output will go to the log, and scanning the log for this specific test is not viable.  Pushing off those changes to keep this branch from getting stale.

## Type of change

- New unit tests (non-breaking change which adds functionality)

# How Has This Been Tested?

via pytets

**Test Configuration**:
* Mac OS X 10.15.4
* python 3.7.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
