### PR TITLE
STY: streamline keep_original_names in icon instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Update ICON instrument file structure
    - Added NaN filter for metadata when writing netCDF4 files
    - Test instruments now part of compiled package for development elsewhere
+   - Custom instrument keywords and defaults are now always found in inst.kwargs
 - Deprecation Warning
   - custom.add will be renamed custom.attach in pysat 3.0.0
   - Several functions in coords will be removed in pysat 3.0.0.  These functions will move to pysatMadrigal

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -359,8 +359,14 @@ class Instrument(object):
         # store kwargs, passed to load routine
         # first, check if keywords are  valid
         _check_if_keywords_supported(self._load_rtn, **kwargs)
-        # store
+        # get and apply default values for custom keywords
+        default_keywords = _get_supported_keywords(self._load_rtn)
+        # store user supplied keywords
         self.kwargs = kwargs
+        # add in defaults if not already present
+        for key in default_keywords.keys():
+            if key not in self.kwargs:
+                self.kwargs[key] = default_keywords[key]
 
         # run instrument init function, a basic pass function is used
         # if user doesn't supply the init function
@@ -2639,7 +2645,7 @@ class Instrument(object):
 
 
 def _get_supported_keywords(load_func):
-    """Return a list of supported keywords
+    """Return a dict of supported keywords and defaults
 
     Intended to be used on the supporting instrument
     functions that enable the general Instrument object
@@ -2652,8 +2658,8 @@ def _get_supported_keywords(load_func):
 
     Returns
     -------
-    list
-        list of keyword argument strings
+    dict
+        dict of keywords and values
 
 
     Notes
@@ -2682,12 +2688,28 @@ def _get_supported_keywords(load_func):
         sig = inspect.getfullargspec(load_func)
         # args are first
         args = sig.args
+        # default values
+        defaults = sig.defaults
+    # deal with special cases for defaults
+    # we get defaults=None when the empty pysat.Instrument() is created
+    if defaults is None:
+        defaults = []
+    else:
+        # standard case
+        # make defaults a list
+        temp = []
+        for item in defaults:
+            temp.append(item)
+        defaults = temp
 
     pop_list = []
     # account for keywords that exist for every load function
     pre_kws = ['fnames', 'sat_id', 'tag']
+    # insert 'missing' default for 'fnames'
+    defaults.insert(0, None)
     # account for keywords already set since input was a partial function
     if existing_kws is not None:
+        # keywords
         pre_kws.extend(existing_kws.keys())
     # remove pre-existing keywords from output
     # first identify locations
@@ -2700,9 +2722,13 @@ def _get_supported_keywords(load_func):
     if len(pop_list) > 0:
         for pop in pop_list[::-1]:
             args.pop(pop)
+            defaults.pop(pop)
 
-    # *args and **kwargs are not required, so ignore them.
-    return args
+    out_dict = {}
+    for arg, defa in zip(args, defaults):
+        out_dict[arg] = defa
+
+    return out_dict
 
 
 def _check_if_keywords_supported(func, **kwargs):
@@ -2722,7 +2748,7 @@ def _check_if_keywords_supported(func, **kwargs):
 
     """
 
-    # get list of supported keywords
+    # get dict of supported keywords and values
     supp = _get_supported_keywords(func)
     # check if kwargs are in list
     for name in kwargs.keys():

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -115,12 +115,11 @@ def default(inst):
     """
 
     mm_gen.convert_timestamp_to_datetime(inst, sec_mult=1.0e-3)
-    if (('keep_original_names' not in inst.kwargs)
-            or (not inst.kwargs['keep_original_names'])):
+    if not inst.kwargs['keep_original_names']:
         mm_gen.remove_leading_text(inst, target='ICON_L26_')
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=None):
+def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     """Loads ICON EUV data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -99,11 +99,6 @@ def init(inst):
     inst.meta.acknowledgements = mm_icon.ackn_str
     inst.meta.references = ''.join((mm_icon.refs['mission'],
                                     mm_icon.refs['euv']))
-    # set default value for keep_original_names if unspecified
-    if 'keep_original_names' in inst.kwargs.keys():
-        inst.keep_original_names = inst.kwargs['keep_original_names']
-    else:
-        inst.keep_original_names = False
 
     pass
 
@@ -120,7 +115,8 @@ def default(inst):
     """
 
     mm_gen.convert_timestamp_to_datetime(inst, sec_mult=1.0e-3)
-    if not inst.keep_original_names:
+    if (('keep_original_names' not in inst.kwargs)
+            or (not inst.kwargs['keep_original_names'])):
         mm_gen.remove_leading_text(inst, target='ICON_L26_')
 
 
@@ -211,7 +207,10 @@ def clean(inst, clean_level=None):
 
     """
 
-    L26_Flag = inst['Flags']
+    try:
+        L26_Flag = inst['Flags']
+    except KeyError:
+        L26_Flag = inst['ICON_L26_Flags']
     vars = ['HmF2', 'NmF2', 'Oplus']
 
     if clean_level == 'clean':

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -136,11 +136,9 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     sat_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    **kwargs : extra keywords
-        Passthrough for additional keyword arguments specified when
-        instantiating an Instrument object. These additional keywords
-        are passed through to this routine by pysat.  Default values are
-        specified in the init routine.
+    keep_original_names : boolean
+        if True then the names as given in the netCDF ICON file
+        will be used as is. If False, a preamble is removed.
 
     Returns
     -------

--- a/pysat/instruments/icon_fuv.py
+++ b/pysat/instruments/icon_fuv.py
@@ -161,7 +161,6 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     keep_original_names : boolean
         if True then the names as given in the netCDF ICON file
         will be used as is. If False, a preamble is removed.
-        This keyword must be set at instantiation.
 
     Returns
     -------

--- a/pysat/instruments/icon_fuv.py
+++ b/pysat/instruments/icon_fuv.py
@@ -114,11 +114,6 @@ def init(inst):
     inst.meta.acknowledgements = mm_icon.ackn_str
     inst.meta.references = ''.join((mm_icon.refs['mission'],
                                     mm_icon.refs['fuv']))
-    # if 'keep_original_names' in inst.kwargs.keys():
-    #     inst.keep_original_names = inst.kwargs['keep_original_names']
-    # else:
-    #     inst.keep_original_names = False
-
     pass
 
 
@@ -134,9 +129,9 @@ def default(inst):
     """
 
     mm_gen.convert_timestamp_to_datetime(inst, sec_mult=1.0e-3)
-    if 'keep_original_names' in inst.kwargs:
-        if not inst.kwargs['keep_original_names']:
-            remove_preamble(inst)
+    if (('keep_original_names' not in inst.kwargs)
+            or (not inst.kwargs['keep_original_names'])):
+        remove_preamble(inst)
 
 
 def remove_preamble(inst):

--- a/pysat/instruments/icon_fuv.py
+++ b/pysat/instruments/icon_fuv.py
@@ -129,8 +129,7 @@ def default(inst):
     """
 
     mm_gen.convert_timestamp_to_datetime(inst, sec_mult=1.0e-3)
-    if (('keep_original_names' not in inst.kwargs)
-            or (not inst.kwargs['keep_original_names'])):
+    if not inst.kwargs['keep_original_names']:
         remove_preamble(inst)
 
 

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -154,11 +154,9 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     sat_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    **kwargs : extra keywords
-        Passthrough for additional keyword arguments specified when
-        instantiating an Instrument object. These additional keywords
-        are passed through to this routine by pysat.  Default values are
-        specified in the init routine.
+    keep_original_names : boolean
+        if True then the names as given in the netCDF ICON file
+        will be used as is. If False, a preamble is removed.
 
     Returns
     -------

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -119,10 +119,6 @@ def init(inst):
     inst.meta.acknowledgements = mm_icon.ackn_str
     inst.meta.references = ''.join((mm_icon.refs['mission'],
                                     mm_icon.refs['ivm']))
-    if 'keep_original_names' in inst.kwargs.keys():
-        inst.keep_original_names = inst.kwargs['keep_original_names']
-    else:
-        inst.keep_original_names = False
 
     pass
 
@@ -137,7 +133,8 @@ def default(inst):
         Instrument class object
 
     """
-    if not inst.keep_original_names:
+    if (('keep_original_names' not in inst.kwargs)
+            or (not inst.kwargs['keep_original_names'])):
         mm_gen.remove_leading_text(inst, target='ICON_L27_')
 
 

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -133,12 +133,11 @@ def default(inst):
         Instrument class object
 
     """
-    if (('keep_original_names' not in inst.kwargs)
-            or (not inst.kwargs['keep_original_names'])):
+    if not inst.kwargs['keep_original_names']:
         mm_gen.remove_leading_text(inst, target='ICON_L27_')
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=None):
+def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     """Loads ICON IVM data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -153,10 +153,6 @@ def init(inst):
     inst.meta.acknowledgements = mm_icon.ackn_str
     inst.meta.references = ''.join((mm_icon.refs['mission'],
                                     mm_icon.refs['mighti']))
-    if 'keep_original_names' in inst.kwargs.keys():
-        inst.keep_original_names = inst.kwargs['keep_original_names']
-    else:
-        inst.keep_original_names = False
 
     pass
 
@@ -168,7 +164,8 @@ def default(inst):
     """
 
     mm_gen.convert_timestamp_to_datetime(inst, sec_mult=1.0e-3)
-    if not inst.keep_original_names:
+    if (('keep_original_names' not in inst.kwargs)
+            or (not inst.kwargs['keep_original_names'])):
         remove_preamble(inst)
 
 

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -164,8 +164,7 @@ def default(inst):
     """
 
     mm_gen.convert_timestamp_to_datetime(inst, sec_mult=1.0e-3)
-    if (('keep_original_names' not in inst.kwargs)
-            or (not inst.kwargs['keep_original_names'])):
+    if not inst.kwargs['keep_original_names']:
         remove_preamble(inst)
 
 
@@ -186,7 +185,7 @@ def remove_preamble(inst):
     return
 
 
-def load(fnames, tag=None, sat_id=None, keep_original_names=None):
+def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     """Loads ICON FUV data using pysat into pandas.
 
     This routine is called as needed by pysat. It is not intended

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -202,11 +202,9 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     sat_id : string
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself.
-    **kwargs : extra keywords
-        Passthrough for additional keyword arguments specified when
-        instantiating an Instrument object. These additional keywords
-        are passed through to this routine by pysat.  Default values are
-        specified in the init routine.
+    keep_original_names : boolean
+        if True then the names as given in the netCDF ICON file
+        will be used as is. If False, a preamble is removed.
 
     Returns
     -------

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -46,11 +46,6 @@ def init(self):
     ----------
     inst : pysat.Instrument
         This object
-    file_date_range : (pds.date_range)
-        Optional keyword argument that specifies the range of dates for which
-        test files will be created
-    mangle_file_dates : bool
-        If True, the loaded file list time index is shifted by 5-minutes.
 
     Returns
     --------
@@ -63,7 +58,7 @@ def init(self):
     self.new_thing = True
 
     # work on file index if keyword present
-    if 'file_date_range' in self.kwargs:
+    if self.kwargs['file_date_range'] is not None:
         # set list files routine to desired date range
         # attach to the instrument object
         fdr = self.kwargs['file_date_range']
@@ -71,10 +66,9 @@ def init(self):
         self.files.refresh()
 
     # mess with file dates if kwarg option present
-    if 'mangle_file_dates' in self.kwargs:
-        if self.kwargs['mangle_file_dates']:
-            self.files.files.index = \
-                self.files.files.index + pds.DateOffset(minutes=5)
+    if self.kwargs['mangle_file_dates']:
+        self.files.files.index = \
+            self.files.files.index + pds.DateOffset(minutes=5)
 
 
 def default(self):
@@ -101,7 +95,7 @@ def default(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, file_date_range=None,
-         malformed_index=False, mangle_file_dates=False, **kwargs):
+         malformed_index=False, mangle_file_dates=False):
     """ Loads the test files
 
     Parameters
@@ -124,7 +118,7 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         Optional central date, uses _test_dates if not specified.
         (default=None)
     file_date_range : (pds.date_range or NoneType)
-        Range of dates for files or None, if this optional arguement is not
+        Range of dates for files or None, if this optional argument is not
         used. Shift actually performed by the init function.
         (default=None)
     malformed_index : bool (default=False)
@@ -132,9 +126,6 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     mangle_file_dates : bool
         If True, the loaded file list time index is shifted by 5-minutes.
         This shift is actually performed by the init function.
-    **kwargs : Additional keywords
-        Additional keyword arguments supplied at pyast.Instrument instantiation
-        are passed here
 
     Returns
     -------


### PR DESCRIPTION
# Description

Opening a new pull for this discussion.  This should push it closer to @rstoneback's syntax, but assuming that the default is to remove the file names.

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally by loading each instrument.  Example:
```
 sat_ids = {'': ['vector_wind_green', 'vector_wind_red'], 
            'a': ['los_wind_green', 'los_wind_red', 'temperature'], 
            'b': ['los_wind_green', 'los_wind_red', 'temperature']}  
for sat_id in sat_ids.keys(): 
    for tag in sat_ids[sat_id]: 
        inst = pysat.Instrument('icon', 'mighti', sat_id=sat_id, tag=tag, keep_original_names=True) 
        inst.load(2020, 2) 
        print(inst) 
for sat_id in sat_ids.keys(): 
    for tag in sat_ids[sat_id]: 
        inst = pysat.Instrument('icon', 'mighti', sat_id=sat_id, tag=tag) 
        inst.load(2020, 2) 
        print(inst) 
```
The first round of tests should have the original names.  The second round should have dropped the prefixes.

**Test Configuration**:
* Mac OS X 10.15.4
* python 3.7.3

# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``master``) branch
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
