### PR TITLE
BUG: Rocsat tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Remove wildcard imports, relative imports
   - Include flake8 check as part of testing suites
   - Improve unit testing coverage of instrument functions and instrument object
+  - Added warning for rocsat ivm download
 
 ## [2.2.0] - 2020-06-28
 - New Features

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -28,10 +28,13 @@ from __future__ import print_function
 from __future__ import absolute_import
 import datetime as dt
 import functools
+import logging
 import warnings
 
 from pysat.instruments.methods import general as mm_gen
 from pysat.instruments.methods import nasa_cdaweb as cdw
+
+logger = logging.getLogger(__name__)
 
 platform = 'rocsat1'
 name = 'ivm'
@@ -56,10 +59,45 @@ basic_tag = {'dir': '/pub/data/rocsat/ipei',
              'remote_fname': '{year:4d}/' + fname,
              'local_fname': fname}
 supported_tags = {'': {'': basic_tag}}
-download = functools.partial(cdw.download, supported_tags)
 # support listing files currently on CDAWeb
 list_remote_files = functools.partial(cdw.list_remote_files,
                                       supported_tags=supported_tags)
+
+
+def download(date_array, tag, sat_id, data_path=None, user=None,
+             password=None):
+    """Routine to download data.
+
+    This routine is invoked by pysat and is not intended for direct use by
+    the end user.
+
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need
+        not be contiguous.
+    tag : string
+        Tag identifier used for particular dataset. This input is provided by
+        pysat.  (default='')
+    sat_id : string
+        Satellite ID string identifier used for particular dataset. This input
+        is provided by pysat.  (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
+        User string input used for download. Provided by user and passed via
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
+
+    Warnings
+    --------
+    Data removed from server July 23, 2020
+
+    """
+    logger.warning("Data removed from server July 23, 2020. Attempting anyway")
+    return functools.partial(cdw.download, supported_tags)
 
 
 def clean(inst):

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -41,7 +41,7 @@ name = 'ivm'
 tags = {'': ''}
 sat_ids = {'': ['']}
 _test_dates = {'': {'': dt.datetime(2002, 1, 1)}}
-
+_test_download = {'': {kk: False for kk in tags.keys()}}
 
 # support list files routine
 # use the default CDAWeb method

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -97,8 +97,11 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
     location of data is sorted out.
 
     """
+
     logger.warning("Data removed from server July 23, 2020. Attempting anyway")
-    return functools.partial(cdw.download, supported_tags)
+    functools.partial(cdw.download, supported_tags)
+
+    return
 
 
 def clean(inst):

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -28,13 +28,10 @@ from __future__ import print_function
 from __future__ import absolute_import
 import datetime as dt
 import functools
-import logging
 import warnings
 
 from pysat.instruments.methods import general as mm_gen
 from pysat.instruments.methods import nasa_cdaweb as cdw
-
-logger = logging.getLogger(__name__)
 
 platform = 'rocsat1'
 name = 'ivm'
@@ -98,7 +95,7 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
 
     """
 
-    logger.warning("Data removed from server July 23, 2020. Attempting anyway")
+    warnings.warn("Data removed from server July 23, 2020. Attempting anyway")
     functools.partial(cdw.download, supported_tags)
 
     return

--- a/pysat/instruments/rocsat1_ivm.py
+++ b/pysat/instruments/rocsat1_ivm.py
@@ -93,7 +93,8 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
 
     Warnings
     --------
-    Data removed from server July 23, 2020
+    Data removed from server July 23, 2020.  Adding a warning until the new
+    location of data is sorted out.
 
     """
     logger.warning("Data removed from server July 23, 2020. Attempting anyway")


### PR DESCRIPTION
# Description

ROCSAT data has disappeared from the server.  Flipping the test flag and adding a user warning for now until the data reappears somewhere.

NOTE: this really should probably use the logger, but none of the other instruments do.  If we change over all instruments (here and elsewhere), this would require the corresponding unit test (`test_download_warning`) to use `caplog` instead of `with warnings.catch_warnings`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``master``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
