### PR TITLE
DEP: Add DeprecationWarning for nasa_cdaweb.list_files 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - spherical_to_cartesian
     - global_to_local_cartesian
     - local_horizontal_to_global_geo
+  - methods.nasa_cdaweb.list_files will move to methods.general.list_files in pysat 3.0.0.
 - Documentation
   - Fixed description of tag and sat_id behaviour in testing instruments
   - Added discussion of github install, develop branches, and reqs to docs

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -59,6 +59,7 @@ import numpy as np
 import pysat
 
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'cnofs'
 name = 'ivm'
@@ -71,7 +72,7 @@ _test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
 # use the default CDAWeb method
 fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # support load routine

--- a/pysat/instruments/cnofs_plp.py
+++ b/pysat/instruments/cnofs_plp.py
@@ -58,6 +58,7 @@ import numpy as np
 
 import pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'cnofs'
 name = 'plp'
@@ -70,7 +71,7 @@ _test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
 # use the default CDAWeb method
 fname = 'cnofs_plp_plasma_1sec_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 # support load routine
 # use the default CDAWeb method

--- a/pysat/instruments/cnofs_vefi.py
+++ b/pysat/instruments/cnofs_vefi.py
@@ -59,6 +59,7 @@ import numpy as np
 
 import pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'cnofs'
 name = 'vefi'
@@ -70,7 +71,7 @@ _test_dates = {'': {'dc_b': pysat.datetime(2009, 1, 1)}}
 # use the default CDAWeb method
 fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
 supported_tags = {'': {'dc_b': fname}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 # support load routine
 # use the default CDAWeb method

--- a/pysat/instruments/de2_lang.py
+++ b/pysat/instruments/de2_lang.py
@@ -62,7 +62,8 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'de2'
 name = 'lang'
@@ -75,7 +76,7 @@ fname = 'de2_plasma500ms_lang_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # use the default CDAWeb method

--- a/pysat/instruments/de2_nacs.py
+++ b/pysat/instruments/de2_nacs.py
@@ -87,7 +87,8 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'de2'
 name = 'nacs'
@@ -100,7 +101,7 @@ fname = 'de2_neutral1s_nacs_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # use the default CDAWeb method

--- a/pysat/instruments/de2_rpa.py
+++ b/pysat/instruments/de2_rpa.py
@@ -72,7 +72,8 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'de2'
 name = 'rpa'
@@ -85,7 +86,7 @@ fname = 'de2_ion2s_rpa_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # use the default CDAWeb method

--- a/pysat/instruments/de2_wats.py
+++ b/pysat/instruments/de2_wats.py
@@ -84,7 +84,8 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-from .methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'de2'
 name = 'wats'
@@ -97,7 +98,7 @@ fname = 'de2_wind2s_wats_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
 
 # use the CDAWeb methods list files routine
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # use the default CDAWeb method

--- a/pysat/instruments/iss_fpmu.py
+++ b/pysat/instruments/iss_fpmu.py
@@ -29,6 +29,7 @@ import numpy as np
 import pysat
 
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'iss'
 name = 'fpmu'
@@ -40,7 +41,7 @@ _test_dates = {'': {'': pysat.datetime(2017, 10, 1)}}
 # use the default CDAWeb method
 fname = 'iss_sp_fpmu_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 # support load routine
 # use the default CDAWeb method

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -4,11 +4,11 @@
 
 from __future__ import absolute_import, division, print_function
 
+import logging
 import pandas as pds
 
 import pysat
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -36,12 +36,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
     supported_tags : (dict or NoneType)
         keys are sat_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
-    fake_daily_files_from_monthly : bool
+    fake_daily_files_from_monthly : (bool)
         Some CDAWeb instrument data files are stored by month, interfering
         with pysat's functionality of loading by day. This flag, when true,
         appends daily dates to monthly files internally. These dates are
         used by load routine in this module to provide data by day.
-    two_digit_year_break : int
+    two_digit_year_break : (int)
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -55,12 +55,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
     --------
     ::
 
-        fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+        fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
         supported_tags = {'dc_b': fname}
         list_files = functools.partial(nasa_cdaweb.list_files,
                                        supported_tags=supported_tags)
 
-        fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
         supported_tags = {'': fname}
         list_files = functools.partial(mm_gen.list_files,
                                        supported_tags=supported_tags)

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+"""Provides generalized routines for integrating instruments into pysat.
+"""
+
+from __future__ import absolute_import, division, print_function
+
+import pandas as pds
+
+import pysat
+
+import logging
+logger = logging.getLogger(__name__)
+
+
+def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
+               supported_tags=None, fake_daily_files_from_monthly=False,
+               two_digit_year_break=None):
+    """Return a Pandas Series of every file for chosen satellite data.
+
+    This routine provides a standard interfacefor pysat instrument modules.
+
+    Parameters
+    -----------
+    tag : (string or NoneType)
+        Denotes type of file to load.  Accepted types are <tag strings>.
+        (default=None)
+    sat_id : (string or NoneType)
+        Specifies the satellite ID for a constellation.  Not used.
+        (default=None)
+    data_path : (string or NoneType)
+        Path to data directory.  If None is specified, the value previously
+        set in Instrument.files.data_path is used.  (default=None)
+    format_str : (string or NoneType)
+        User specified file format.  If None is specified, the default
+        formats associated with the supplied tags are used. (default=None)
+    supported_tags : (dict or NoneType)
+        keys are sat_id, each containing a dict keyed by tag
+        where the values file format template strings. (default=None)
+    fake_daily_files_from_monthly : bool
+        Some CDAWeb instrument data files are stored by month, interfering
+        with pysat's functionality of loading by day. This flag, when true,
+        appends daily dates to monthly files internally. These dates are
+        used by load routine in this module to provide data by day.
+    two_digit_year_break : int
+        If filenames only store two digits for the year, then
+        '1900' will be added for years >= two_digit_year_break
+        and '2000' will be added for years < two_digit_year_break.
+
+    Returns
+    --------
+    pysat.Files.from_os : (pysat._files.Files)
+        A class containing the verified available files
+
+    Examples
+    --------
+    ::
+
+        fname = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+        supported_tags = {'dc_b': fname}
+        list_files = functools.partial(nasa_cdaweb.list_files,
+                                       supported_tags=supported_tags)
+
+        fname = 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        supported_tags = {'': fname}
+        list_files = functools.partial(mm_gen.list_files,
+                                       supported_tags=supported_tags)
+
+    """
+
+    if data_path is not None:
+        if format_str is None:
+            try:
+                format_str = supported_tags[sat_id][tag]
+            except KeyError as estr:
+                raise ValueError(' '.join(('Unknown sat_id or tag:',
+                                           str(estr))))
+        out = pysat.Files.from_os(data_path=data_path,
+                                  format_str=format_str)
+
+        if (not out.empty) and fake_daily_files_from_monthly:
+            out.loc[out.index[-1] + pds.DateOffset(months=1)
+                    - pds.DateOffset(days=1)] = out.iloc[-1]
+            out = out.asfreq('D', 'pad')
+            out = out + '_' + out.index.strftime('%Y-%m-%d')
+            return out
+
+        return out
+    else:
+        estr = ''.join(('A directory must be passed to the loading routine ',
+                        'for <Instrument Code>'))
+        raise ValueError(estr)

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -43,12 +43,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
     supported_tags : (dict or NoneType)
         keys are sat_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
-    fake_daily_files_from_monthly : bool
+    fake_daily_files_from_monthly : (bool)
         Some CDAWeb instrument data files are stored by month, interfering
         with pysat's functionality of loading by day. This flag, when true,
         appends daily dates to monthly files internally. These dates are
         used by load routine in this module to provide data by day.
-    two_digit_year_break : int
+    two_digit_year_break : (int)
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.
@@ -74,16 +74,14 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
 
     Note
     ----
-    This function will move to pysat.instruments.methods.general.list_files in
-    pysat 3.0.0.  This will not affect the core instruments, but will need to
-    be updated for custom instruments that use this method.
+    This function has been deprecated and will be removed in pysat 3.0.0.
+    Please use methods.general.list_files instead
 
     """
 
-    warnings.warn(' '.join(["methods.nasa_cdaweb.list_files will be",
-                            "moved to methods.general.list_files in pysat",
-                            "3.0.0. This only affects custom instruments",
-                            "not in the standard pysat distribution."]),
+    warnings.warn(' '.join(["methods.nasa_cdaweb.list_files has been",
+                            "deprecated and will be removed in pysat 3.0.0.",
+                            "Please use methods.general.list_files instead"]),
                   DeprecationWarning, stacklevel=2)
 
     out = mm_gen.list_files(tag=tag, sat_id=sat_id, data_path=data_path,

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -12,6 +12,7 @@ import warnings
 import pandas as pds
 
 import pysat
+from pysat.instruments.methods import general as mm_gen
 
 import logging
 logger = logging.getLogger(__name__)
@@ -85,27 +86,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                             "not in the standard pysat distribution."]),
                   DeprecationWarning, stacklevel=2)
 
-    if data_path is not None:
-        if format_str is None:
-            try:
-                format_str = supported_tags[sat_id][tag]
-            except KeyError as estr:
-                raise ValueError('Unknown sat_id or tag: ' + estr)
-        out = pysat.Files.from_os(data_path=data_path,
-                                  format_str=format_str)
-
-        if (not out.empty) and fake_daily_files_from_monthly:
-            out.loc[out.index[-1] + pds.DateOffset(months=1)
-                    - pds.DateOffset(days=1)] = out.iloc[-1]
-            out = out.asfreq('D', 'pad')
-            out = out + '_' + out.index.strftime('%Y-%m-%d')
-            return out
-
-        return out
-    else:
-        estr = ''.join(('A directory must be passed to the loading routine ',
-                        'for <Instrument Code>'))
-        raise ValueError(estr)
+    out = mm_gen.list_files(tag=tag, sat_id=sat_id, data_path=data_path,
+                            format_str=format_str,
+                            supported_tags=supported_tags,
+                            fake_daily_files_from_monthly=fake_daily_files_from_monthly,
+                            two_digit_year_break=two_digit_year_break)
+    return out
 
 
 def load(fnames, tag=None, sat_id=None,

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -6,6 +6,7 @@ intervention.
 """
 
 from __future__ import absolute_import, division, print_function
+import logging
 import sys
 import warnings
 
@@ -14,7 +15,6 @@ import pandas as pds
 import pysat
 from pysat.instruments.methods import general as mm_gen
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -7,6 +7,7 @@ intervention.
 
 from __future__ import absolute_import, division, print_function
 import sys
+import warnings
 
 import pandas as pds
 
@@ -71,6 +72,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                                        supported_tags=supported_tags)
 
     """
+
+    warnings.warn(' '.join(["methods.nasa_cdaweb.list_files will be",
+                            "moved to methods.general.list_files in pysat",
+                            "3.0.0. This only affects custom instruments",
+                            "not in the standard pysat distribution."]),
+                  DeprecationWarning, stacklevel=2)
 
     if data_path is not None:
         if format_str is None:

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -71,6 +71,12 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         list_files = functools.partial(cdw.list_files,
                                        supported_tags=supported_tags)
 
+    Note
+    ----
+    This function will move to pysat.instruments.methods.general.list_files in
+    pysat 3.0.0.  This will not affect the core instruments, but will need to
+    be updated for custom instruments that use this method.
+
     """
 
     warnings.warn(' '.join(["methods.nasa_cdaweb.list_files will be",

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -49,6 +49,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 
 import functools
+import logging
 import numpy as np
 import pandas as pds
 
@@ -56,7 +57,6 @@ import pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
 from pysat.instruments.methods import general as mm_gen
 
-import logging
 logger = logging.getLogger(__name__)
 
 platform = 'omni'

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -54,6 +54,7 @@ import pandas as pds
 
 import pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 import logging
 logger = logging.getLogger(__name__)
@@ -72,7 +73,7 @@ fname1 = 'omni_hro_1min_{year:4d}{month:02d}{day:02d}_v01.cdf'
 fname5 = 'omni_hro_5min_{year:4d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'1min': fname1,
                        '5min': fname5}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
                                fake_daily_files_from_monthly=True)
 

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -32,6 +32,7 @@ import warnings
 import pysat
 
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 platform = 'rocsat1'
 name = 'ivm'
@@ -44,7 +45,7 @@ _test_dates = {'': {'': pysat.datetime(2002, 1, 1)}}
 # use the default CDAWeb method
 fname = 'rs_k0_ipei_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 # support load routine
 # use the default CDAWeb method

--- a/pysat/instruments/timed_saber.py
+++ b/pysat/instruments/timed_saber.py
@@ -56,6 +56,7 @@ import functools
 import pysat
 # CDAWeb methods prewritten for pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 # the platform and name strings associated with this instrument
 # need to be defined at the top level
@@ -101,7 +102,7 @@ supported_tags = {'': {'': fname}}
 # use the CDAWeb methods list files routine
 # the command below presets some of the methods inputs, leaving
 # those provided by pysat available when invoked
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # let pysat know that data is spread across more than one file

--- a/pysat/instruments/timed_see.py
+++ b/pysat/instruments/timed_see.py
@@ -42,6 +42,7 @@ import functools
 
 import pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 # include basic instrument info
 platform = 'timed'
@@ -55,7 +56,7 @@ _test_dates = {'': {'': pysat.datetime(2009, 1, 1)}}
 # use the default CDAWeb method
 fname = 'timed_l3a_see_{year:04d}{month:02d}{day:02d}_v01.cdf'
 supported_tags = {'': {'': fname}}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags,
                                fake_daily_files_from_monthly=True)
 

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -42,3 +42,19 @@ class TestCDAWeb():
 
         assert len(war) >= 1
         assert war[0].category == DeprecationWarning
+
+    def test_list_files_deprecation_warning(self):
+        """Test generation of deprecation warning for remote_file_list kwargs
+        """
+        warnings.simplefilter("always")
+
+        with warnings.catch_warnings(record=True) as war:
+            # testing with single day since we just need the warning
+            try:
+                pysat.instruments.methods.nasa_cdaweb.list_files()
+            except ValueError:
+                # Using default tags will produce a ValueError
+                pass
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -48,7 +48,7 @@ class TestCDAWeb():
         """
         warnings.simplefilter("always")
 
-        with warnings.catch_warnings(record=True) as war:
+        with warnings.catch_warnings(record=True) as war1:
             # testing with single day since we just need the warning
             try:
                 pysat.instruments.methods.nasa_cdaweb.list_files()
@@ -56,5 +56,14 @@ class TestCDAWeb():
                 # Using default tags will produce a ValueError
                 pass
 
-        assert len(war) >= 1
-        assert war[0].category == DeprecationWarning
+        with warnings.catch_warnings(record=True) as war2:
+            # testing with single day since we just need the warning
+            try:
+                pysat.instruments.methods.general.list_files()
+            except ValueError:
+                # Using default tags will produce a ValueError
+                pass
+
+        assert len(war1) >= 1
+        assert war1[0].category == DeprecationWarning
+        assert len(war2) == 0


### PR DESCRIPTION
# Description

As part of the pysat 3.0.0 overhaul, the `list_files` routine from `instruments.methods.nasa_cdaweb` has been moved to `instruments.methods.general`.  While this change should not affect standard users, in theory it could affect users with custom instruments.  This will be frequently called, so I'm not sure we want it to be thrown every time.  Thoughts?

EDIT: After discussion, moving the method `'list_files` to general now, but leaving a method with the same name in the cdaweb methods to throw a DeprecationWarning and then call the new method.  This allows for a smoother transition, while only using a DeprecationWarning when needed.  Updating current instruments to use the new method, except for ICON instruments, which will be handled in #457.

## Type of change

- New warning

# How Has This Been Tested?
```
            try:
                pysat.instruments.methods.nasa_cdaweb.list_files()
            except ValueError:
                # Using default tags will produce a ValueError
                pass
```
should produce a deprecation warning.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
