### PR TITLE
DOC/TST: deprecation in docstring, format stuff, test compliance

### DIFF
--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -150,6 +150,9 @@ class Constellation(object):
         Combines signals from multiple instruments within
         given bounds.
 
+        .. deprecated:: 2.2.0
+          `add` will be removed in pysat 3.0.0, it will be added to pysatSeasons
+
         Parameters
         ----------
         bounds1 : (min, max)
@@ -266,6 +269,10 @@ class Constellation(object):
         """
         Calculates the difference in signals from multiple
         instruments within the given bounds.
+
+        .. deprecated:: 2.2.0
+          `difference` will be removed in pysat 3.0.0, it will be added to
+          pysatSeasons
 
         Parameters
         ----------

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -58,6 +58,10 @@ class Custom(object):
     def add(self, function, kind='add', at_pos='end', *args, **kwargs):
         """Add a function to custom processing queue.
 
+        .. deprecated:: 2.2.0
+          `add` will be removed in pysat 3.0.0, it is replaced by
+          `attach` to clarify the syntax
+
         Custom functions are applied automatically to associated
         pysat instrument whenever instrument.load command called.
 

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -113,6 +113,7 @@ class Meta(object):
     Examples
     --------
     ::
+
         # instantiate Meta object, default values for attribute labels are used
         meta = pysat.Meta()
         # set a couple base units

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -65,7 +65,7 @@ import pandas as pds
 
 import pysat
 from pysat.instruments.methods import madrigal as mad_meth
-from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 import logging
 logger = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ dmsp_fname1 = {'utd': 'dms_ut_{year:4d}{month:02d}{day:02d}_',
 dmsp_fname2 = {'utd': '.{version:03d}.hdf5', '': 's?.{version:03d}.hdf5'}
 supported_tags = {ss: {kk: dmsp_fname1[kk] + ss[1:] + dmsp_fname2[kk]
                        for kk in sat_ids[ss]} for ss in sat_ids.keys()}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # madrigal tags

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -40,7 +40,7 @@ import numpy as np
 
 import pysat
 from pysat.instruments.methods import madrigal as mad_meth
-from pysat.instruments.methods import nasa_cdaweb as cdw
+from pysat.instruments.methods import general as mm_gen
 
 import logging
 logger = logging.getLogger(__name__)
@@ -69,7 +69,7 @@ supported_tags = {ss: {'drifts': jro_fname1 + "drifts" + jro_fname2,
                        'oblique_rand': jro_fname1 + "?" + jro_fname2,
                        'oblique_long': jro_fname1 + "?" + jro_fname2}
                   for ss in sat_ids.keys()}
-list_files = functools.partial(cdw.list_files,
+list_files = functools.partial(mm_gen.list_files,
                                supported_tags=supported_tags)
 
 # madrigal tags

--- a/pysat/instruments/methods/madrigal.py
+++ b/pysat/instruments/methods/madrigal.py
@@ -17,7 +17,7 @@ import sys
 
 import h5py
 from madrigalWeb import madrigalWeb
-    
+
 import pysat
 
 logger = logging.getLogger(__name__)
@@ -519,8 +519,11 @@ def filter_data_single_date(self):
 
     This routine is intended to be added to the Instrument
     nanokernel processing queue via
+    ::
+
         inst = pysat.Instrument()
         inst.custom.add(filter_data_single_date, 'modify')
+
     This function will then be automatically applied to the
     Instrument object data on every load by the pysat nanokernel.
 
@@ -531,7 +534,10 @@ def filter_data_single_date(self):
     pysat instrument file to this one.
 
     within platform_name.py set
+    ::
+
         default = pysat.instruments.methods.madrigal.filter_data_single_date
+
     at the top level
 
     """

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -23,6 +23,10 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                two_digit_year_break=None):
     """Return a Pandas Series of every file for chosen satellite data.
 
+    .. deprecated:: 2.2.0
+      `list_files` will be removed in pysat 3.0.0, it will be replaced by the
+      copy in instruments.methods.general
+
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
 
@@ -71,11 +75,6 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         supported_tags = {'': fname}
         list_files = functools.partial(cdw.list_files,
                                        supported_tags=supported_tags)
-
-    Note
-    ----
-    This function has been deprecated and will be removed in pysat 3.0.0.
-    Please use methods.general.list_files instead
 
     """
 
@@ -336,6 +335,10 @@ def list_remote_files(tag, sat_id,
                       two_digit_year_break=None, delimiter=None,
                       year=None, month=None, day=None):
     """Return a Pandas Series of every file for chosen remote data.
+
+    .. deprecated:: 2.2.0
+      `year/month/day` keywords will be removed in pysat 3.0.0, they will be
+      replaced with a start/stop syntax consistent with the download routine
 
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.

--- a/pysat/instruments/supermag_magnetometer.py
+++ b/pysat/instruments/supermag_magnetometer.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Supports SuperMAG ground magnetometer measurements and SML/SMU indices.
 Downloading is supported; please follow their rules of the road:
-    http://supermag.jhuapl.edu/info/?page=rulesoftheroad
+http://supermag.jhuapl.edu/info/?page=rulesoftheroad
 
 Properties
 ----------

--- a/pysat/model_utils.py
+++ b/pysat/model_utils.py
@@ -23,6 +23,10 @@ from pysat import logger
 def satellite_view_through_model(sat, tie, scoords, tlabels):
     """Interpolate model values onto satellite orbital path.
 
+    .. deprecated:: 2.2.0
+      `satellite_view_through_model` will be removed in pysat 3.0.0, it will
+      be added to pysatModels
+
     Parameters
     ----------
     sat : pysat.Instrument object
@@ -69,6 +73,10 @@ def satellite_view_through_model(sat, tie, scoords, tlabels):
 def compare_model_and_inst(pairs=None, inst_name=[], mod_name=[],
                            methods=['all']):
     """Compare modelled and measured data
+
+    .. deprecated:: 2.2.0
+      `satellite_view_through_model` will be removed in pysat 3.0.0, it will
+      be added to pysatModels
 
     Parameters
     ------------
@@ -254,6 +262,10 @@ def collect_inst_model_pairs(start=None, stop=None, tinc=None, inst=None,
                              comp_clean='clean'):
     """Pair instrument and model data, applying data cleaning after finding the
     times and locations where the instrument and model align
+
+    .. deprecated:: 2.2.0
+      `collect_inst_model_pairs` will be removed in pysat 3.0.0, it will
+      be added to pysatModels
 
     Parameters
     ----------
@@ -470,6 +482,10 @@ def extract_modelled_observations(inst=None, model=None, inst_name=[],
                                   sel_name=None, method='linear',
                                   model_label='model'):
     """Extracts instrument-aligned data from a modelled data set
+
+    .. deprecated:: 2.2.0
+      `extract_modelled_observations` will be removed in pysat 3.0.0, it will
+      be added to pysatModels
 
     Parameters
     ----------

--- a/pysat/ssnl/_core.py
+++ b/pysat/ssnl/_core.py
@@ -2,6 +2,10 @@ def computational_form(data):
     """
     Repackages numbers, Series, or DataFrames
 
+    .. deprecated:: 2.2.0
+      `computational_form` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     Regardless of input format, mathematical operations may be performed on the
     output via the same pandas mechanisms.
 

--- a/pysat/ssnl/avg.py
+++ b/pysat/ssnl/avg.py
@@ -16,6 +16,10 @@ import warnings
 def median1D(const, bin1, label1, data_label, auto_bin=True, returnData=False):
     """Return a 1D median of data_label over a season and label1
 
+    .. deprecated:: 2.2.0
+      `median1D` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     Parameters
     ----------
     const: Constellation or Instrument
@@ -109,6 +113,10 @@ def median1D(const, bin1, label1, data_label, auto_bin=True, returnData=False):
 def median2D(const, bin1, label1, bin2, label2, data_label,
              returnData=False, auto_bin=True):
     """Return a 2D average of data_label over a season and label1, label2.
+
+    .. deprecated:: 2.2.0
+      `median2D` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
 
     Parameters
     ----------
@@ -328,6 +336,10 @@ def _calc_2d_median(ans, data_label, binx, biny, xarr, yarr, zarr, numx,
 def mean_by_day(inst, data_label):
     """Mean of data_label by day over Instrument.bounds
 
+    .. deprecated:: 2.2.0
+      `mean_by_day` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     Parameters
     ----------
     data_label : string
@@ -352,6 +364,10 @@ def mean_by_day(inst, data_label):
 def mean_by_orbit(inst, data_label):
     """Mean of data_label by orbit over Instrument.bounds
 
+    .. deprecated:: 2.2.0
+      `mean_by_orbit` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     Parameters
     ----------
     data_label : string
@@ -375,6 +391,10 @@ def mean_by_orbit(inst, data_label):
 
 def mean_by_file(inst, data_label):
     """Mean of data_label by orbit over Instrument.bounds
+
+    .. deprecated:: 2.2.0
+      `mean_by_file` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
 
     Parameters
     ----------

--- a/pysat/ssnl/occur_prob.py
+++ b/pysat/ssnl/occur_prob.py
@@ -25,6 +25,10 @@ def daily2D(inst, bin1, label1, bin2, label2, data_label, gate,
             returnBins=False):
     """2D Daily Occurrence Probability of data_label > gate over a season.
 
+    .. deprecated:: 2.2.0
+      `daily2D` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     If data_label is greater than gate at least once per day,
     then a 100% occurrence probability results.Season delineated by the bounds
     attached to Instrument object.
@@ -74,6 +78,10 @@ def daily2D(inst, bin1, label1, bin2, label2, data_label, gate,
 def by_orbit2D(inst, bin1, label1, bin2, label2, data_label, gate,
                returnBins=False):
     """2D Occurrence Probability of data_label orbit-by-orbit over a season.
+
+    .. deprecated:: 2.2.0
+      `by_orbit2D` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
 
     If data_label is greater than gate atleast once per orbit, then a
     100% occurrence probability results. Season delineated by the bounds
@@ -190,6 +198,10 @@ def daily3D(inst, bin1, label1, bin2, label2, bin3, label3,
             data_label, gate, returnBins=False):
     """3D Daily Occurrence Probability of data_label > gate over a season.
 
+    .. deprecated:: 2.2.0
+      `daily3D` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     If data_label is greater than gate atleast once per day,
     then a 100% occurrence probability results. Season delineated by
     the bounds attached to Instrument object.
@@ -238,6 +250,10 @@ def daily3D(inst, bin1, label1, bin2, label2, bin3, label3,
 def by_orbit3D(inst, bin1, label1, bin2, label2, bin3, label3,
                data_label, gate, returnBins=False):
     """3D Occurrence Probability of data_label orbit-by-orbit over a season.
+
+    .. deprecated:: 2.2.0
+      `by_orbit3D` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
 
     If data_label is greater than gate atleast once per orbit, then a
     100% occurrence probability results. Season delineated by the bounds

--- a/pysat/ssnl/plot.py
+++ b/pysat/ssnl/plot.py
@@ -14,6 +14,10 @@ def scatterplot(inst, labelx, labely, data_label, datalim, xlim=None,
     """Return scatterplot of data_label(s) as functions of labelx,y over a
     season.
 
+    .. deprecated:: 2.2.0
+      `scatterplot` will be removed in pysat 3.0.0, it will
+      be added to pysatSeasons
+
     Parameters
     ----------
     labelx : string

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -1,8 +1,6 @@
 import requests
 import warnings
 
-import pytest
-
 import pysat
 from pysat.instruments.methods import nasa_cdaweb as cdw
 
@@ -19,15 +17,17 @@ class TestCDAWeb():
 
     def test_remote_file_list_connection_error_append(self):
         """Test that pysat appends suggested help to ConnectionError"""
-        with pytest.raises(Exception) as excinfo:
-            # Giving a bad remote_site address yields similar ConnectionError
+        # Giving a bad remote_site address yields similar ConnectionError
+        try:
             cdw.list_remote_files(tag='', sat_id='',
                                   supported_tags=self.supported_tags,
                                   remote_site='http:/')
-
-        assert excinfo.type is requests.exceptions.ConnectionError
-        # Check that pysat appends the message
-        assert str(excinfo.value).find('pysat -> Request potentially') > 0
+        except Exception as excinfo:
+            assert isinstance(excinfo, requests.exceptions.ConnectionError)
+            # Check that pysat appends the message
+            assert str(excinfo.message).find('pysat -> Request potentially') > 0
+        else:
+            raise(ValueError, 'Test was expected to raise an Exception.')
 
     def test_remote_file_list_deprecation_warning(self):
         """Test generation of deprecation warning for remote_file_list kwargs

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -25,7 +25,7 @@ class TestCDAWeb():
         except Exception as excinfo:
             assert isinstance(excinfo, requests.exceptions.ConnectionError)
             # Check that pysat appends the message
-            assert str(excinfo.message).find('pysat -> Request potentially') > 0
+            assert str(excinfo).find('pysat -> Request potentially') > 0
         else:
             raise(ValueError, 'Test was expected to raise an Exception.')
 

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -151,6 +151,10 @@ def scale_units(out_unit, in_unit):
 def geodetic_to_geocentric(lat_in, lon_in=None, inverse=False):
     """Converts position from geodetic to geocentric or vice-versa.
 
+    .. deprecated:: 2.2.0
+      `geodetic_to_geocentric` will be removed in pysat 3.0.0, it will
+      be added to pysatMadrigal
+
     Parameters
     ----------
     lat_in : float
@@ -222,6 +226,10 @@ def geodetic_to_geocentric_horizontal(lat_in, lon_in, az_in, el_in,
     """Converts from local horizontal coordinates in a geodetic system to local
     horizontal coordinates in a geocentric system
 
+    .. deprecated:: 2.2.0
+      `geodetic_to_geocentric_horizontal` will be removed in pysat 3.0.0, it
+      will be added to pysatMadrigal
+
     Parameters
     ----------
     lat_in : float
@@ -292,6 +300,10 @@ def geodetic_to_geocentric_horizontal(lat_in, lon_in, az_in, el_in,
 def spherical_to_cartesian(az_in, el_in, r_in, inverse=False):
     """Convert a position from spherical to cartesian, or vice-versa
 
+    .. deprecated:: 2.2.0
+      `spherical_to_cartesian` will be removed in pysat 3.0.0, it will
+      be added to pysatMadrigal
+
     Parameters
     ----------
     az_in : float
@@ -350,6 +362,10 @@ def spherical_to_cartesian(az_in, el_in, r_in, inverse=False):
 def global_to_local_cartesian(x_in, y_in, z_in, lat_cent, lon_cent, rad_cent,
                               inverse=False):
     """Converts a position from global to local cartesian or vice-versa
+
+    .. deprecated:: 2.2.0
+      `global_to_local_cartesian` will be removed in pysat 3.0.0, it will
+      be added to pysatMadrigal
 
     Parameters
     ----------
@@ -443,6 +459,10 @@ def local_horizontal_to_global_geo(az, el, dist, lat_orig, lon_orig, alt_orig,
                                    geodetic=True):
     """ Convert from local horizontal coordinates to geodetic or geocentric
     coordinates
+
+    .. deprecated:: 2.2.0
+      `local_horizontal_to_global_geo` will be removed in pysat 3.0.0, it will
+      be added to pysatMadrigal
 
     Parameters
     ----------

--- a/pysat/utils/stats.py
+++ b/pysat/utils/stats.py
@@ -13,8 +13,9 @@ import warnings
 def median1D(self, bin_params, bin_label, data_label):
     """Calculates the median for a series of binned data.
 
-    ** Will be remvoed in a future version now that ssnl.avgs has a
-    similar function
+    .. deprecated:: 2.2.0
+      `median1D` will be removed in pysat 3.0.0, a
+      similar function will be added to pysatSeasons
 
     Parameters
     ----------
@@ -53,6 +54,10 @@ def median1D(self, bin_params, bin_label, data_label):
 
 def nan_circmean(samples, high=2.0*np.pi, low=0.0, axis=None):
     """NaN insensitive version of scipy's circular mean routine
+
+    .. deprecated:: 2.2.0
+      `nan_circmean` will be removed in pysat 3.0.0, this functionality has
+      been added to scipy 1.4
 
     Parameters
     -----------
@@ -108,6 +113,10 @@ def nan_circmean(samples, high=2.0*np.pi, low=0.0, axis=None):
 
 def nan_circstd(samples, high=2.0*np.pi, low=0.0, axis=None):
     """NaN insensitive version of scipy's circular standard deviation routine
+
+    .. deprecated:: 2.2.0
+      `nan_circstd` will be removed in pysat 3.0.0, this functionality has
+      been added to scipy 1.4
 
     Parameters
     -----------

--- a/pysat/utils/stats.py
+++ b/pysat/utils/stats.py
@@ -55,7 +55,7 @@ def median1D(self, bin_params, bin_label, data_label):
 def nan_circmean(samples, high=2.0*np.pi, low=0.0, axis=None):
     """NaN insensitive version of scipy's circular mean routine
 
-    .. deprecated:: 2.2.0
+    .. deprecated:: 2.1.0
       `nan_circmean` will be removed in pysat 3.0.0, this functionality has
       been added to scipy 1.4
 
@@ -114,7 +114,7 @@ def nan_circmean(samples, high=2.0*np.pi, low=0.0, axis=None):
 def nan_circstd(samples, high=2.0*np.pi, low=0.0, axis=None):
     """NaN insensitive version of scipy's circular standard deviation routine
 
-    .. deprecated:: 2.2.0
+    .. deprecated:: 2.1.0
       `nan_circstd` will be removed in pysat 3.0.0, this functionality has
       been added to scipy 1.4
 

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -128,7 +128,7 @@ def season_date_range(start, stop, freq='D'):
     """
     Deprecated Function, will be removed in future version.
 
-    .. deprecated:: 2.2.0
+    .. deprecated:: 2.1.0
       `season_date_range` will be removed in pysat 3.0.0, this will be
       replaced by create_date_range
 

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -128,7 +128,11 @@ def season_date_range(start, stop, freq='D'):
     """
     Deprecated Function, will be removed in future version.
 
-    Replaced by create_date_range
+    .. deprecated:: 2.2.0
+      `season_date_range` will be removed in pysat 3.0.0, this will be
+      replaced by create_date_range
+
+
 
     """
 


### PR DESCRIPTION
# Description

- Adds deprecation info to docstrings according to numpydoc
- minor formatting issues.
- Fixes a test that required pytest

## Type of change

- This change is a documentation update

# How Has This Been Tested?

make html

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
