### PR TITLE
ENH: allow time or Epoch in getitem_xarray

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -433,16 +433,20 @@ class Instrument(object):
             inst[datetime1:datetime1, 'name1':'name2']
 
         """
-        if 'Epoch' not in self.data:
+        if 'Epoch' in self.data.indexes:
+            epoch_name = 'Epoch'
+        elif 'time' in self.data.indexes:
+            epoch_name = 'time'
+        else:
             return xr.Dataset(None)
         if isinstance(key, tuple):
             if len(key) == 2:
                 # support slicing time, variable name
                 try:
-                    return self.data.isel(Epoch=key[0])[key[1]]
+                    return self.data.isel(indexers={epoch_name: key[0]})[key[1]]
                 except:
                     try:
-                        return self.data.sel(Epoch=key[0])[key[1]]
+                        return self.data.sel(indexers={epoch_name: key[0]})[key[1]]
                     except TypeError:  # construct dataset from names
                         return self.data[self.variables[key[1]]]
             else:
@@ -461,10 +465,10 @@ class Instrument(object):
                 try:
                     # get all data variables but for a subset of time
                     # using integer indexing
-                    return self.data.isel(Epoch=key)
+                    return self.data.isel(indexers={epoch_name: key})
                 except:
                     # subset of time, using label based indexing
-                    return self.data.sel(Epoch=key)
+                    return self.data.sel(indexers={epoch_name: key})
 
     def __setitem__(self, key, new):
         """Convenience method for adding data to instrument.


### PR DESCRIPTION
Alternate method for getitem_xarray.  This should be more compatible and allow either 'time' or 'Epoch' to be used as the key index.  Should be more backwards-compatible for when these are ported to pysat 2.2.

Note this is several commits behind #441.  This allows the test instruments to be maintained for 2.2, though we may want to upgrade in 3.0.