### PR TITLE
ENH: Method for renaming variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - methods.nasa_cdaweb.list_files moved to methods.general
   - `strict_time_flag` now defaults to True
   - Use of start / stop notation in remote_file_list
+  - Added variable rename method to Instrument object (#91)
 - Deprecations
   - Removed ssnl
   - Removed utils.stats

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -620,7 +620,7 @@ class Instrument(object):
             self.meta[key] = new
 
     def rename(self, names):
-        """Renames variable, here and in meta, preserving case when desired.
+        """Renames variable within both data and metadata.
 
         Parameters
         ----------
@@ -635,19 +635,29 @@ class Instrument(object):
         Examples
         --------
         ..
+            # standard renaming
             new_names = {'old_name': 'new_name',
                          'old_name2':, 'new_name2'}
             inst.rename(new_names)
 
         If using a pandas DataFrame as the underlying data object,
-        to rename higher-order variables. Note that this
-        rename will be invoked individually for all times in the
-        dataset.
+        to rename higher-order variables supply a modified dictionary.
+        Note that this rename will be invoked individually for all
+        times in the dataset.
         ..
+            # applies to higher-order datasets
+            # that are loaded into pandas
+            # general example
             new_names = {'old_name': 'new_name',
                          'old_name2':, 'new_name2',
-                         'col_name': {'old_ho_name': 'new_ho_name'}
+                         'col_name': {'old_ho_name': 'new_ho_name'}}
             inst.rename(new_names)
+
+            # specific example
+            inst = pysat.Instrument('pysat', 'testing2D')
+            inst.load(2009, 1)
+            names = {'uts': 'pysat_uts',
+                     'profiles': {'density': 'pysat_density'}}
 
         """
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -619,6 +619,32 @@ class Instrument(object):
             # attach metadata
             self.meta[key] = new
 
+    def rename(self, old, new):
+        """Renames variable, here and in meta, preserving case when desired.
+
+        Parameters
+        ----------
+        old : string
+            Old variable name, cases insensitive
+        new : string
+            New variable name, case is preserved.
+
+        Returns
+        -------
+        Void
+            Object modified in place.
+
+        """
+
+        if self.pandas_format:
+            self.data.rename(columns={old: new}, inplace=True)
+        else:
+            pass
+
+        case_old = self.meta.var_case_name(old)
+        self.meta.data.rename(index={case_old: new}, inplace=True)
+        return
+
     @property
     def empty(self):
         """Boolean flag reflecting lack of data.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -627,11 +627,6 @@ class Instrument(object):
         names : dict or other map
             Existing names are keys, values are new names
 
-        Returns
-        -------
-        Void
-            Object modified in place.
-
         Examples
         --------
         ..

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -660,12 +660,18 @@ class Instrument(object):
             hdict = {}
             # keys for existing higher order data labels
             ho_keys = [a for a in self.meta.keys_nD()]
+            lo_keys = [a for a in self.meta.keys()]
             # iterate, collect normal variables
             # rename higher order variables
             for key in names:
                 oname, nname = key, names[key]
                 if oname not in ho_keys:
-                    fdict[oname] = nname
+                    if oname in lo_keys:
+                        fdict[oname] = nname
+                    else:
+                        estr = ' '.join((oname, ' is not',
+                                         'a known variable.'))
+                        raise ValueError(estr)
                 else:
                     if isinstance(nname, dict):
                         # changing a variable name within
@@ -682,6 +688,7 @@ class Instrument(object):
                                                              inplace=True)
                         hdict.pop(label)
                     else:
+                        # changing the outer 'column' label
                         fdict[oname] = nname
             # rename regular variables, single go
             self.data.rename(columns=fdict, inplace=True)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -707,6 +707,8 @@ class Instrument(object):
         else:
             # xarray renaming
             self.data = self.data.rename(names)
+            # set up dictionary for renaming metadata variables
+            fdict = names
 
         # update normal metadata parameters in a single go
         new_fdict = {}

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -624,10 +624,8 @@ class Instrument(object):
 
         Parameters
         ----------
-        old : string
-            Old variable name
-        new : string
-            New variable name
+        names : dict or other map
+            Existing names are keys, values are new names
 
         Returns
         -------
@@ -660,8 +658,10 @@ class Instrument(object):
             fdict = {}
             # higher order names
             hdict = {}
-            # keys for existing labels
+            # keys for existing higher order data labels
             ho_keys = [a for a in self.meta.keys_nD()]
+            # iterate, collect normal variables
+            # rename higher order variables
             for key in names:
                 oname, nname = key, names[key]
                 if oname not in ho_keys:
@@ -687,6 +687,7 @@ class Instrument(object):
             self.data.rename(columns=fdict, inplace=True)
 
         else:
+            # xarray renaming
             self.data = self.data.rename(names)
 
         # update normal metadata parameters in a single go

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -667,25 +667,36 @@ class Instrument(object):
                 oname, nname = key, names[key]
                 if oname not in ho_keys:
                     if oname in lo_keys:
+                        # within low order (standard) variable keys
+                        # may be renamed directly
                         fdict[oname] = nname
                     else:
+                        # not in standard or higher order keys
                         estr = ' '.join((oname, ' is not',
                                          'a known variable.'))
                         raise ValueError(estr)
                 else:
+                    # variable name is in higher order list
                     if isinstance(nname, dict):
                         # changing a variable name within
                         # higher order object
                         label = [k for k in nname.keys()][0]
                         hdict[label] = nname[label]
+                        # ensure variable is there
+                        if label not in self.meta[oname]['children']:
+                            estr = ''.join((label, ' is not a known ',
+                                            'higher-order variable under ',
+                                            oname, '.'))
+                            raise ValueError(estr)
                         # change names for frame at each time
                         for i in np.arange(len(self.index)):
                             # within data itself
                             self[i, oname].rename(columns=hdict,
                                                   inplace=True)
-                        # change metadata
+                        # change metadata, once per variable only
                         self.meta.ho_data[oname].data.rename(hdict,
                                                              inplace=True)
+                        # clear out dict for next loop
                         hdict.pop(label)
                     else:
                         # changing the outer 'column' label

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -687,7 +687,7 @@ class Instrument(object):
             self.data.rename(columns=fdict, inplace=True)
 
         else:
-            pass
+            self.data = self.data.rename(names)
 
         # update normal metadata parameters in a single go
         new_fdict = {}

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -683,7 +683,7 @@ class Instrument(object):
 
             # Note that the labels in meta may be used when creating a file
             # thus 'Pysat_UTS' would be found in the resulting file
-            inst.to_netcdf4(fname, preserve_meta_case=True)
+            inst.to_netcdf4('./test.nc', preserve_meta_case=True)
 
             # load in file and check
             raw = netCDF4.Dataset('./test.nc')

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2,6 +2,7 @@
 # Test some of the basic _core functions
 import datetime as dt
 from importlib import reload as re_load
+import logging
 import numpy as np
 
 import pandas as pds

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -623,8 +623,7 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [{'uts': 'uts1'},
                                         {'uts': 'uts2',
-                                         'mlt': 'mlt2'},
-                                        {'profiles': 'new_profiles'}])
+                                         'mlt': 'mlt2'}])
     def test_basic_variable_renaming(self, values):
         # test single variable
         self.testInst.load(2009, 1)
@@ -667,19 +666,16 @@ class TestBasics():
                         check_var = self.testInst.meta[key]['children']
                         assert ikey not in check_var
 
-    def test_ho_pandas_unknown_variable_error_renaming(self):
+    @pytest.mark.parametrize("values", [{'profiles': {'help': 'I need somebody'}},
+                                        {'fake_profiles': {'help': 'I need somebody'}}])
+    def test_ho_pandas_unknown_variable_error_renaming(self, values):
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':
             if self.testInst.name == 'testing2D':
                 self.testInst.load(2009, 1)
-                # check for error for unknown HO variable name
+                # check for error for unknown column or HO variable name
                 with pytest.raises(ValueError):
-                    sub_dict = {'help': 'I need somebody'}
-                    self.testInst.rename({'profiles': sub_dict})
-                # check for bad column name when doing HO renaming
-                with pytest.raises(ValueError):
-                    sub_dict = {'help': 'I need somebody'}
-                    self.testInst.rename({'fake_profiles': sub_dict})
+                    self.testInst.rename(values)
 
     # --------------------------------------------------------------------------
     #

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -657,12 +657,14 @@ class TestBasics():
                 assert 'profiles' in self.testInst.meta
                 assert 'utd' in self.testInst.meta['profiles']['children']
                 assert 'utd' in self.testInst[0, 'profiles']
-                assert 'density' not in self.testInst.meta['profiles']['children']
+                check_var = self.testInst.meta['profiles']['children']
+                assert 'density' not in check_var
                 assert 'density' not in self.testInst[0, 'profiles']
 
                 # check for error for unknown variable name
                 with pytest.raises(ValueError):
-                    self.testInst.rename({'profiles': {'help': 'I need somebody'}})
+                    sub_dict = {'help': 'I need somebody'}
+                    self.testInst.rename({'profiles': sub_dict})
 
     # --------------------------------------------------------------------------
     #

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -647,6 +647,25 @@ class TestBasics():
         with pytest.raises(ValueError):
             self.testInst.rename(values)
 
+
+    @pytest.mark.parametrize("values", [{'uts': 'UTS1'},
+                                        {'uts': 'UTs2',
+                                         'mlt': 'Mlt2'},
+                                        {'uts': 'Long Change with spaces'}])
+    def test_basic_variable_renaming_lowercase(self, values):
+        # test single variable
+        self.testInst.load(2009, 1)
+        self.testInst.rename(values, lowercase_data_labels=True)
+        for key in values:
+            # check for new name
+            assert values[key].lower() in self.testInst.data
+            assert values[key].lower() in self.testInst.meta
+            # ensure case retained in meta
+            assert values[key] == self.testInst.meta[values[key]].name
+            # ensure old name not present
+            assert key not in self.testInst.data
+            assert key not in self.testInst.meta
+
     @pytest.mark.parametrize("values", [{'profiles': {'density': 'ionization'}},
                                         {'profiles': {'density': 'mass'},
                                          'alt_profiles': {'density': 'volume'},
@@ -686,6 +705,34 @@ class TestBasics():
                 # check for error for unknown column or HO variable name
                 with pytest.raises(ValueError):
                     self.testInst.rename(values)
+
+    @pytest.mark.parametrize("values", [{'profiles': {'density': 'Ionization'}},
+                                        {'profiles': {'density': 'MASa'},
+                                         'alt_profiles': {'density': 'VoLuMe'},
+                                         'alt_profiles': {'fraction': 'compLETION'}}])
+    def test_ho_pandas_variable_renaming_lowercase(self, values):
+        # check for pysat_testing2D instrument
+        if self.testInst.platform == 'pysat':
+            if self.testInst.name == 'testing2D':
+                self.testInst.load(2009, 1)
+                self.testInst.rename(values)
+                for key in values:
+                    for ikey in values[key]:
+                        # check column name unchanged
+                        assert key in self.testInst.data
+                        assert key in self.testInst.meta
+                        # check for new name in HO data
+                        assert values[key][ikey].lower() in self.testInst[0, key]
+                        check_var = self.testInst.meta[key]['children']
+                        # case insensitive check
+                        assert values[key][ikey] in check_var
+                        # ensure new case in there
+                        check_var = check_var[ikey].name
+                        assert values[key][ikey] == check_var
+                        # ensure old name not present
+                        assert ikey not in self.testInst[0, key]
+                        check_var = self.testInst.meta[key]['children']
+                        assert ikey not in check_var
 
     # --------------------------------------------------------------------------
     #

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -617,6 +617,51 @@ class TestBasics():
 
     # --------------------------------------------------------------------------
     #
+    # Test variable renaming
+    #
+    # --------------------------------------------------------------------------
+    def test_basic_variable_renaming(self):
+        # test single variable
+        self.testInst.load(2009, 1)
+        self.testInst.rename({'uts': 'uts1'})
+        assert 'uts1' in self.testInst.data
+        assert 'uts1' in self.testInst.meta
+        assert 'uts' not in self.testInst.data
+        assert 'uts' not in self.testInst.meta
+
+        # test multiple variables
+        self.testInst.rename({'uts1': 'uts2',
+                              'mlt': 'mlt2'})
+        assert 'uts2' in self.testInst.data
+        assert 'uts2' in self.testInst.meta
+        assert 'uts' not in self.testInst.data
+        assert 'uts' not in self.testInst.meta
+        assert 'uts1' not in self.testInst.data
+        assert 'uts1' not in self.testInst.meta
+
+        assert 'mlt2' in self.testInst.data
+        assert 'mlt2' in self.testInst.meta
+        assert 'mlt' not in self.testInst.data
+        assert 'mlt' not in self.testInst.meta
+
+        # check for error for unknown variable name
+        with pytest.raises(ValueError):
+            self.testInst.rename({'help': 'I need somebody'})
+
+    def test_ho_pandas_variable_renaming(self):
+        # check for pysat_testing2D instrument
+        if self.testInst.platform == 'pysat':
+            if self.testInst.name == 'testing2D':
+                self.testInst.rename({'profiles': {'density': 'utd'}})
+                assert 'profiles' in self.testInst.data
+                assert 'profiles' in self.testInst.meta
+                assert 'utd' in self.testInst.meta['profiles']['children']
+                assert 'utd' in self.testInst[0, 'profiles']
+                assert 'density' not in self.testInst.meta['profiles']['children']
+                assert 'density' not in self.testInst[0, 'profiles']
+
+    # --------------------------------------------------------------------------
+    #
     # Test iteration behaviors
     #
     # --------------------------------------------------------------------------

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -660,6 +660,10 @@ class TestBasics():
                 assert 'density' not in self.testInst.meta['profiles']['children']
                 assert 'density' not in self.testInst[0, 'profiles']
 
+                # check for error for unknown variable name
+                with pytest.raises(ValueError):
+                    self.testInst.rename({'profiles': {'help': 'I need somebody'}})
+
     # --------------------------------------------------------------------------
     #
     # Test iteration behaviors

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -668,8 +668,8 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [{'profiles': {'density': 'ionization'}},
                                         {'profiles': {'density': 'mass'},
-                                         'alt_profiles': {'density': 'volume'},
-                                         'alt_profiles': {'fraction': 'completion'}}])
+                                         'alt_profiles':
+                                             {'density': 'volume'}}])
     def test_ho_pandas_variable_renaming(self, values):
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':
@@ -690,13 +690,20 @@ class TestBasics():
                         check_var = self.testInst.meta[key]['children']
                         assert ikey not in check_var
 
-    @pytest.mark.parametrize("values", [{'profiles': {'help': 'I need somebody'}},
-                                        {'fake_profiles': {'help': 'Not just anybody'}},
-                                        {'wrong_profile': {'help': 'You know I need someone'},
-                                         'fake_profiles': {'Beatles': 'help!'},
-                                         'profiles': {'density': 'valid_change'}},
-                                        {'fake_profiles': {'density': 'valid HO change'}},
-                                        {'Nope_profiles': {'density': 'valid_HO_change'}}])
+    @pytest.mark.parametrize("values", [{'profiles':
+                                            {'help': 'I need somebody'}},
+                                        {'fake_profi':
+                                            {'help': 'Not just anybody'}},
+                                        {'wrong_profile':
+                                            {'help': 'You know I need someone'},
+                                         'fake_profiles':
+                                            {'Beatles': 'help!'},
+                                         'profiles':
+                                            {'density': 'valid_change'}},
+                                        {'fake_profile':
+                                            {'density': 'valid HO change'}},
+                                        {'Nope_profiles':
+                                            {'density': 'valid_HO_change'}}])
     def test_ho_pandas_unknown_variable_error_renaming(self, values):
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':
@@ -708,8 +715,8 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [{'profiles': {'density': 'Ionization'}},
                                         {'profiles': {'density': 'MASa'},
-                                         'alt_profiles': {'density': 'VoLuMe'},
-                                         'alt_profiles': {'fraction': 'compLETION'}}])
+                                         'alt_profiles':
+                                             {'density': 'VoLuMe'}}])
     def test_ho_pandas_variable_renaming_lowercase(self, values):
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':
@@ -722,7 +729,8 @@ class TestBasics():
                         assert key in self.testInst.data
                         assert key in self.testInst.meta
                         # check for new name in HO data
-                        assert values[key][ikey].lower() in self.testInst[0, key]
+                        test_val = values[key][ikey].lower()
+                        assert test_val in self.testInst[0, key]
                         check_var = self.testInst.meta[key]['children']
                         # case insensitive check
                         assert values[key][ikey] in check_var

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -620,6 +620,7 @@ class TestBasics():
     # Test variable renaming
     #
     # --------------------------------------------------------------------------
+
     def test_basic_variable_renaming(self):
         # test single variable
         self.testInst.load(2009, 1)
@@ -629,7 +630,9 @@ class TestBasics():
         assert 'uts' not in self.testInst.data
         assert 'uts' not in self.testInst.meta
 
+    def test_multiple_basic_variable_renaming(self):
         # test multiple variables
+        self.testInst.load(2009, 1)
         self.testInst.rename({'uts1': 'uts2',
                               'mlt': 'mlt2'})
         assert 'uts2' in self.testInst.data
@@ -644,7 +647,9 @@ class TestBasics():
         assert 'mlt' not in self.testInst.data
         assert 'mlt' not in self.testInst.meta
 
+    def test_unknown_variable_error_renaming(self):
         # check for error for unknown variable name
+        self.testInst.load(2009, 1)
         with pytest.raises(ValueError):
             self.testInst.rename({'help': 'I need somebody'})
 
@@ -652,6 +657,7 @@ class TestBasics():
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':
             if self.testInst.name == 'testing2D':
+                self.testInst.load(2009, 1)
                 self.testInst.rename({'profiles': {'density': 'utd'}})
                 assert 'profiles' in self.testInst.data
                 assert 'profiles' in self.testInst.meta
@@ -661,6 +667,11 @@ class TestBasics():
                 assert 'density' not in check_var
                 assert 'density' not in self.testInst[0, 'profiles']
 
+    def test_ho_pandas_unknown_variable_error_renaming(self):
+        # check for pysat_testing2D instrument
+        if self.testInst.platform == 'pysat':
+            if self.testInst.name == 'testing2D':
+                self.testInst.load(2009, 1)
                 # check for error for unknown variable name
                 with pytest.raises(ValueError):
                     sub_dict = {'help': 'I need somebody'}

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -647,7 +647,6 @@ class TestBasics():
         with pytest.raises(ValueError):
             self.testInst.rename(values)
 
-
     @pytest.mark.parametrize("values", [{'uts': 'UTS1'},
                                         {'uts': 'UTs2',
                                          'mlt': 'Mlt2'},
@@ -691,19 +690,19 @@ class TestBasics():
                         assert ikey not in check_var
 
     @pytest.mark.parametrize("values", [{'profiles':
-                                            {'help': 'I need somebody'}},
+                                        {'help': 'I need somebody'}},
                                         {'fake_profi':
-                                            {'help': 'Not just anybody'}},
+                                        {'help': 'Not just anybody'}},
                                         {'wrong_profile':
-                                            {'help': 'You know I need someone'},
+                                        {'help': 'You know I need someone'},
                                          'fake_profiles':
-                                            {'Beatles': 'help!'},
+                                        {'Beatles': 'help!'},
                                          'profiles':
-                                            {'density': 'valid_change'}},
+                                        {'density': 'valid_change'}},
                                         {'fake_profile':
-                                            {'density': 'valid HO change'}},
+                                        {'density': 'valid HO change'}},
                                         {'Nope_profiles':
-                                            {'density': 'valid_HO_change'}}])
+                                        {'density': 'valid_HO_change'}}])
     def test_ho_pandas_unknown_variable_error_renaming(self, values):
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -623,7 +623,8 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [{'uts': 'uts1'},
                                         {'uts': 'uts2',
-                                         'mlt': 'mlt2'}])
+                                         'mlt': 'mlt2'},
+                                        {'uts': 'long change with spaces'}])
     def test_basic_variable_renaming(self, values):
         # test single variable
         self.testInst.load(2009, 1)
@@ -636,11 +637,15 @@ class TestBasics():
             assert key not in self.testInst.data
             assert key not in self.testInst.meta
 
-    def test_unknown_variable_error_renaming(self):
+    @pytest.mark.parametrize("values", [{'help': 'I need somebody'},
+                                        {'UTS': 'litte_uts'},
+                                        {'utS': 'uts1'},
+                                        {'utS': 'uts'}])
+    def test_unknown_variable_error_renaming(self, values):
         # check for error for unknown variable name
         self.testInst.load(2009, 1)
         with pytest.raises(ValueError):
-            self.testInst.rename({'help': 'I need somebody'})
+            self.testInst.rename(values)
 
     @pytest.mark.parametrize("values", [{'profiles': {'density': 'ionization'}},
                                         {'profiles': {'density': 'mass'},
@@ -667,7 +672,12 @@ class TestBasics():
                         assert ikey not in check_var
 
     @pytest.mark.parametrize("values", [{'profiles': {'help': 'I need somebody'}},
-                                        {'fake_profiles': {'help': 'I need somebody'}}])
+                                        {'fake_profiles': {'help': 'Not just anybody'}},
+                                        {'wrong_profile': {'help': 'You know I need someone'},
+                                         'fake_profiles': {'Beatles': 'help!'},
+                                         'profiles': {'density': 'valid_change'}},
+                                        {'fake_profiles': {'density': 'valid HO change'}},
+                                        {'Nope_profiles': {'density': 'valid_HO_change'}}])
     def test_ho_pandas_unknown_variable_error_renaming(self, values):
         # check for pysat_testing2D instrument
         if self.testInst.platform == 'pysat':


### PR DESCRIPTION
# Description

Addresses #91 

Includes a .rename variable method attached to the Instrument object. Renames variables for both data and metadata, keeping both objects in sync. Includes support for changing the name of variables in higher-order datasets forced into pandas. Examples are included in the docstring.

This feature could be sneakily snaked into v2.2 to support changing ICON variables to something easier to work with.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

 - Developed new tests included in test_instrument
 - Ran pytests locally

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
