### PR TITLE
DOC: update function-level docstrings in instruments

### DIFF
--- a/pysat/instruments/champ_star.py
+++ b/pysat/instruments/champ_star.py
@@ -53,17 +53,18 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
     sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
 
     Returns
     --------
-    pysat.Files.from_os : (pysat._files.Files)
+    pysat.Files.from_os : pysat._files.Files
         A class containing the verified available files
+
     """
 
     if format_str is None and tag is not None:
@@ -85,19 +86,20 @@ def load(fnames, tag=None, sat_id=None):
 
     Parameters
     ------------
-    fnames : (pandas.Series)
+    fnames : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
     ---------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
+
     """
     import re
     if len(fnames) <= 0:
@@ -202,13 +204,13 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
     Returns
     --------
-    Void : (NoneType)
+    Void : NoneType
         data in inst is modified in-place.
 
     Notes
@@ -226,18 +228,14 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
+    Warnings
     --------
     No cleaning currently available for CHAMP
+
     """
 
     warnings.warn("No cleaning currently available for CHAMP")

--- a/pysat/instruments/champ_star.py
+++ b/pysat/instruments/champ_star.py
@@ -209,11 +209,6 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    --------
-    Void : NoneType
-        data in inst is modified in-place.
-
     Notes
     --------
     No data download currently available for CHAMP

--- a/pysat/instruments/champ_star.py
+++ b/pysat/instruments/champ_star.py
@@ -30,6 +30,7 @@ from __future__ import absolute_import
 
 import numpy as np
 import pandas as pds
+import re
 import warnings
 
 import pysat
@@ -101,7 +102,7 @@ def load(fnames, tag=None, sat_id=None):
         Object containing metadata such as column names and units
 
     """
-    import re
+
     if len(fnames) <= 0:
         return pysat.DataFrame(None), pysat.Meta(None)
 

--- a/pysat/instruments/cnofs_ivm.py
+++ b/pysat/instruments/cnofs_ivm.py
@@ -103,14 +103,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Notes
     --------

--- a/pysat/instruments/cnofs_plp.py
+++ b/pysat/instruments/cnofs_plp.py
@@ -100,11 +100,6 @@ def clean(inst):
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
     Notes
     --------
     Basic cleaning to find valid Epoch values

--- a/pysat/instruments/cnofs_vefi.py
+++ b/pysat/instruments/cnofs_vefi.py
@@ -100,14 +100,10 @@ def clean(inst):
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
     Notes
     --------
     'dusty' or 'clean' removes data when interpolation flag is set to 1
+
     """
 
     if (inst.clean_level == 'dusty') | (inst.clean_level == 'clean'):

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -49,14 +49,18 @@ Warnings
 
 from __future__ import print_function
 from __future__ import absolute_import
+import logging
 import numpy as np
 import os
+import requests
+from requests.auth import HTTPBasicAuth
+import shutil
 import sys
+import tarfile
 
 import netCDF4
 import pysat
 
-import logging
 logger = logging.getLogger(__name__)
 
 platform = 'cosmic'
@@ -432,10 +436,6 @@ def download(date_array, tag, sat_id, data_path=None,
         the desired level of data selectivity.
 
     """
-    import requests
-    from requests.auth import HTTPBasicAuth
-    import tarfile
-    import shutil
 
     if tag == 'ionprf':
         sub_dir = 'ionPrf'

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -79,16 +79,16 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (NoneType)
+    format_str : NoneType
         User specified file format not supported here. (default=None)
 
     Returns
@@ -158,21 +158,21 @@ def load(fnames, tag=None, sat_id=None, altitude_bin=None):
 
     Parameters
     ----------
-    fnames : (pandas.Series)
+    fnames : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
     altitude_bin : integer
         Number of kilometers to bin altitude profiles by when loading.
-        Currently only supported for tag='ionprf'.
+        Currently only supported for tag='ionprf'. (default=None)
 
     Returns
     -------
-    output : (pandas.DataFrame)
+    output : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
 
     """
@@ -273,22 +273,23 @@ def load_files(files, tag=None, sat_id=None, altitude_bin=None):
 
     Parameters
     ----------
-    files : (pandas.Series)
+    files : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
     altitude_bin : integer
         Number of kilometers to bin altitude profiles by when loading.
-        Currently only supported for tag='ionprf'.
+        Currently only supported for tag='ionprf'. (default=None)
 
     Returns
     -------
-    output : (list of dicts, one per file)
-        Object containing satellite data
+    output : list of dicts
+        Object containing satellite data, one dict per file
 
     """
+
     output = [None] * len(files)
     drop_idx = []
     main_dict = {}
@@ -426,14 +427,9 @@ def download(date_array, tag, sat_id, data_path=None,
 
     Parameters
     ----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    -------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     """
     import requests
@@ -519,20 +515,16 @@ def clean(inst):
 
     Parameters
     ----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    -------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Notes
     -----
     Supports 'clean', 'dusty', 'dirty'
 
     """
+
     if inst.tag == 'ionprf':
         # ionosphere density profiles
         if inst.clean_level == 'clean':

--- a/pysat/instruments/de2_lang.py
+++ b/pysat/instruments/de2_lang.py
@@ -126,17 +126,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/de2_lang.py
+++ b/pysat/instruments/de2_lang.py
@@ -84,30 +84,6 @@ list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)
 
 
-# code should be defined below as needed
-def default(self):
-    """Default customization function.
-
-    This routine is automatically applied to the Instrument object
-    on every load by the pysat nanokernel (first in queue).
-
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
-
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
-    """
-
-    return
-
-
-# code should be defined below as needed
 def clean(inst):
     """Routine to return PLATFORM/NAME data cleaned to the specified level
 

--- a/pysat/instruments/de2_nacs.py
+++ b/pysat/instruments/de2_nacs.py
@@ -110,30 +110,6 @@ list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)
 
 
-# code should be defined below as needed
-def default(self):
-    """Default customization function.
-
-    This routine is automatically applied to the Instrument object
-    on every load by the pysat nanokernel (first in queue).
-
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
-
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
-    """
-
-    return
-
-
-# code should be defined below as needed
 def clean(inst):
     """Routine to return PLATFORM/NAME data cleaned to the specified level
 

--- a/pysat/instruments/de2_nacs.py
+++ b/pysat/instruments/de2_nacs.py
@@ -152,17 +152,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/de2_rpa.py
+++ b/pysat/instruments/de2_rpa.py
@@ -95,30 +95,6 @@ list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)
 
 
-# code should be defined below as needed
-def default(self):
-    """Default customization function.
-
-    This routine is automatically applied to the Instrument object
-    on every load by the pysat nanokernel (first in queue).
-
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
-
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
-    """
-
-    return
-
-
-# code should be defined below as needed
 def clean(inst):
     """Routine to return PLATFORM/NAME data cleaned to the specified level
 

--- a/pysat/instruments/de2_rpa.py
+++ b/pysat/instruments/de2_rpa.py
@@ -137,17 +137,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/de2_wats.py
+++ b/pysat/instruments/de2_wats.py
@@ -107,30 +107,6 @@ list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)
 
 
-# code should be defined below as needed
-def default(self):
-    """Default customization function.
-
-    This routine is automatically applied to the Instrument object
-    on every load by the pysat nanokernel (first in queue).
-
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
-
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
-    """
-
-    return
-
-
-# code should be defined below as needed
 def clean(inst):
     """Routine to return PLATFORM/NAME data cleaned to the specified level
 

--- a/pysat/instruments/de2_wats.py
+++ b/pysat/instruments/de2_wats.py
@@ -149,17 +149,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/demeter_iap.py
+++ b/pysat/instruments/demeter_iap.py
@@ -90,19 +90,19 @@ def list_files(tag="survey", sat_id='', data_path=None, format_str=None,
 
     Parameters
     ----------
-    tag : (string)
+    tag : string
         Denotes type of file to load.  Accepted types are 'survey'; 'burst'
         will be added in the future.  (default='survey')
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default='')
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
-    index_start_time : (bool)
+    index_start_time : bool
         Determine time index using file start time (True) or end time (False)
         (default=True)
 
@@ -133,18 +133,18 @@ def load(fnames, tag='survey', sat_id=''):
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of file names
-    tag : (string)
+    tag : string
         Denotes type of file to load.  Accepted types are 'survey'; 'burst'
         will be added in the future.  (default='survey')
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default='')
 
     Returns
     -------
-    data : (pds.DataFrame)
+    data : pds.DataFrame
         DataFrame of DEMETER satellite data
     meta :
         Metadata object
@@ -179,7 +179,7 @@ def load_experiment_data(fhandle):
 
     Parameters
     ----------
-    fhandle : (file)
+    fhandle : file
         file handle
 
     Returns
@@ -195,6 +195,7 @@ def load_experiment_data(fhandle):
         'data names'
 
     """
+
     import codecs  # ensures encode is python 2/3 compliant
 
     chunk = fhandle.read(108)
@@ -249,11 +250,6 @@ def clean(inst):
     inst : pysat.Instrument
         DEMETER IAP instrument class object
 
-    Return
-    ------
-    Updates data by removing times where data quality fails the conditions
-    for the specified cleaning level
-
     Notes
     -----
     clean : only data when at least two ions are considered and currents >= 1nA
@@ -263,7 +259,7 @@ def clean(inst):
 
     if inst.clean_level in ['dusty', 'dirty']:
         logger.info(''.join("'dusty' and 'dirty' levels not supported, ",
-                      "defaulting to 'clean'"))
+                            "defaulting to 'clean'"))
         inst.clean_level = 'clean'
 
     if inst.clean_level == 'clean':

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -130,12 +130,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     logger.info(mad_meth.cedar_rules())
@@ -151,26 +145,20 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
 
     Notes
     -----
@@ -189,10 +177,6 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
                       data_path=data_path, user=user, password=password)
 
 
-def default(inst):
-    pass
-
-
 def clean(inst):
     """Routine to return DMSP IVM data cleaned to the specified level
 
@@ -205,14 +189,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Notes
     --------

--- a/pysat/instruments/iss_fpmu.py
+++ b/pysat/instruments/iss_fpmu.py
@@ -70,11 +70,6 @@ def clean(inst):
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Returns
-    -------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
     """
 
     inst.data.replace(-999., np.nan, inplace=True)  # Te

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -111,12 +111,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     logger.info("The Jicamarca Radio Observatory is operated by the Instituto " +
@@ -135,26 +129,20 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
 
     Notes
     -----
@@ -175,11 +163,6 @@ def download(date_array, tag='', sat_id='', data_path=None, user=None,
 
 def clean(self):
     """Routine to return JRO ISR data cleaned to the specified level
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Notes
     --------

--- a/pysat/instruments/omni_hro.py
+++ b/pysat/instruments/omni_hro.py
@@ -171,6 +171,7 @@ def calculate_clock_angle(inst):
     -----------
     inst : pysat.Instrument
         Instrument with OMNI HRO data
+
     """
 
     # Calculate clock angle in degrees
@@ -205,6 +206,7 @@ def calculate_imf_steadiness(inst, steady_window=15, min_window_frac=0.75,
     max_bmag_cv : float
         Maximum coefficient of variation of the IMF magnitude in the GSM
         Y-Z plane (default=0.5)
+
     """
 
     from pysat.utils import stats as pystats
@@ -273,7 +275,9 @@ def calculate_dayside_reconnection(inst):
     Notes
     --------
     recon_day = 3.8 Re (Vx / 4e5 m/s)^1/3 Vx B_yz (sin(theta/2))^9/2
+
     """
+
     rearth = 6371008.8
     sin_htheta = np.power(np.sin(np.radians(0.5 * inst['clock_angle'])), 4.5)
     byz = inst['BYZ_GSM'] * 1.0e-9

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -46,17 +46,11 @@ def init(self):
     ----------
     inst : pysat.Instrument
         This object
-    file_date_range : (pds.date_range)
+    file_date_range : pds.date_range
         Optional keyword argument that specifies the range of dates for which
         test files will be created
     mangle_file_dates : bool
         If True, the loaded file list time index is shifted by 5-minutes.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
 
     """
 
@@ -88,12 +82,6 @@ def default(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     pass
@@ -106,29 +94,28 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of filenames
-    tag : (str or NoneType)
-        Instrument tag (accepts '' or a string to change the behaviour of
-        dummy1 for constellation testing)
-    sat_id : (str or NoneType)
+    tag : str or NoneType
+        Instrument tag (accepts '')
+    sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
-    sim_multi_file_right : (boolean)
+    sim_multi_file_right : boolean
         Adjusts date range to be 12 hours in the future or twelve hours beyond
         root_date (default=False)
-    sim_multi_file_left : (boolean)
+    sim_multi_file_left : boolean
         Adjusts date range to be 12 hours in the past or twelve hours before
         root_date (default=False)
-    root_date : (NoneType)
+    root_date : NoneType
         Optional central date, uses _test_dates if not specified.
         (default=None)
-    file_date_range : (pds.date_range or NoneType)
+    file_date_range : pds.date_range or NoneType
         Range of dates for files or None, if this optional arguement is not
         used. Shift actually performed by the init function.
         (default=None)
-    malformed_index : bool (default=False)
-        If True, time index for simulation will be non-unique and non-monotonic
+    malformed_index : boolean
+        If True, time index will be non-unique and non-monotonic.
     mangle_file_dates : bool
         If True, the loaded file list time index is shifted by 5-minutes.
         This shift is actually performed by the init function.

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -29,12 +29,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     self.new_thing = True
@@ -51,12 +45,6 @@ def default(inst):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     pass
@@ -67,21 +55,22 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         Instrument tag (accepts '')
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
-    malformed_index : bool (False)
+    malformed_index : bool
         If True, the time index will be non-unique and non-monotonic.
+        (default=False)
 
     Returns
     -------
-    data : (pds.DataFrame)
+    data : pds.DataFrame
         Testing data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Metadataxs
 
     """

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -31,12 +31,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     self.new_thing = True
@@ -53,12 +47,6 @@ def default(inst):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     pass
@@ -69,21 +57,21 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         Instrument tag (accepts '')
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
-    malformed_index : bool (False)
+    malformed_index : bool False
         If True, the time index will be non-unique and non-monotonic.
 
     Returns
     -------
-    data : (xr.Dataset)
+    data : xr.Dataset
         Testing data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Metadataxs
 
     """

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -33,12 +33,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     self.new_thing = True
@@ -55,12 +49,6 @@ def default(inst):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     pass
@@ -73,20 +61,20 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         Instrument tag (accepts '')
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
-    sim_multi_file_right : (boolean)
+    sim_multi_file_right : boolean
         Adjusts date range to be 12 hours in the future or twelve hours beyond
         root_date (default=False)
-    sim_multi_file_left : (boolean)
+    sim_multi_file_left : boolean
         Adjusts date range to be 12 hours in the past or twelve hours before
         root_date (default=False)
-    malformed_index : (boolean)
+    malformed_index : boolean
         If True, time index will be non-unique and non-monotonic.
     kwargs : dict
         Additional unspecified keywords supplied to pysat.Instrument upon

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -33,12 +33,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     self.new_thing = True
@@ -49,20 +43,20 @@ def load(fnames, tag=None, sat_id=None):
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         Instrument tag (accepts '')
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
 
 
     Returns
     -------
-    data : (xr.Dataset)
+    data : xr.Dataset
         Testing data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Metadata
 
     """

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -11,7 +11,7 @@ name
     'ivm'
 tag
     None
-sat_id 
+sat_id
     None supported
 
 Note
@@ -68,14 +68,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Notes
     --------

--- a/pysat/instruments/sport_ivm.py
+++ b/pysat/instruments/sport_ivm.py
@@ -81,8 +81,9 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     Examples
     --------
     ::
+
         inst = pysat.Instrument('sport', 'ivm')
-        inst.load(2019,1)
+        inst.load(2019, 1)
 
     """
 
@@ -170,12 +171,6 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
         error if user not supplied.
     password : string (None)
         Password for data download.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
-
 
     """
 

--- a/pysat/instruments/sport_ivm.py
+++ b/pysat/instruments/sport_ivm.py
@@ -7,13 +7,13 @@ with the development of code associated with SPORT and the IVM.
 
 """
 
-# import pandas as pds
-# import numpy as np
+import functools
+import logging
 import warnings
 
 import pysat
+from pysat.instruments.methods import general as mm_gen
 
-import logging
 logger = logging.getLogger(__name__)
 
 
@@ -30,6 +30,15 @@ sat_ids = {'': ['']}
 # good day to download test data for. Downloads aren't currently supported
 _test_dates = {'': {'': pysat.datetime(2019, 1, 1)}}
 
+prefix = 'SPORT_{tag}_IVM_'
+format_str = ''.join(('{year:04d}-{month:02d}-{day:02d}',
+                      '_v{version:02d}r{revision:04d}.NC'))
+supported_tags = {'': {'': ''.join((prefix.format(tag='L2'), format_str)),
+                       'L1': ''.join((prefix.format(tag='L1'), format_str)),
+                       'L0': ''.join((prefix.format(tag='L0'), format_str))}}
+list_files = functools.partial(mm_gen.list_files,
+                               supported_tags=supported_tags)
+
 
 def init(self):
     """Initializes the Instrument object with instrument specific values.
@@ -38,8 +47,8 @@ def init(self):
 
     """
 
-    logger.info("Mission acknowledgements and data restrictions will be printed " +
-          "here when available.")
+    logger.info(' '.join(("Mission acknowledgements and data restrictions will",
+                          "be printed here when available.")))
 
     pass
 
@@ -88,61 +97,6 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     """
 
     return pysat.utils.load_netcdf4(fnames, **kwargs)
-
-
-def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
-    """Produce a list of files corresponding to SPORT IVM.
-
-    This routine is invoked by pysat and is not intended for direct use by
-    the end user.
-
-    Multiple data levels may be supported via the 'tag' input string.
-    Currently defaults to level-2 data, or L2 in the filename.
-
-    Parameters
-    ----------
-    tag : string ('')
-        tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
-        Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    data_path : string
-        Full path to directory containing files to be loaded. This
-        is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
-        String template used to parse the datasets filenames. If a user
-        supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
-
-    Returns
-    -------
-    pandas.Series
-        Series of filename strings, including the path, indexed by datetime.
-
-    Examples
-    --------
-    ::
-        If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
-        is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
-        'v{version:02d}r{revision:04d}.NC'
-
-    Note
-    ----
-    The returned Series should not have any duplicate datetimes. If there are
-    multiple versions of a file the most recent version should be kept and the
-    rest discarded. This routine uses the pysat.Files.from_os constructor, thus
-    the returned files are up to pysat specifications.
-
-    """
-
-    if format_str is None:
-        if tag == '':
-            tag = 'L2'
-        format_str = ''.join(['SPORT_', tag, '_IVM_{year:04d}-{month:02d}-'
-                              '{day:02d}_v{version:02d}r{revision:04d}.NC'])
-    return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 
 
 def download(date_array, tag, sat_id, data_path=None, user=None,

--- a/pysat/instruments/superdarn_grdex.py
+++ b/pysat/instruments/superdarn_grdex.py
@@ -153,16 +153,16 @@ def list_files(tag='north', sat_id=None, data_path=None, format_str=None):
 
     Parameters
     -----------
-    tag : (string)
+    tag : string
         Denotes type of file to load.  Accepted types are 'north' and 'south'.
         (default='north')
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
 

--- a/pysat/instruments/superdarn_grdex.py
+++ b/pysat/instruments/superdarn_grdex.py
@@ -34,8 +34,6 @@ are constituted from what it is thought to be good data.
 
 from __future__ import print_function
 from __future__ import absolute_import
-import sys
-import os
 import functools
 
 import pandas as pds

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -36,11 +36,13 @@ Warnings
 """
 
 from __future__ import print_function, absolute_import
-import pandas as pds
+import functools
 import numpy as np
 from os import path
-import functools
+import re
 import warnings
+
+import pandas as pds
 
 import pysat
 
@@ -320,7 +322,6 @@ def load_csv_data(fname, tag):
         Pandas DataFrame
 
     """
-    import re
 
     if tag == "stations":
         # Because there may be multiple operators, the default pandas reader
@@ -389,7 +390,7 @@ def load_ascii_data(fname, tag):
         baselines for each file.  None of not present or not applicable.
 
     """
-    import re
+
     ndata = {"indices": 2, "": 4, "all": 4, "stations": 8}
     dkeys = {'stations': list(), '': ['IAGA', 'N', 'E', 'Z']}
     data = pds.DataFrame(None)
@@ -735,7 +736,6 @@ def append_ascii_data(file_strings, tag):
         String with all data, ready for output to a file
 
     """
-    import re
 
     # Start with data from the first list element
     out_lines = file_strings[0].split('\n')

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -64,12 +64,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     # if the tag is 'indices', update data_path to reflect this
@@ -101,28 +95,28 @@ def list_remote_files(tag='', sat_id=None, data_path=None, format_str=None,
 
     Parameters
     ----------
-    tag : (string)
+    tag : string
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements).
         (default='')
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
-    year : (int or NoneType)
+    year : int or NoneType
         Selects a given year to return remote files for.  None returns all
         years.
         (default=None)
-    month : (int or NoneType)
+    month : int or NoneType
         Selects a given month to return remote files for.  None returns all
         months.  Requires year to be defined.
         (default=None)
-    day : (int or NoneType)
+    day : int or NoneType
         Selects a given day to return remote files for.  None returns all
         days.  Requires year and month to be defined.
         (default=None)
@@ -175,22 +169,22 @@ def list_files(tag='', sat_id=None, data_path=None, format_str=None):
 
     Parameters
     -----------
-    tag : (string)
+    tag : string
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements). (default='')
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
 
     Returns
     --------
-    pysat.Files.from_os : (pysat._files.Files)
+    pysat.Files.from_os : pysat._files.Files
         A pandas Series containing the verified available files
 
     """
@@ -247,19 +241,19 @@ def load(fnames, tag='', sat_id=None):
 
     Parameters
     -----------
-    fnames : (list)
+    fnames : list
         List of filenames
-    tag : (str)
+    tag : str
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements). (default='')
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         Satellite ID for constellations, not used. (default=None)
 
     Returns
     --------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
 
     """
@@ -314,15 +308,15 @@ def load_csv_data(fname, tag):
 
     Parameters
     ------------
-    fname : (str)
+    fname : str
         CSV SuperMAG file name
-    tag : (str)
+    tag : str
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements).
 
     Returns
     --------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Pandas DataFrame
 
     """
@@ -380,17 +374,17 @@ def load_ascii_data(fname, tag):
 
     Parameters
     ------------
-    fname : (str)
+    fname : str
         ASCII SuperMAG filename
-    tag : (str)
+    tag : str
         Denotes type of file to load.  Accepted types are 'indices', 'all',
         'stations', and '' (for just magnetometer measurements).
 
     Returns
     --------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Pandas DataFrame
-    baseline : (list)
+    baseline : list
         List of strings denoting the presence of a standard and file-specific
         baselines for each file.  None of not present or not applicable.
 
@@ -537,12 +531,12 @@ def update_smag_metadata(col_name):
 
     Parameters
     -----------
-    col_name : (str)
+    col_name : str
         Data column name
 
     Returns
     --------
-    col_dict : (dict)
+    col_dict : dict
        Dictionary of strings detailing the units and long-form name of the data
 
     """
@@ -619,13 +613,13 @@ def format_baseline_list(baseline_list):
 
     Parameters
     ------------
-    baseline_list : (list)
+    baseline_list : list
         List of strings specifying the baseline information for each
         SuperMAG file
 
     Returns
     ---------
-    base_string : (str)
+    base_string : str
         Single string containing the relevent data
 
     """

--- a/pysat/instruments/sw_dst.py
+++ b/pysat/instruments/sw_dst.py
@@ -7,7 +7,7 @@ platform
     'sw'
 name
     'dst'
-tag 
+tag
     None supported
 
 Note
@@ -47,18 +47,18 @@ def load(fnames, tag=None, sat_id=None):
 
     Parameters
     ------------
-    fnames : (pandas.Series)
+    fnames : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
     ---------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
 
     Note
@@ -126,22 +126,22 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are '1min' and '5min'.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
 
     Returns
     --------
-    pysat.Files.from_os : (pysat._files.Files)
+    pysat.Files.from_os : pysat._files.Files
         A class containing the verified available files
 
     Notes
@@ -178,20 +178,15 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-
-    Returns
-    --------
-    Void : (NoneType)
-        data downloaded to disk, if available.
 
     Notes
     -----

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -201,7 +201,6 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     Called by pysat. Not intended for direct use by user.
 
     """
-    import time
 
     if data_path is not None:
         if tag == '':

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -84,18 +84,18 @@ def load(fnames, tag=None, sat_id=None):
 
     Parameters
     ------------
-    fnames : (pandas.Series)
+    fnames : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
     ---------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
 
     Notes
@@ -178,22 +178,22 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
 
     Returns
     --------
-    pysat.Files.from_os : (pysat._files.Files)
+    pysat.Files.from_os : pysat._files.Files
         A class containing the verified available files
 
     Notes
@@ -334,20 +334,15 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are '' and 'forecast'.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-
-    Returns
-    --------
-    Void : (NoneType)
-        data downloaded to disk, if available.
 
     Note
     ----
@@ -626,14 +621,14 @@ def parse_45day_block(block_lines):
 
     Parameters
     ----------
-    block_lines : (list)
+    block_lines : list
         List of lines containing data in this data block
 
     Returns
     -------
-    dates : (list)
+    dates : list
         List of dates for each date/data pair in this block
-    values : (list)
+    values : list
         List of values for each date/data pair in this block
 
     """
@@ -662,16 +657,12 @@ def rewrite_daily_file(year, outfile, lines):
 
     Parameters
     ----------
-    year : (int)
+    year : int
         Year of data file (format changes based on date)
-    outfile : (str)
+    outfile : str
         Output filename
-    lines : (str)
+    lines : str
         String containing all output data (result of 'read')
-
-    Returns
-    -------
-    Void
 
     """
 
@@ -706,18 +697,18 @@ def parse_daily_solar_data(data_lines, year, optical):
 
     Parameters
     ----------
-    data_lines : (list)
+    data_lines : list
         List of lines containing data
-    year : (list)
+    year : list
         Year of file
-    optical : (boolean)
+    optical : boolean
         Flag denoting whether or not optical data is available
 
     Returns
     -------
-    dates : (list)
+    dates : list
         List of dates for each date/data pair in this block
-    values : (dict)
+    values : dict
         Dict of lists of values, where each key is the value name
 
     """
@@ -769,13 +760,13 @@ def calc_f107a(f107_inst, f107_name='f107', f107a_name='f107a', min_pnts=41):
 
     Parameters
     ----------
-    f107_inst : (pysat.Instrument)
+    f107_inst : pysat.Instrument
         pysat Instrument holding the F10.7 data
-    f107_name : (str)
+    f107_name : str
         Data column name for the F10.7 data (default='f107')
-    f107a_name : (str)
+    f107a_name : str
         Data column name for the F10.7a data (default='f107a')
-    min_pnts : (int)
+    min_pnts : int
         Minimum number of points required to calculate an average (default=41)
 
     Returns

--- a/pysat/instruments/sw_kp.py
+++ b/pysat/instruments/sw_kp.py
@@ -91,18 +91,18 @@ def load(fnames, tag=None, sat_id=None):
 
     Parameters
     ------------
-    fnames : (pandas.Series)
+    fnames : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
 
     Returns
     ---------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
 
     Notes
@@ -186,22 +186,22 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    format_str : (string or NoneType)
+    format_str : string or NoneType
         User specified file format.  If None is specified, the default
         formats associated with the supplied tags are used. (default=None)
 
     Returns
     --------
-    pysat.Files.from_os : (pysat._files.Files)
+    pysat.Files.from_os : pysat._files.Files
         A class containing the verified available files
 
     Notes
@@ -261,20 +261,15 @@ def download(date_array, tag, sat_id, data_path, user=None, password=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are '' and 'forecast'.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-
-    Returns
-    --------
-    Void : (NoneType)
-        data downloaded to disk, if available.
 
     Note
     ----
@@ -425,11 +420,6 @@ def filter_geoquiet(sat, maxKp=None, filterTime=None, kpData=None,
     kp_inst : pysat.Instrument (optional)
         Kp pysat.Instrument object ready to load Kp data.Overrides kpData.
 
-    Returns
-    -------
-    None : NoneType
-        sat Instrument object modified in place
-
     Notes
     -----
     Loads Kp data for the same timeframe covered by sat and sets sat.data to
@@ -473,18 +463,12 @@ def initialize_kp_metadata(meta, data_key, fill_val=-1):
 
     Parameters
     ----------
-    meta : (pysat._meta.Meta)
+    meta : pysat._meta.Meta
         Pysat Metadata
-    data_key : (str)
+    data_key : str
         String denoting the data key
-    fill_val : (int or float)
+    fill_val : int or float
         File-specific fill value (default=-1)
-
-    Returns
-    -------
-    Void
-
-    Updates metadata
 
     """
 
@@ -506,7 +490,7 @@ def convert_3hr_kp_to_ap(kp_inst):
 
     Parameters
     ----------
-    kp_inst : (pysat.Instrument)
+    kp_inst : pysat.Instrument
         Pysat instrument containing Kp data
 
     Returns

--- a/pysat/instruments/templates/madrigal_pandas.py
+++ b/pysat/instruments/templates/madrigal_pandas.py
@@ -20,19 +20,18 @@ Warnings
     Files can be safely downloaded without knowing the file_format keyword,
     or equivalently, how Madrigal names the files. See `Examples` for more.
 
-Properties
+Parameters
 ----------
-platform
+platform : string
     'madrigal'
-name
+name : string
     'pandas'
-tag
+tag : string
     ''
 
 Examples
 --------
 ::
-
     # for isolated use of a madrigal data set
     import pysat
     # download DMSP data from Madrigal
@@ -179,8 +178,8 @@ def _general_download(date_array, tag='', sat_id='', data_path=None, user=None,
     kindat : int
         Madrigal integer code used to identify data set (default=None)
 
-    Notes
-    -----
+    Note
+    ----
     The user's names should be provided in field user. Ruby Payne-Scott should
     be entered as Ruby+Payne-Scott
 

--- a/pysat/instruments/templates/madrigal_pandas.py
+++ b/pysat/instruments/templates/madrigal_pandas.py
@@ -133,12 +133,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     logger.info(mad_meth.cedar_rules())
@@ -166,30 +160,24 @@ def _general_download(date_array, tag='', sat_id='', data_path=None, user=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
     inst_code : int
-        Madrigal integer code used to identify platform
+        Madrigal integer code used to identify platform (default=None)
     kindat : int
-        Madrigal integer code used to identify data set
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
+        Madrigal integer code used to identify data set (default=None)
 
     Notes
     -----
@@ -210,11 +198,6 @@ def _general_download(date_array, tag='', sat_id='', data_path=None, user=None,
 def clean(self):
     """Placeholder routine that would normally return cleaned data
 
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
     Notes
     --------
     Supports 'clean', 'dusty', 'dirty' in the sense that it prints
@@ -224,6 +207,7 @@ def clean(self):
     Routine is called by pysat, and not by the end user directly.
 
     """
+
     if self.clean_level in ['clean', 'dusty', 'dirty']:
         logger.warning('Generalized Madrigal data support has no cleaning.')
 

--- a/pysat/instruments/templates/netcdf_pandas.py
+++ b/pysat/instruments/templates/netcdf_pandas.py
@@ -120,20 +120,20 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
+        This input is nominally provided by pysat itself. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
+        This input is nominally provided by pysat itself. (default='')
     data_path : string
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
+        at Instrument instantiation and it will appear here. (default=None)
+    format_str : string
         String template used to parse the datasets filenames. If a user
         supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
+        then it will appear here, otherwise defaults to None. (default=None)
 
     Returns
     -------
@@ -147,6 +147,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
         is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
         'v{version:02d}r{revision:04d}.NC'
+
 
     Note
     ----
@@ -187,26 +188,20 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
+        is provided by pysat. (default='')
     data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
-        error if user not supplied.
-    password : string (None)
-        Password for data download.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
-
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
 
     """
 

--- a/pysat/instruments/templates/template_cdaweb_instrument.py
+++ b/pysat/instruments/templates/template_cdaweb_instrument.py
@@ -145,12 +145,6 @@ def default(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     return
@@ -175,17 +169,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -341,40 +341,20 @@ def load(fnames, tag=None, sat_id=None, custom_keyword=None):
     # we can adapt pysat to the standard by specifying
     # the string labels used in the file
     # function below returns both data and metadata
-    return pysat.utils.load_netcdf4(fnames, epoch_name='Epoch',
-                                    units_label='Units',
-                                    name_label='Long_Name',
-                                    notes_label='Var_Notes',
-                                    desc_label='CatDesc',
-                                    plot_label='FieldNam',
-                                    axis_label='LablAxis',
-                                    scale_label='ScaleTyp',
-                                    min_label='ValidMin',
-                                    max_label='ValidMax',
-                                    fill_label='FillVal')
+    data, mdata = pysat.utils.load_netcdf4(fnames, epoch_name='Epoch',
+                                           units_label='Units',
+                                           name_label='Long_Name',
+                                           notes_label='Var_Notes',
+                                           desc_label='CatDesc',
+                                           plot_label='FieldNam',
+                                           axis_label='LablAxis',
+                                           scale_label='ScaleTyp',
+                                           min_label='ValidMin',
+                                           max_label='ValidMax',
+                                           fill_label='FillVal'
+                                           pandas_format=pandas_format)
+    # Some variables may need modification.  For example, pysat requires a
+    # variable in the index named 'time' for xarray objects.  These can be set
+    # here
 
-    # This code below demonstrates the use of xarray
-    # functions to load TIEGCM data
-    # Metadata is transferred from xarray to the Instrument object
-    # Data is transferred as well
-    # data not indexed by time are transferred to the Instrument object as an
-    # attribute
-
-    # load data
-    data = xr.open_dataset(fnames[0])
-    # move attributes to the Meta object
-    # these attributes will be trasnferred to the Instrument object
-    # automatically by pysat
-    meta = pysat.Meta()
-    for attr in data.attrs:
-        setattr(meta, attr[0], attr[1])
-    data.attrs = {}
-
-    # fill Meta object with variable information
-    for key in data.variables.keys():
-        attrs = data.variables[key].attrs
-        meta[key] = attrs
-        # remove attributes from xarray
-        data.variables[key].attrs = {}
-
-    return data, meta
+    return data, mdata

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -148,21 +148,20 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
     custom_keywords : placeholder
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this
@@ -172,11 +171,11 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
 
     return
 
-# not required
+
 def init(self):
     """Initializes the Instrument object with instrument specific values.
 
-    Runs once upon instantiation. Object modified in place.
+    Runs once upon instantiation. Object modified in place. Optional.
 
     Parameters
     ----------
@@ -203,20 +202,20 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
+        This input is nominally provided by pysat itself. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    data_path : string (None)
+        This input is nominally provided by pysat itself. (default='')
+    data_path : string
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
+        at Instrument instantiation and it will appear here. (default=None)
+    format_str : string
         String template used to parse the datasets filenames. If a user
         supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
+        then it will appear here, otherwise defaults to None. (default=None)
 
     Returns
     -------
@@ -226,9 +225,11 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     Examples
     --------
     ::
+
         If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
         is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
         'v{version:02d}r{revision:04d}.NC'
+
 
     Note
     ----
@@ -261,16 +262,16 @@ def list_remote_files(tag, sat_id, user=None, password=None):
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    user : (string or NoneType)
+    user : string or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)
-    password : (string or NoneType)
+    password : string or NoneType
         User password to be passed along to resource with relevant data.
         (default=None)
 
@@ -296,14 +297,14 @@ def load(fnames, tag=None, sat_id=None, custom_keyword=None):
     fnames : array-like
         iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. While
         tag defaults to None here, pysat provides '' as the default
-        tag unless specified by user at Instrument instantiation.
-    sat_id : string ('')
+        tag unless specified by user at Instrument instantiation. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
+        This input is nominally provided by pysat itself. (default='')
     custom_keyword : type to be set
         Developers may include any custom keywords, with default values
         defined in the method signature. This is included here as a
@@ -316,16 +317,19 @@ def load(fnames, tag=None, sat_id=None, custom_keyword=None):
         pandas DataFrame or xarray DataSet while metadata is a pysat.Meta
         instance.
 
+
     Note
     ----
     Any additional keyword arguments passed to pysat.Instrument
     upon instantiation are passed along to this routine.
 
+
     Examples
     --------
     ::
+
         inst = pysat.Instrument('ucar', 'tiegcm')
-        inst.load(2019,1)
+        inst.load(2019, 1)
 
     """
 

--- a/pysat/instruments/timed_saber.py
+++ b/pysat/instruments/timed_saber.py
@@ -53,83 +53,30 @@ from __future__ import absolute_import
 import functools
 
 import pysat
-# CDAWeb methods prewritten for pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
 from pysat.instruments.methods import general as mm_gen
 
-# the platform and name strings associated with this instrument
-# need to be defined at the top level
-# these attributes will be copied over to the Instrument object by pysat
-# the strings used here should also be used to name this file
-# platform_name.py
 platform = 'timed'
 name = 'saber'
 
 # dictionary of data 'tags' and corresponding description
 tags = {'': ''}
-
-# Let pysat know if there are multiple satellite platforms supported
-# by these routines
-# define a dictionary keyed by satellite ID, each with a list of
-# corresponding tags
-# sat_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
 sat_ids = {'': ['']}
 
-# Define good days to download data for when pysat undergoes testing.
-# format is outer dictionary has sat_id as the key
-# each sat_id has a dictionary of test dates keyed by tag string
-# _test_dates = {'a':{'L0':pysat.datetime(2019,1,1),
-#                     'L1':pysat.datetime(2019,1,2)},
-#                'b':{'L1':pysat.datetime(2019,3,1),
-#                     'L2':pysat.datetime(2019,11,23),}}
 _test_dates = {'': {'': pysat.datetime(2019, 1, 1)}}
 
-# Additional information needs to be defined
-# to support the CDAWeb list files routine
-# We need to define a filename format string for every
-# supported combination of sat_id and tag string
-# fname1 = 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
-# fname2 = 'cnofs_vefi_acfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
-# supported_tags = {'sat1':{'tag1':fname1},
-#                   'sat2':{'tag2':fname2}}
-# you can use format keywords year, month, day, hour, min, sec,
-# version and revision
-# see code docstring for latest
 fname = ''.join(('timed_l2av207_saber_{year:04d}{month:02d}{day:02d}',
                  '????_v01.cdf'))
 supported_tags = {'': {'': fname}}
 # use the CDAWeb methods list files routine
-# the command below presets some of the methods inputs, leaving
-# those provided by pysat available when invoked
 list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # let pysat know that data is spread across more than one file
 multi_file_day = True
-
-# Set to False to specify using xarray (not using pandas)
-# Set to True if data will be returned via a pandas DataFrame
 pandas_format = True
 
-#
-# support load routine
-#
-# use the default CDAWeb method
-# no other information needs to be supplied here
-# pysatCDF is used to load data
 load = cdw.load
-
-#
-# support download routine
-#
-# to use the default CDAWeb method
-# we need to provide additional information
-# directory location on CDAWeb ftp server
-# formatting template for filenames on CDAWeb
-# formatting template for files saved to the local disk
-# a dictionary needs to be created for each sat_id and tag
-# combination along with the file format template
-# outer dict keyed by sat_id, inner dict keyed by tag
 basic_tag = {'dir': '/pub/data/timed/saber/level2a_v2_07_cdf',
              'remote_fname': '{year:4d}/{month:02d}/' + fname,
              'local_fname': fname}
@@ -141,30 +88,6 @@ list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)
 
 
-# code should be defined below as needed
-def default(self):
-    """Default customization function.
-
-    This routine is automatically applied to the Instrument object
-    on every load by the pysat nanokernel (first in queue).
-
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
-
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
-    """
-
-    return
-
-
-# code should be defined below as needed
 def clean(inst):
     """Routine to return PLATFORM/NAME data cleaned to the specified level
 

--- a/pysat/instruments/timed_saber.py
+++ b/pysat/instruments/timed_saber.py
@@ -183,17 +183,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/timed_see.py
+++ b/pysat/instruments/timed_see.py
@@ -17,7 +17,7 @@ tag
     None
 sat_id
     None supported
-flatten_twod 
+flatten_twod
     If True, then two dimensional data is flattened across
     columns. Name mangling is used to group data, first column
     is 'name', last column is 'name_end'. In between numbers are
@@ -84,18 +84,14 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
 
     Notes
     --------
     No cleaning currently available.
+
     """
 
     return None

--- a/pysat/instruments/timed_see.py
+++ b/pysat/instruments/timed_see.py
@@ -83,13 +83,13 @@ def clean(inst):
     """Routine to return TIMED SEE data cleaned to the specified level
 
     Parameters
-    -----------
+    ----------
     inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
 
-    Notes
-    --------
+    Note
+    ----
     No cleaning currently available.
 
     """

--- a/pysat/instruments/ucar_tiegcm.py
+++ b/pysat/instruments/ucar_tiegcm.py
@@ -20,11 +20,12 @@ sat_id
 # python 2/3 comptability
 from __future__ import print_function
 from __future__ import absolute_import
+import logging
+import warnings
 
 import xarray as xr
 import pysat
 
-import logging
 logger = logging.getLogger(__name__)
 
 # the platform and name strings associated with this instrument
@@ -224,8 +225,6 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
         routine via kwargs.
 
     """
-
-    import warnings
 
     warnings.warn('Not implemented in this version.')
     return

--- a/pysat/instruments/ucar_tiegcm.py
+++ b/pysat/instruments/ucar_tiegcm.py
@@ -60,12 +60,6 @@ def init(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     logger.info("Mission acknowledgements and data restrictions will be printed " +
@@ -84,12 +78,12 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     fnames : array-like
         iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
+        This input is nominally provided by pysat itself. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
+        This input is nominally provided by pysat itself. (default='')
     **kwargs : extra keywords
         Passthrough for additional keyword arguments specified when
         instantiating an Instrument object. These additional keywords
@@ -109,6 +103,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     Examples
     --------
     ::
+
         inst = pysat.Instrument('ucar', 'tiegcm')
         inst.load(2019,1)
 
@@ -153,20 +148,20 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
+        This input is nominally provided by pysat itself. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    data_path : string (None)
+        This input is nominally provided by pysat itself. (default='')
+    data_path : string
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
+        at Instrument instantiation and it will appear here. (default=None)
+    format_str : string
         String template used to parse the datasets filenames. If a user
         supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
+        then it will appear here, otherwise defaults to None. (default=None)
 
     Returns
     -------
@@ -176,6 +171,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     Examples
     --------
     ::
+
         If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
         is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
         'v{version:02d}r{revision:04d}.NC'
@@ -208,31 +204,24 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
         pysat.
-    sat_id : string  ('')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
     **kwargs : dict
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this
         routine via kwargs.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
-
 
     """
 


### PR DESCRIPTION
- removes void returns
- standardized parameter lists (no parens, default at end of long description)
- updates template with new load info for xarray
- removes unused bits of template leftover in some instruments (de2, saber)
- uses general list_files for sport_ivm to cut down on untested code

Merge chain: This branch => #480 => #469