### PR TITLE
DEP: Add deprecation warnings for functions in coords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Test instruments now part of compiled package for development elsewhere
 - Deprecation Warning
   - custom.add will be renamed custom.attach in pysat 3.0.0
+  - Several functions in coords will be removed in pysat 3.0.0.  These functions will move to pysatMadrigal
+    - geodetic_to_geocentric
+    - geodetic_to_geocentric_horizontal
+    - spherical_to_cartesian
+    - global_to_local_cartesian
+    - local_horizontal_to_global_geo
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
   - Added discussion of github install, develop branches, and reqs to docs

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -2,6 +2,7 @@
 tests the pysat coords area
 """
 import numpy as np
+import warnings
 
 import pandas as pds
 
@@ -449,3 +450,59 @@ class TestBasics():
         assert abs(lat - 50.414315865044202) < 1.0e-6
         assert abs(lon + 7.6855551809119502) < 1.0e-6
         assert abs(rad - 7185.6983665760772) < 1.0e-6
+
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
+    def test_deprecation_warning_geodetic_to_geocentric(self):
+        """Test if median1D in stats is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            coords.geodetic_to_geocentric(45.0, lon_in=8.0)
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_geodetic_to_geocentric_horz(self):
+        """Test if median1D in stats is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            coords.geodetic_to_geocentric_horizontal(45.0, 8.0, 52.0, 63.0)
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_spherical_to_cartesian(self):
+        """Test if median1D in stats is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            coords.spherical_to_cartesian(45.0, 30.0, 1.0)
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_global_to_local_cartesian(self):
+        """Test if median1D in stats is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            coords.global_to_local_cartesian(7000.0, 8000.0, 9000.0,
+                                             37.5, 289.0, 6380.0)
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_local_horizontal_to_global_geo(self):
+        """Test if median1D in stats is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            coords.local_horizontal_to_global_geo(30.0, 45.0, 1000.0,
+                                                  45.0, 0.0, 400.0)
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -462,7 +462,7 @@ class TestDeprecation():
         """Runs after every method to clean up previous testing"""
 
     def test_deprecation_warning_geodetic_to_geocentric(self):
-        """Test if median1D in stats is deprecated"""
+        """Test if geodetic_to_geocentric in coords is deprecated"""
 
         with warnings.catch_warnings(record=True) as war:
             coords.geodetic_to_geocentric(45.0, lon_in=8.0)
@@ -471,7 +471,7 @@ class TestDeprecation():
         assert war[0].category == DeprecationWarning
 
     def test_deprecation_warning_geodetic_to_geocentric_horz(self):
-        """Test if median1D in stats is deprecated"""
+        """Test if geodetic_to_geocentric_horizontal in coords is deprecated"""
 
         with warnings.catch_warnings(record=True) as war:
             coords.geodetic_to_geocentric_horizontal(45.0, 8.0, 52.0, 63.0)
@@ -480,7 +480,7 @@ class TestDeprecation():
         assert war[0].category == DeprecationWarning
 
     def test_deprecation_warning_spherical_to_cartesian(self):
-        """Test if median1D in stats is deprecated"""
+        """Test if spherical_to_cartesian in coords is deprecated"""
 
         with warnings.catch_warnings(record=True) as war:
             coords.spherical_to_cartesian(45.0, 30.0, 1.0)
@@ -489,7 +489,7 @@ class TestDeprecation():
         assert war[0].category == DeprecationWarning
 
     def test_deprecation_warning_global_to_local_cartesian(self):
-        """Test if median1D in stats is deprecated"""
+        """Test if global_to_local_cartesian in coords is deprecated"""
 
         with warnings.catch_warnings(record=True) as war:
             coords.global_to_local_cartesian(7000.0, 8000.0, 9000.0,
@@ -499,7 +499,7 @@ class TestDeprecation():
         assert war[0].category == DeprecationWarning
 
     def test_deprecation_warning_local_horizontal_to_global_geo(self):
-        """Test if median1D in stats is deprecated"""
+        """Test if local_horizontal_to_global_geo in coords is deprecated"""
 
         with warnings.catch_warnings(record=True) as war:
             coords.local_horizontal_to_global_geo(30.0, 45.0, 1000.0,

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -8,6 +8,7 @@ functions used throughout the pysat package.
 
 import numpy as np
 import pandas as pds
+import warnings
 
 
 def adjust_cyclic_data(samples, high=2.0*np.pi, low=0.0):
@@ -117,7 +118,7 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
     if inst.pandas_format:
         inst[slt_name] = pds.Series(slt, index=inst.data.index)
     else:
-        inst.data = inst.data.assign({slt_name: (inst.data.coords.keys(),slt)})
+        inst.data = inst.data.assign({slt_name: (inst.data.coords.keys(), slt)})
 
     # Add units to the metadata
     inst.meta[slt_name] = {inst.meta.units_label: 'h',
@@ -179,6 +180,12 @@ def geodetic_to_geocentric(lat_in, lon_in=None, inverse=False):
     Based on J.M. Ruohoniemi's geopack and R.J. Barnes radar.pro
 
     """
+
+    warnings.warn(' '.join(["coords.geodetic_to_geocentric is deprecated and",
+                            "will be removed in pysat 3.0.0. This function will",
+                            "move to the new pysatMadrigal package."]),
+                  DeprecationWarning, stacklevel=2)
+
     rad_eq = 6378.1370  # WGS-84 semi-major axis
     flat = 1.0 / 298.257223563  # WGS-84 flattening
     rad_pol = rad_eq * (1.0 - flat)  # WGS-84 semi-minor axis
@@ -249,6 +256,11 @@ def geodetic_to_geocentric_horizontal(lat_in, lon_in, az_in, el_in,
 
     """
 
+    warnings.warn(' '.join(["coords.geodetic_to_geocentric_horizontal is deprecated",
+                            "and will be removed in pysat 3.0.0. This function",
+                            "will move to the new pysatMadrigal package."]),
+                  DeprecationWarning, stacklevel=2)
+
     az = np.radians(az_in)
     el = np.radians(el_in)
 
@@ -309,6 +321,11 @@ def spherical_to_cartesian(az_in, el_in, r_in, inverse=False):
     (angle from the z-axis)
 
     """
+
+    warnings.warn(' '.join(["coords.spherical_to_cartesian is deprecated and",
+                            "will be removed in pysat 3.0.0. This function will",
+                            "move to the new pysatMadrigal package."]),
+                  DeprecationWarning, stacklevel=2)
 
     if inverse:
         # Cartesian to Spherical
@@ -372,6 +389,11 @@ def global_to_local_cartesian(x_in, y_in, z_in, lat_cent, lon_cent, rad_cent,
     The local system has z pointing up, y pointing North, and x pointing East.
 
     """
+
+    warnings.warn(' '.join(["coords.global_to_local_cartesian is deprecated and",
+                            "will be removed in pysat 3.0.0. This function will",
+                            "move to the new pysatMadrigal package."]),
+                  DeprecationWarning, stacklevel=2)
 
     # Get the global cartesian coordinates of local origin
     x_cent, y_cent, z_cent = spherical_to_cartesian(lon_cent, lat_cent,
@@ -455,6 +477,11 @@ def local_horizontal_to_global_geo(az, el, dist, lat_orig, lon_orig, alt_orig,
     Based on J.M. Ruohoniemi's geopack and R.J. Barnes radar.pro
 
     """
+
+    warnings.warn(' '.join(["coords.local_horizontal_to_global_geo is deprecated",
+                            "and will be removed in pysat 3.0.0. This function",
+                            "will move to the new pysatMadrigal package."]),
+                  DeprecationWarning, stacklevel=2)
 
     # If the data are in geodetic coordiantes, convert to geocentric
     if geodetic:


### PR DESCRIPTION
# Description

Addresses #167 (partial)

Several functions in coords will be removed in pysat 3.0.0.  These functions will move to pysatMadrigal.  This pull adds deprecation warnings and tests for them.
    - geodetic_to_geocentric
    - geodetic_to_geocentric_horizontal
    - spherical_to_cartesian
    - global_to_local_cartesian
    - local_horizontal_to_global_geo

## Type of change

- ROADMAP changes

# How Has This Been Tested?

locally via pytest


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
