### PR TITLE
BUG: clean not run in icon -- 3.0 version

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -578,8 +578,8 @@ class Instrument(object):
                 indict = {}
                 for i, dim in enumerate(self[key[-1]].dims):
                     indict[dim] = key[i]
-                    # if dim == 'Epoch':
-                    #     indict[dim] = self.index[key[i]]
+                    if dim == epoch_name:
+                        indict[dim] = self.index[key[i]]
                 try:
                     self.data[key[-1]].loc[indict] = in_data
                 except:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -578,8 +578,6 @@ class Instrument(object):
                 indict = {}
                 for i, dim in enumerate(self[key[-1]].dims):
                     indict[dim] = key[i]
-                    if dim == epoch_name:
-                        indict[dim] = self.index[key[i]]
                 try:
                     self.data[key[-1]].loc[indict] = in_data
                 except:

--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -9,7 +9,7 @@ is contained within a subpackage of this set.
 __all__ = ['champ_star', 'cnofs_ivm', 'cnofs_plp', 'cnofs_vefi', 'cosmic_gps',
            'de2_lang', 'de2_nacs', 'de2_rpa', 'de2_wats',
            'demeter_iap',
-           'icon_ivm', 'icon_euv', 'icon_fuv', 'icon_mighti',
+           'icon_euv', 'icon_fuv', 'icon_ivm', 'icon_mighti',
            'iss_fpmu', 'omni_hro', 'rocsat1_ivm',
            'sport_ivm', 'superdarn_grdex', 'supermag_magnetometer',
            'sw_dst', 'sw_kp', 'sw_f107', 'timed_saber', 'timed_see',

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -46,7 +46,6 @@ from __future__ import absolute_import
 import datetime as dt
 import functools
 import logging
-import numpy as np
 
 import pysat
 from pysat.instruments.methods import general as mm_gen
@@ -205,16 +204,13 @@ def clean(inst):
         vars = ['ICON_L26_' + x for x in vars]
 
     if inst.clean_level == 'clean':
-        idx, = np.where(inst[icon_flag] > 0)
         for var in vars:
-            inst[idx, :, var] = np.nan
+            inst[var] = inst[var].where(inst[icon_flag] == 0)
     elif inst.clean_level == 'dusty':
-        idx, = np.where(inst[icon_flag] > 1)
         for var in vars:
-            inst[idx, :, var] = np.nan
+                inst[var] = inst[var].where(inst[icon_flag] <= 1)
     elif inst.clean_level == 'dirty':
-        idx, = np.where(inst[icon_flag] > 2)
         for var in vars:
-            inst[idx, :, var] = np.nan
+            inst[var] = inst[var].where(inst[icon_flag] <= 2)
 
     return

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -197,10 +197,9 @@ def clean(inst):
 
     """
 
-
     vars = ['HmF2', 'NmF2', 'Oplus']
     if 'Flags' in inst.variables:
-            icon_flag = 'Flags'
+        icon_flag = 'Flags'
     else:
         icon_flag = 'ICON_L26_Flags'
         vars = ['ICON_L26_' + x for x in vars]

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -208,14 +208,13 @@ def clean(inst):
         icon_flag = 'ICON_L26_Flags'
         vars = ['ICON_L26_' + x for x in vars]
 
-    if inst.clean_level == 'clean':
+    min_val = {'clean': 1.0,
+               'dusty': 2.0}
+    if inst.clean_level in ['clean', 'dusty']:
         for var in vars:
-            inst[var] = inst[var].where(inst[icon_flag] == 0)
-    elif inst.clean_level == 'dusty':
-        for var in vars:
-            inst[var] = inst[var].where(inst[icon_flag] <= 1)
-    elif inst.clean_level == 'dirty':
-        for var in vars:
-            inst[var] = inst[var].where(inst[icon_flag] <= 2)
-
+            inst[var] = inst[var].where(inst[icon_flag]
+                                        <= min_val[inst.clean_level])
+    else:
+        # dirty and worse lets everything through
+        pass
     return

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -207,14 +207,14 @@ def clean(inst):
     if inst.clean_level == 'clean':
         idx, = np.where(inst[icon_flag] > 0)
         for var in vars:
-            inst[idx, var] = np.nan
+            inst[idx, :, var] = np.nan
     elif inst.clean_level == 'dusty':
         idx, = np.where(inst[icon_flag] > 1)
         for var in vars:
-            inst[idx, vars] = np.nan
+            inst[idx, :, var] = np.nan
     elif inst.clean_level == 'dirty':
         idx, = np.where(inst[icon_flag] > 2)
         for var in vars:
-            inst[idx, vars] = np.nan
+            inst[idx, :, var] = np.nan
 
     return

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -197,20 +197,25 @@ def clean(inst):
 
     """
 
-    try:
-        L26_Flag = inst['Flags']
-    except KeyError:
-        L26_Flag = inst['ICON_L26_Flags']
+
     vars = ['HmF2', 'NmF2', 'Oplus']
+    if 'Flags' in inst.variables:
+            icon_flag = 'Flags'
+    else:
+        icon_flag = 'ICON_L26_Flags'
+        vars = ['ICON_L26_' + x for x in vars]
 
     if inst.clean_level == 'clean':
-        idx, = np.where(L26_Flag > 0)
-        inst[idx, vars] = np.nan
+        idx, = np.where(inst[icon_flag] > 0)
+        for var in vars:
+            inst[idx, var] = np.nan
     elif inst.clean_level == 'dusty':
-        idx, = np.where(L26_Flag > 1)
-        inst[idx, vars] = np.nan
+        idx, = np.where(inst[icon_flag] > 1)
+        for var in vars:
+            inst[idx, vars] = np.nan
     elif inst.clean_level == 'dirty':
-        idx, = np.where(L26_Flag > 2)
-        inst[idx, vars] = np.nan
+        idx, = np.where(inst[icon_flag] > 2)
+        for var in vars:
+            inst[idx, vars] = np.nan
 
     return

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -171,7 +171,9 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
                                            max_label='ValidMax',
                                            fill_label='FillVal',
                                            pandas_format=pandas_format)
-    data = data.rename_dims(dims_dict={'Altitude': 'Alt'})
+    # xarray can't merge if variable and dim names are the same
+    if 'Altitude' in data.dims:
+        data = data.rename_dims(dims_dict={'Altitude': 'Alt'})
     return data, mdata
 
 

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -148,6 +148,9 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
     Any additional keyword arguments passed to pysat.Instrument
     upon instantiation are passed along to this routine.
 
+    The 'Altitude' dimension is renamed as 'Alt' to avoid confusion with the
+    'Altitude' variable when performing xarray operations
+
     Examples
     --------
     ::
@@ -156,18 +159,20 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
 
     """
 
-    return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch',
-                                    units_label='Units',
-                                    name_label='Long_Name',
-                                    notes_label='Var_Notes',
-                                    desc_label='CatDesc',
-                                    plot_label='FieldNam',
-                                    axis_label='LablAxis',
-                                    scale_label='ScaleTyp',
-                                    min_label='ValidMin',
-                                    max_label='ValidMax',
-                                    fill_label='FillVal',
-                                    pandas_format=pandas_format)
+    data, mdata = pysat.utils.load_netcdf4(fnames, epoch_name='Epoch',
+                                           units_label='Units',
+                                           name_label='Long_Name',
+                                           notes_label='Var_Notes',
+                                           desc_label='CatDesc',
+                                           plot_label='FieldNam',
+                                           axis_label='LablAxis',
+                                           scale_label='ScaleTyp',
+                                           min_label='ValidMin',
+                                           max_label='ValidMax',
+                                           fill_label='FillVal',
+                                           pandas_format=pandas_format)
+    data = data.rename_dims(dims_dict={'Altitude': 'Alt'})
+    return data, mdata
 
 
 def clean(inst):
@@ -208,7 +213,7 @@ def clean(inst):
             inst[var] = inst[var].where(inst[icon_flag] == 0)
     elif inst.clean_level == 'dusty':
         for var in vars:
-                inst[var] = inst[var].where(inst[icon_flag] <= 1)
+            inst[var] = inst[var].where(inst[icon_flag] <= 1)
     elif inst.clean_level == 'dirty':
         for var in vars:
             inst[var] = inst[var].where(inst[icon_flag] <= 2)

--- a/pysat/instruments/icon_euv.py
+++ b/pysat/instruments/icon_euv.py
@@ -171,7 +171,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
                                     pandas_format=pandas_format)
 
 
-def clean(inst, clean_level=None):
+def clean(inst):
     """Provides data cleaning based upon clean_level.
 
     clean_level is set upon Instrument instantiation to
@@ -190,11 +190,6 @@ def clean(inst, clean_level=None):
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
     Note
     ----
         Supports 'clean', 'dusty', 'dirty', 'none'. Method is
@@ -208,13 +203,13 @@ def clean(inst, clean_level=None):
         L26_Flag = inst['ICON_L26_Flags']
     vars = ['HmF2', 'NmF2', 'Oplus']
 
-    if clean_level == 'clean':
+    if inst.clean_level == 'clean':
         idx, = np.where(L26_Flag > 0)
         inst[idx, vars] = np.nan
-    elif clean_level == 'dusty':
+    elif inst.clean_level == 'dusty':
         idx, = np.where(L26_Flag > 1)
         inst[idx, vars] = np.nan
-    elif clean_level == 'dirty':
+    elif inst.clean_level == 'dirty':
         idx, = np.where(L26_Flag > 2)
         inst[idx, vars] = np.nan
 

--- a/pysat/instruments/icon_fuv.py
+++ b/pysat/instruments/icon_fuv.py
@@ -216,6 +216,5 @@ def clean(inst):
 
     """
 
-    if inst.clean_level != 'none':
-        warnings.warn("Cleaning actions for ICON FUV are not yet defined.")
+    warnings.warn("Cleaning actions for ICON FUV are not yet defined.")
     return

--- a/pysat/instruments/icon_fuv.py
+++ b/pysat/instruments/icon_fuv.py
@@ -191,7 +191,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
                                     pandas_format=pandas_format)
 
 
-def clean(inst, clean_level=None):
+def clean(inst):
     """Provides data cleaning based upon clean_level.
 
     clean_level is set upon Instrument instantiation to
@@ -209,11 +209,6 @@ def clean(inst, clean_level=None):
     inst : (pysat.Instrument)
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Note
     ----

--- a/pysat/instruments/icon_fuv.py
+++ b/pysat/instruments/icon_fuv.py
@@ -216,6 +216,6 @@ def clean(inst):
 
     """
 
-    if clean_level != 'none':
+    if inst.clean_level != 'none':
         warnings.warn("Cleaning actions for ICON FUV are not yet defined.")
     return

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -219,20 +219,29 @@ def clean(inst):
     rpa_variables = ['Ion_Temperature', 'Ion_Density',
                      'Fractional_Ion_Density_H',
                      'Fractional_Ion_Density_O']
+    if 'RPA_Flag' in inst.variables:
+        rpa_flag = 'RPA_Flag'
+        dm_flag = 'DM_Flag'
+    else:
+        rpa_flag = 'ICON_L27_RPA_Flag'
+        dm_flag = 'ICON_L27_DM_Flag'
+        drift_variables = ['ICON_L27_' + x for x in drift_variables]
+        cross_drift_variables = ['ICON_L27_' + x for x in cross_drift_variables]
+        rpa_variables = ['ICON_L27_' + x for x in rpa_variables]
 
     if inst.clean_level in ['clean', 'dusty']:
         # remove drift values impacted by RPA
-        idx, = np.where(inst['RPA_Flag'] >= 1)
+        idx, = np.where(inst[rpa_flag] >= 1)
         for var in drift_variables:
             inst[idx, var] = np.nan
         # DM values
-        idx, = np.where(inst['DM_Flag'] >= 1)
+        idx, = np.where(inst[dm_flag] >= 1)
         for var in cross_drift_variables:
             inst[idx, var] = np.nan
 
     if inst.clean_level == 'clean':
         # other RPA parameters
-        idx, = np.where(inst['RPA_Flag'] >= 2)
+        idx, = np.where(inst[rpa_flag] >= 2)
         for var in rpa_variables:
             inst[idx, var] = np.nan
 

--- a/pysat/instruments/icon_ivm.py
+++ b/pysat/instruments/icon_ivm.py
@@ -186,7 +186,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
                                     fill_label='FillVal')
 
 
-def clean(inst, clean_level=None):
+def clean(inst):
     """Provides data cleaning based upon clean_level.
 
     clean_level is set upon Instrument instantiation to
@@ -205,41 +205,35 @@ def clean(inst, clean_level=None):
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
     Note
     ----
         Supports 'clean', 'dusty', 'dirty', 'none'
 
     """
 
-    if clean_level != 'none':
-        # IVM variable groupings
-        drift_variables = ['Ion_Velocity_X', 'Ion_Velocity_Zonal',
-                           'Ion_Velocity_Meridional',
-                           'Ion_Velocity_Field_Aligned']
-        cross_drift_variables = ['Ion_Velocity_Z', 'Ion_Velocity_Y']
-        rpa_variables = ['Ion_Temperature', 'Ion_Density',
-                         'Fractional_Ion_Density_H',
-                         'Fractional_Ion_Density_O']
+    # IVM variable groupings
+    drift_variables = ['Ion_Velocity_X', 'Ion_Velocity_Zonal',
+                       'Ion_Velocity_Meridional',
+                       'Ion_Velocity_Field_Aligned']
+    cross_drift_variables = ['Ion_Velocity_Z', 'Ion_Velocity_Y']
+    rpa_variables = ['Ion_Temperature', 'Ion_Density',
+                     'Fractional_Ion_Density_H',
+                     'Fractional_Ion_Density_O']
 
-        if clean_level == 'clean' or (clean_level == 'dusty'):
-            # remove drift values impacted by RPA
-            idx, = np.where(inst['RPA_Flag'] >= 1)
-            for var in drift_variables:
-                inst[idx, var] = np.nan
-            # DM values
-            idx, = np.where(inst['DM_Flag'] >= 1)
-            for var in cross_drift_variables:
-                inst[idx, var] = np.nan
+    if inst.clean_level in ['clean', 'dusty']:
+        # remove drift values impacted by RPA
+        idx, = np.where(inst['RPA_Flag'] >= 1)
+        for var in drift_variables:
+            inst[idx, var] = np.nan
+        # DM values
+        idx, = np.where(inst['DM_Flag'] >= 1)
+        for var in cross_drift_variables:
+            inst[idx, var] = np.nan
 
-        if clean_level == 'clean':
-            # other RPA parameters
-            idx, = np.where(inst['RPA_Flag'] >= 2)
-            for var in rpa_variables:
-                inst[idx, var] = np.nan
+    if inst.clean_level == 'clean':
+        # other RPA parameters
+        idx, = np.where(inst['RPA_Flag'] >= 2)
+        for var in rpa_variables:
+            inst[idx, var] = np.nan
 
     return

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -234,7 +234,7 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
                                     pandas_format=pandas_format)
 
 
-def clean(inst, clean_level=None):
+def clean(inst):
     """Provides data cleaning based upon clean_level.
 
     clean_level is set upon Instrument instantiation to
@@ -262,10 +262,10 @@ def clean(inst, clean_level=None):
     if inst.tag[0:2] == 've':
         # vector winds area
         mvars = ['Zonal_Wind', 'Meridional_Wind']
-        if clean_level == 'good':
+        if inst.clean_level == 'good':
             idx, = np.where(inst['Wind_Quality'] != 1)
             inst[idx, mvars] = np.nan
-        elif clean_level == 'dusty':
+        elif inst.clean_level == 'dusty':
             idx, = np.where(inst['Wind_Quality'] < 0.5)
             inst[idx, mvars] = np.nan
         else:
@@ -274,7 +274,7 @@ def clean(inst, clean_level=None):
     elif inst.tag[0:2] == 'te':
         # neutral temperatures
         mvar = 'Temperature'
-        if (clean_level == 'good') or (clean_level == 'dusty'):
+        if inst.clean_level in ['good', 'dusty']:
             # SAA
             saa_flag = 'MIGHTI_{s}_Quality_Flag_South_Atlantic_Anomaly'
             idx, = np.where(inst[saa_flag.format(inst.sat_id.upper())] > 0)
@@ -288,7 +288,7 @@ def clean(inst, clean_level=None):
             pass
     elif inst.tag[0:2] == 'lo':
         # dealing with LOS winds
-        if (clean_level == 'good') or (clean_level == 'dusty'):
+        if inst.clean_level in ['good', 'dusty']:
             # find location with any of the flags set
             idx, idy, = np.where(inst['Quality_Flags'].any(axis=2))
             inst[idx, idy, 'Line_of_Sight_Wind'] = np.nan

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -284,10 +284,12 @@ def clean(inst):
             vars = ['ICON_L22_' + x for x in vars]
         if inst.clean_level == 'clean':
             idx, = np.where(inst[qual_flag] != 1)
-            inst[idx, mvars] = np.nan
+            for var in vars:
+                inst[idx, var] = np.nan
         elif inst.clean_level == 'dusty':
             idx, = np.where(inst[qual_flag] < 0.5)
-            inst[idx, mvars] = np.nan
+            for var in vars:
+                inst[idx, vars] = np.nan
         else:
             # dirty lets everything through
             pass

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -301,7 +301,7 @@ def clean(inst):
         if saa_flag.format(s=inst.sat_id.upper()) not in inst.variables:
             saa_flag = 'ICON_L1_' + saa_flag
             cal_flag = 'ICON_L1_' + cal_flag
-            var = 'ICON_L23_' + var
+            var = 'ICON_L23_MIGHTI_' + inst.sat_id.upper() + '_' + var
         if inst.clean_level in ['clean', 'dusty']:
             # SAA
             idx, = np.where(inst[saa_flag.format(s=inst.sat_id.upper())] > 0)

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -325,7 +325,7 @@ def clean(inst):
                                  cal_flag))
             var = '_'.JOIN(('ICON_L23_MIGHTI', inst.sat_id.upper(), var))
         if inst.clean_level in ['clean', 'dusty']:
-            inst[var] = inst[var].where((saa_flag == 0) & (cal_flag == 0))
+            inst[var] = inst[var].where((inst[saa_flag] == 0) & (inst[cal_flag] == 0))
         else:
             # dirty and worse lets everything through
             pass

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -170,12 +170,10 @@ def remove_preamble(inst):
               'los_wind_red': 'ICON_L21_',
               'vector_wind_green': 'ICON_L22_',
               'vector_wind_red': 'ICON_L22_',
-              'temperature': 'ICON_L23_MIGHTI_' + inst.sat_id.upper() + '_'}
+              'temperature': ['ICON_L1_MIGHTI_{}_'.format(inst.sat_id.upper()),
+                              'ICON_L23_MIGHTI_{}_'.format(inst.sat_id.upper()),
+                              'ICON_L23_']}
     mm_gen.remove_leading_text(inst, target=target[inst.tag])
-
-    # for temps need
-    mm_gen.remove_leading_text(inst, target='ICON_L23_')
-    mm_gen.remove_leading_text(inst, target='ICON_L1_')
 
     return
 
@@ -296,12 +294,14 @@ def clean(inst):
     elif inst.tag.find('temp') >= 0:
         # neutral temperatures
         var = 'Temperature'
-        saa_flag = 'MIGHTI_{s}_Quality_Flag_South_Atlantic_Anomaly'
-        cal_flag = 'MIGHTI_{s}_Quality_Flag_Bad_Calibration'
-        if saa_flag.format(s=inst.sat_id.upper()) not in inst.variables:
-            saa_flag = 'ICON_L1_' + saa_flag
-            cal_flag = 'ICON_L1_' + cal_flag
-            var = 'ICON_L23_MIGHTI_' + inst.sat_id.upper() + '_' + var
+        saa_flag = 'Quality_Flag_South_Atlantic_Anomaly'
+        cal_flag = 'Quality_Flag_Bad_Calibration'
+        if saa_flag not in inst.variables:
+            saa_flag = '_'.join(('ICON_L1_MIGHTI', inst.sat_id.upper(),
+                                 saa_flag))
+            cal_flag = '_'.join(('ICON_L1_MIGHTI', inst.sat_id.upper(),
+                                 cal_flag))
+            var = '_'.JOIN(('ICON_L23_MIGHTI', inst.sat_id.upper(), var))
         if inst.clean_level in ['clean', 'dusty']:
             # SAA
             idx, = np.where(inst[saa_flag.format(s=inst.sat_id.upper())] > 0)

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -262,7 +262,7 @@ def clean(inst):
     if inst.tag[0:2] == 've':
         # vector winds area
         mvars = ['Zonal_Wind', 'Meridional_Wind']
-        if inst.clean_level == 'good':
+        if inst.clean_level == 'clean':
             idx, = np.where(inst['Wind_Quality'] != 1)
             inst[idx, mvars] = np.nan
         elif inst.clean_level == 'dusty':
@@ -274,7 +274,7 @@ def clean(inst):
     elif inst.tag[0:2] == 'te':
         # neutral temperatures
         mvar = 'Temperature'
-        if inst.clean_level in ['good', 'dusty']:
+        if inst.clean_level in ['clean', 'dusty']:
             # SAA
             saa_flag = 'MIGHTI_{s}_Quality_Flag_South_Atlantic_Anomaly'
             idx, = np.where(inst[saa_flag.format(inst.sat_id.upper())] > 0)
@@ -288,7 +288,7 @@ def clean(inst):
             pass
     elif inst.tag[0:2] == 'lo':
         # dealing with LOS winds
-        if inst.clean_level in ['good', 'dusty']:
+        if inst.clean_level in ['clean', 'dusty']:
             # find location with any of the flags set
             idx, idy, = np.where(inst['Quality_Flags'].any(axis=2))
             inst[idx, idy, 'Line_of_Sight_Wind'] = np.nan

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -217,18 +217,22 @@ def load(fnames, tag=None, sat_id=None, keep_original_names=False):
 
     """
 
-    return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch',
-                                    units_label='Units',
-                                    name_label='Long_Name',
-                                    notes_label='Var_Notes',
-                                    desc_label='CatDesc',
-                                    plot_label='FieldNam',
-                                    axis_label='LablAxis',
-                                    scale_label='ScaleTyp',
-                                    min_label='ValidMin',
-                                    max_label='ValidMax',
-                                    fill_label='FillVal',
-                                    pandas_format=pandas_format)
+    data, mdata = pysat.utils.load_netcdf4(fnames, epoch_name='Epoch',
+                                           units_label='Units',
+                                           name_label='Long_Name',
+                                           notes_label='Var_Notes',
+                                           desc_label='CatDesc',
+                                           plot_label='FieldNam',
+                                           axis_label='LablAxis',
+                                           scale_label='ScaleTyp',
+                                           min_label='ValidMin',
+                                           max_label='ValidMax',
+                                           fill_label='FillVal',
+                                           pandas_format=pandas_format)
+    # xarray can't merge if variable and dim names are the same
+    if 'Altitude' in data.dims:
+        data = data.rename_dims(dims_dict={'Altitude': 'Alt'})
+    return data, mdata
 
 
 def clean(inst):
@@ -291,10 +295,10 @@ def clean(inst):
         ver_vars = ['Fringe_Amplitude', 'Fringe_Amplitude_Error',
                     'Relative_VER', 'Relative_VER_Error']
         if wind_flag not in inst.variables:
-            wind_flag = '_'.join(('ICON_L21', wind_flag))
-            ver_flag = '_'.join(('ICON_L21', ver_flag))
-            wind_vars = ['ICON_L21_' + var for var in wind_vars]
-            ver_vars = ['ICON_L21_' + var for var in ver_vars]
+            wind_flag = '_'.join(('ICON_L22', wind_flag))
+            ver_flag = '_'.join(('ICON_L22', ver_flag))
+            wind_vars = ['ICON_L22_' + var for var in wind_vars]
+            ver_vars = ['ICON_L22_' + var for var in ver_vars]
         min_val = {'clean': 1.0,
                    'dusty': 0.5}
         if inst.clean_level in ['clean', 'dusty']:

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -325,7 +325,8 @@ def clean(inst):
                                  cal_flag))
             var = '_'.JOIN(('ICON_L23_MIGHTI', inst.sat_id.upper(), var))
         if inst.clean_level in ['clean', 'dusty']:
-            inst[var] = inst[var].where((inst[saa_flag] == 0) & (inst[cal_flag] == 0))
+            inst[var] = inst[var].where((inst[saa_flag] == 0)
+                                        & (inst[cal_flag] == 0))
         else:
             # dirty and worse lets everything through
             pass

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -283,13 +283,13 @@ def clean(inst):
             qual_flag = 'ICON_L22_Wind_Quality'
             vars = ['ICON_L22_' + x for x in vars]
         if inst.clean_level == 'clean':
-            idx, = np.where(inst[qual_flag] != 1)
+            idx, idy, = np.where(inst[qual_flag] != 1)
             for var in vars:
-                inst[idx, var] = np.nan
+                inst[idx, idy, var] = np.nan
         elif inst.clean_level == 'dusty':
-            idx, = np.where(inst[qual_flag] < 0.5)
+            idx, idy, = np.where(inst[qual_flag] < 0.5)
             for var in vars:
-                inst[idx, vars] = np.nan
+                inst[idx, idy, vars] = np.nan
         else:
             # dirty lets everything through
             pass

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -284,13 +284,11 @@ def clean(inst):
             qual_flag = 'ICON_L22_Wind_Quality'
             vars = ['ICON_L22_' + x for x in vars]
         if inst.clean_level == 'clean':
-            idx, idy, = np.where(inst[qual_flag] != 1)
             for var in vars:
-                inst[idx, idy, var] = np.nan
+                inst[var] = inst[var].where(inst[qual_flag] == 1.0)
         elif inst.clean_level == 'dusty':
-            idx, idy, = np.where(inst[qual_flag] < 0.5)
             for var in vars:
-                inst[idx, idy, var] = np.nan
+                inst[var] = inst[var].where(inst[qual_flag] >= 0.5)
         else:
             # dirty lets everything through
             pass

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -303,12 +303,7 @@ def clean(inst):
                                  cal_flag))
             var = '_'.JOIN(('ICON_L23_MIGHTI', inst.sat_id.upper(), var))
         if inst.clean_level in ['clean', 'dusty']:
-            # SAA
-            idx, = np.where(inst[saa_flag] > 0)
-            inst[:, idx, var] = np.nan
-            # Calibration file
-            idx, = np.where(inst[cal_flag] > 0)
-            inst[:, idx, var] = np.nan
+            inst[var] = inst[var].where((saa_flag == 0) & (cal_flag == 0))
         else:
             # dirty and worse lets everything through
             pass

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -274,6 +274,7 @@ def clean(inst):
         else:
             # dirty and worse lets everything through
             pass
+
     elif inst.tag.find('vector') >= 0:
         # vector winds area
         vars = ['Zonal_Wind', 'Meridional_Wind']
@@ -289,10 +290,11 @@ def clean(inst):
         elif inst.clean_level == 'dusty':
             idx, idy, = np.where(inst[qual_flag] < 0.5)
             for var in vars:
-                inst[idx, idy, vars] = np.nan
+                inst[idx, idy, var] = np.nan
         else:
             # dirty lets everything through
             pass
+
     elif inst.tag.find('temp') >= 0:
         # neutral temperatures
         var = 'Temperature'

--- a/pysat/instruments/icon_mighti.py
+++ b/pysat/instruments/icon_mighti.py
@@ -304,10 +304,10 @@ def clean(inst):
             var = '_'.JOIN(('ICON_L23_MIGHTI', inst.sat_id.upper(), var))
         if inst.clean_level in ['clean', 'dusty']:
             # SAA
-            idx, = np.where(inst[saa_flag.format(s=inst.sat_id.upper())] > 0)
+            idx, = np.where(inst[saa_flag] > 0)
             inst[:, idx, var] = np.nan
             # Calibration file
-            idx, = np.where(inst[cal_flag.format(s=inst.sat_id.upper())] > 0)
+            idx, = np.where(inst[cal_flag] > 0)
             inst[:, idx, var] = np.nan
         else:
             # dirty and worse lets everything through

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -120,7 +120,7 @@ def remove_leading_text(inst, target=None):
     ----------
     inst : pysat.Instrument
         associated pysat.Instrument object
-    target : str
+    target : str or list of strings
         Leading string to remove. If none supplied,
         ICON project standards are used to identify and remove
         leading text
@@ -133,8 +133,12 @@ def remove_leading_text(inst, target=None):
 
     """
 
-    if target is not None:
-        prepend_str = target
+    if isinstance(target, str):
+        target = [target]
+    elif (not isinstance(target, list)) or (not isinstance(target[0], str)):
+        raise ValueError('target must be a string or list of strings')
+
+    for prepend_str in target:
 
         if isinstance(inst.data, pds.DataFrame):
             inst.data.rename(columns=lambda x: x.split(prepend_str)[-1],

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -133,7 +133,9 @@ def remove_leading_text(inst, target=None):
 
     """
 
-    if isinstance(target, str):
+    if target is None:
+        return
+    elif isinstance(target, str):
         target = [target]
     elif (not isinstance(target, list)) or (not isinstance(target[0], str)):
         raise ValueError('target must be a string or list of strings')

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -209,17 +209,18 @@ meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time'}
 meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
 meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
 meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
-series_profile_meta = pysat.Meta()
-series_profile_meta['series_profiles'] = {'units': '', 'long_name': 'series'}
-meta['series_profiles'] = {'meta': series_profile_meta, 'units': '',
-                           'long_name': 'series'}
+variable_profile_meta = pysat.Meta()
+variable_profile_meta['variable_profiles'] = {'units': '',
+                                              'long_name': 'series'}
+meta['variable_profiles'] = {'meta': variable_profile_meta, 'units': '',
+                             'long_name': 'series'}
 profile_meta = pysat.Meta()
 profile_meta['density'] = {'units': '', 'long_name': 'profiles'}
 profile_meta['dummy_str'] = {'units': '', 'long_name': 'profiles'}
 profile_meta['dummy_ustr'] = {'units': '', 'long_name': 'profiles'}
 meta['profiles'] = {'meta': profile_meta, 'units': '', 'long_name': 'profiles'}
-alt_profile_meta = pysat.Meta()
-alt_profile_meta['density'] = {'units': '', 'long_name': 'profiles'}
-alt_profile_meta['fraction'] = {'units': '', 'long_name': 'profiles'}
-meta['alt_profiles'] = {'meta': alt_profile_meta, 'units': '',
-                        'long_name': 'profiles'}
+image_meta = pysat.Meta()
+image_meta['density'] = {'units': '', 'long_name': 'profiles'}
+image_meta['fraction'] = {'units': '', 'long_name': 'profiles'}
+meta['images'] = {'meta': image_meta, 'units': '',
+                  'long_name': 'profiles'}

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -42,6 +42,11 @@ class TestRemoveLeadText():
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.Npts
 
+    def test_remove_prefix_w_bad_target(self):
+        self.testInst['ICON_L27_Blurp'] = self.testInst['dummy1']
+        with pytest.raises(ValueError):
+            gen.remove_leading_text(self.testInst, target=17.5)
+
     def test_remove_names_wo_target(self):
         self.testInst['ICON_L27_Blurp'] = self.testInst['dummy1']
         gen.remove_leading_text(self.testInst)
@@ -55,6 +60,17 @@ class TestRemoveLeadText():
         gen.remove_leading_text(self.testInst, target='ICON_L27')
         # check prepended text removed
         assert (len(self.testInst['_Blurp']) == self.Npts)
+        # check other names untouched
+        assert (len(self.testInst['dummy1']) == self.Npts)
+
+    def test_remove_names_w_target_list(self):
+        self.testInst['ICON_L27_Blurp'] = self.testInst['dummy1']
+        self.testInst['ICON_L23_Bloop'] = self.testInst['dummy1']
+        gen.remove_leading_text(self.testInst,
+                                target=['ICON_L27', 'ICON_L23_B'])
+        # check prepended text removed
+        assert (len(self.testInst['_Blurp']) == self.Npts)
+        assert (len(self.testInst['loop']) == self.Npts)
         # check other names untouched
         assert (len(self.testInst['dummy1']) == self.Npts)
 
@@ -78,5 +94,16 @@ class TestRemoveLeadTextXarray(TestRemoveLeadText):
         gen.remove_leading_text(self.testInst, target='ICON_L27')
         # check prepended text removed
         assert (len(self.testInst['_Blurp']) == self.Npts)
+        # check other names untouched
+        assert (len(self.testInst['profiles']) == self.Npts)
+
+    def test_remove_2D_names_w_target_list(self):
+        self.testInst['ICON_L27_Blurp'] = self.testInst['profiles']
+        self.testInst['ICON_L23_Bloop'] = self.testInst['dummy1']
+        gen.remove_leading_text(self.testInst,
+                                target=['ICON_L27', 'ICON_L23_B'])
+        # check prepended text removed
+        assert (len(self.testInst['_Blurp']) == self.Npts)
+        assert (len(self.testInst['loop']) == self.Npts)
         # check other names untouched
         assert (len(self.testInst['profiles']) == self.Npts)

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -59,9 +59,11 @@ class TestRemoveLeadText():
         self.testInst['ICON_L27_Blurp'] = self.testInst['dummy1']
         gen.remove_leading_text(self.testInst, target='ICON_L27')
         # check prepended text removed
-        assert (len(self.testInst['_Blurp']) == self.Npts)
+        assert len(self.testInst['_Blurp']) == self.Npts
         # check other names untouched
-        assert (len(self.testInst['dummy1']) == self.Npts)
+        assert len(self.testInst['dummy1']) == self.Npts
+        # check prepended text removed from metadata
+        assert '_Blurp' in self.testInst.meta.keys()
 
     def test_remove_names_w_target_list(self):
         self.testInst['ICON_L27_Blurp'] = self.testInst['dummy1']
@@ -69,10 +71,13 @@ class TestRemoveLeadText():
         gen.remove_leading_text(self.testInst,
                                 target=['ICON_L27', 'ICON_L23_B'])
         # check prepended text removed
-        assert (len(self.testInst['_Blurp']) == self.Npts)
-        assert (len(self.testInst['loop']) == self.Npts)
+        assert len(self.testInst['_Blurp']) == self.Npts
+        assert len(self.testInst['loop']) == self.Npts
         # check other names untouched
-        assert (len(self.testInst['dummy1']) == self.Npts)
+        assert len(self.testInst['dummy1']) == self.Npts
+        # check prepended text removed from metadata
+        assert '_Blurp' in self.testInst.meta.keys()
+        assert 'loop' in self.testInst.meta.keys()
 
 
 class TestRemoveLeadTextXarray(TestRemoveLeadText):
@@ -83,20 +88,27 @@ class TestRemoveLeadTextXarray(TestRemoveLeadText):
                                          sat_id='12',
                                          clean_level='clean')
         self.testInst.load(2009, 1)
-        self.Npts = len(self.testInst['profiles'])
+        self.Npts = len(self.testInst['uts'])
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.Npts
 
     def test_remove_2D_names_w_target(self):
-        gen.remove_leading_text(self.testInst, target='ser')
-        # check prepended text removed
-        assert (len(self.testInst['ies_profiles']) == self.Npts)
+        gen.remove_leading_text(self.testInst, target='variable')
+        # check prepended text removed from variables
+        assert '_profiles' in self.testInst.data.variables
+        assert self.testInst.data['_profiles'].shape[0] == self.Npts
+        # check prepended text removed from metadata
+        assert '_profiles' in self.testInst.meta.keys()
 
     def test_remove_2D_names_w_target_list(self):
         gen.remove_leading_text(self.testInst,
-                                target=['ser', 'alt_prof'])
-        # check prepended text removed
-        assert (len(self.testInst['ies_profiles']) == self.Npts)
-        assert (len(self.testInst['iles']) == self.Npts)
+                                target=['variable', 'im'])
+        # check prepended text removed from variables
+        assert '_profiles' in self.testInst.data.variables
+        assert self.testInst.data['_profiles'].shape[0] == self.Npts
+        assert 'ages' in self.testInst.data.variables
+        # check prepended text removed from metadata
+        assert '_profiles' in self.testInst.meta.keys()
+        assert 'ages' in self.testInst.meta.keys()

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -90,20 +90,13 @@ class TestRemoveLeadTextXarray(TestRemoveLeadText):
         del self.testInst, self.Npts
 
     def test_remove_2D_names_w_target(self):
-        self.testInst['ICON_L27_Blurp'] = self.testInst['profiles']
-        gen.remove_leading_text(self.testInst, target='ICON_L27')
+        gen.remove_leading_text(self.testInst, target='ser')
         # check prepended text removed
-        assert (len(self.testInst['_Blurp']) == self.Npts)
-        # check other names untouched
-        assert (len(self.testInst['profiles']) == self.Npts)
+        assert (len(self.testInst['ies_profiles']) == self.Npts)
 
     def test_remove_2D_names_w_target_list(self):
-        self.testInst['ICON_L27_Blurp'] = self.testInst['profiles']
-        self.testInst['ICON_L23_Bloop'] = self.testInst['dummy1']
         gen.remove_leading_text(self.testInst,
-                                target=['ICON_L27', 'ICON_L23_B'])
+                                target=['ser', 'alt_prof'])
         # check prepended text removed
-        assert (len(self.testInst['_Blurp']) == self.Npts)
-        assert (len(self.testInst['loop']) == self.Npts)
-        # check other names untouched
-        assert (len(self.testInst['profiles']) == self.Npts)
+        assert (len(self.testInst['ies_profiles']) == self.Npts)
+        assert (len(self.testInst['iles']) == self.Npts)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -406,10 +406,13 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
         else:
             out = xr.open_mfdataset(fnames, combine='by_coords')
         for key in out.variables.keys():
+            # Copy the variable attributes from the data object to the metadata
             meta_dict = {}
             for nc_key in out.variables[key].attrs.keys():
                 meta_dict[nc_key] = out.variables[key].attrs[nc_key]
             mdata[key] = meta_dict
+            # Remove variable attributes from the data object
+            out.variables[key].attrs = []
         # Copy the file attributes from the data object to the metadata
         for d in out.attrs.keys():
             if hasattr(mdata, d):

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -412,7 +412,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
                 meta_dict[nc_key] = out.variables[key].attrs[nc_key]
             mdata[key] = meta_dict
             # Remove variable attributes from the data object
-            out.variables[key].attrs = []
+            out.variables[key].attrs = {}
         # Copy the file attributes from the data object to the metadata
         for d in out.attrs.keys():
             if hasattr(mdata, d):
@@ -420,6 +420,6 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
             else:
                 mdata.__setattr__(d, out.attrs[d])
         # Remove attributes from the data object
-        out.attrs = []
+        out.attrs = {}
 
     return out, mdata


### PR DESCRIPTION
The clean routines for the icon instruments need to be updated.  Comparing with cnofs_ivm, we need to look at inst.clean_level rather than declaring a separate kwarg.  Since default was `None`, the clean routines were skipped.

NOTE: these will not run if the keep_original_names flag is set, as they are based on the trimmed names.  This needs to be fixed.

Other NOTE: working in the 3.0 branch as I can run these tests locally and they take half the time.

Simple local test:
```
import pysat
import numpy as np
ivm = pysat.Instrument('icon', 'ivm', sat_id='a')
ivm.load(2020, 1)
idx, = np.where(ivm['RPA_Flag'] == 2)
len(idx) == sum(np.isnan(ivm['Ion_Velocity_X'][idx]))
```
If the clean routines are being run, then Ion_Velocity_X should be NaN wherever the RPA_Flag is 2.  For this date, this occurs 23636 times.

Similarly
```
ivm = pysat.Instrument('icon', 'ivm', sat_id='a', keep_original_names=True) 
ivm.load(2020, 1) 
idx, = np.where(ivm['ICON_L27_RPA_Flag'] == 2) 
len(idx) == sum(np.isnan(ivm['ICON_L27_Ion_Velocity_X'][idx]))      
```