### PR TITLE
ENH: move file methods to utils.files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-07-03
+## [3.0.0] - 2020-08-05
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - `strict_time_flag` now defaults to True
   - Use of start / stop notation in remote_file_list
   - Added variable rename method to Instrument object (#91)
+  - Migrated file methods to pysat.utils.files (#336)
 - Deprecations
   - Removed ssnl
   - Removed utils.stats
@@ -33,6 +34,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed utils.coords.spherical_to_cartesian
   - Removed utils.coords.global_to_local_cartesian
   - Removed utils.coords.local_horizontal_to_global_geo
+  - Deprecation Warnings for methods in `pysat._files`
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and sat_id behaviour in testing instruments

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -552,6 +552,10 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     """Accepts dict with data parsed from filenames and creates
     a pandas Series object formatted for the Files class.
 
+    .. deprecated:: 3.0.0
+      This function will be removed in pysat x, please use the version under
+      pysat.utils.files
+
     Parameters
     ----------
     stored : orderedDict
@@ -589,6 +593,10 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 def parse_fixed_width_filenames(files, format_str):
     """Parses list of files, extracting data identified by format_str
 
+    .. deprecated:: 3.0.0
+      This function will be removed in pysat x, please use the version under
+      pysat.utils.files
+
     Parameters
     ----------
     files : list
@@ -622,6 +630,10 @@ def parse_fixed_width_filenames(files, format_str):
 
 def parse_delimited_filenames(files, format_str, delimiter):
     """Parses list of files, extracting data identified by format_str
+
+    .. deprecated:: 3.0.0
+      This function will be removed in pysat x, please use the version under
+      pysat.utils.files
 
     Parameters
     ----------
@@ -658,6 +670,10 @@ def parse_delimited_filenames(files, format_str, delimiter):
 def construct_searchstring_from_format(format_str, wildcard=False):
     """
     Parses format file string and returns string formatted for searching.
+
+    .. deprecated:: 3.0.0
+      This function will be removed in pysat x, please use the version under
+      pysat.utils.files
 
     Parameters
     ----------
@@ -705,6 +721,10 @@ def construct_searchstring_from_format(format_str, wildcard=False):
 def search_local_system_formatted_filename(data_path, search_str):
     """
     Parses format file string and returns string formatted for searching.
+
+    .. deprecated:: 3.0.0
+      This function will be removed in pysat x, please use the version under
+      pysat.utils.files
 
     Parameters
     ----------

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -503,13 +503,14 @@ class Files(object):
             Supports 'year', 'month', 'day', 'hour', 'minute', 'second',
             'version', and 'revision'
             Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
-        two_digit_year_break : int
+        two_digit_year_break : int or None
             If filenames only store two digits for the year, then
             '1900' will be added for years >= two_digit_year_break
             and '2000' will be added for years < two_digit_year_break.
-        delimiter : string (None)
+            If None, then four-digit years are assumed. (default=None)
+        delimiter : string
             If set, then filename will be processed using delimiter rather
-            than assuming a fixed width
+            than assuming a fixed width (default=None)
 
         Note
         ----

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -556,7 +556,7 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     a pandas Series object formatted for the Files class.
 
     .. deprecated:: 3.0.0
-      This function will be removed in pysat x, please use the version under
+      This function will be removed in pysat 4.0.0, please use the version under
       pysat.utils.files
 
     Parameters
@@ -597,7 +597,7 @@ def parse_fixed_width_filenames(files, format_str):
     """Parses list of files, extracting data identified by format_str
 
     .. deprecated:: 3.0.0
-      This function will be removed in pysat x, please use the version under
+      This function will be removed in pysat 4.0.0, please use the version under
       pysat.utils.files
 
     Parameters
@@ -635,7 +635,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
     """Parses list of files, extracting data identified by format_str
 
     .. deprecated:: 3.0.0
-      This function will be removed in pysat x, please use the version under
+      This function will be removed in pysat 4.0.0, please use the version under
       pysat.utils.files
 
     Parameters
@@ -675,7 +675,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
     Parses format file string and returns string formatted for searching.
 
     .. deprecated:: 3.0.0
-      This function will be removed in pysat x, please use the version under
+      This function will be removed in pysat 4.0.0, please use the version under
       pysat.utils.files
 
     Parameters
@@ -726,7 +726,7 @@ def search_local_system_formatted_filename(data_path, search_str):
     Parses format file string and returns string formatted for searching.
 
     .. deprecated:: 3.0.0
-      This function will be removed in pysat x, please use the version under
+      This function will be removed in pysat 4.0.0, please use the version under
       pysat.utils.files
 
     Parameters

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -533,19 +533,22 @@ class Files(object):
             wildcard = False
         else:
             wildcard = True
-        search_dict = construct_searchstring_from_format(format_str,
-                                                         wildcard=wildcard)
+        search_dict = \
+            futils.construct_searchstring_from_format(format_str,
+                                                      wildcard=wildcard)
         search_str = search_dict['search_string']
         # perform local file search
-        files = search_local_system_formatted_filename(data_path, search_str)
+        files = futils.search_local_system_formatted_filename(data_path,
+                                                              search_str)
         # we have a list of files, now we need to extract the information
         # pull of data from the areas identified by format_str
         if delimiter is None:
-            stored = parse_fixed_width_filenames(files, format_str)
+            stored = futils.parse_fixed_width_filenames(files, format_str)
         else:
-            stored = parse_delimited_filenames(files, format_str, delimiter)
+            stored = futils.parse_delimited_filenames(files, format_str,
+                                                      delimiter)
         # process the parsed filenames and return a properly formatted Series
-        return process_parsed_filenames(stored, two_digit_year_break)
+        return futils.process_parsed_filenames(stored, two_digit_year_break)
 
 
 def process_parsed_filenames(stored, two_digit_year_break=None):

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -143,10 +143,10 @@ class Files(object):
         else:
             # construct subdirectory path
             self.sub_dir_path = \
-                    self.directory_format.format(name=self._sat.name,
-                                                 platform=self._sat.platform,
-                                                 tag=self._sat.tag,
-                                                 sat_id=self._sat.sat_id)
+                self.directory_format.format(name=self._sat.name,
+                                             platform=self._sat.platform,
+                                             tag=self._sat.tag,
+                                             sat_id=self._sat.sat_id)
         # ensure we have a path for pysat data directory
         if data_dir == '':
             raise RuntimeError(" ".join(("pysat's data_dir is None. Set a",
@@ -271,7 +271,7 @@ class Files(object):
 
             if self.write_to_disk:
                 stored_files.to_csv(os.path.join(self.home_path,
-                                                 'previous_'+name),
+                                                 'previous_' + name),
                                     date_format='%Y-%m-%d %H:%M:%S.%f',
                                     header=False)
                 self.files.to_csv(os.path.join(self.home_path, name),
@@ -299,7 +299,7 @@ class Files(object):
 
         fname = self.stored_file_name
         if prev_version:
-            fname = os.path.join(self.home_path, 'previous_'+fname)
+            fname = os.path.join(self.home_path, 'previous_' + fname)
         else:
             fname = os.path.join(self.home_path, fname)
 
@@ -400,9 +400,9 @@ class Files(object):
             idx, = np.where(fname == np.array(self.files))
 
             if len(idx) == 0:
-                raise ValueError('Could not find "' + fname +
-                                 '" in available file list. Valid Example: ' +
-                                 self.files.iloc[0])
+                raise ValueError(' '.join(('Could not find "{:}"'.format(fname),
+                                           'in available file list. Valid',
+                                           'Example:', self.files.iloc[0])))
         # return a scalar rather than array - otherwise introduces array to
         # index warnings.
         return idx[0]
@@ -467,14 +467,14 @@ class Files(object):
             for (sta, stp) in zip(start, end):
                 id1 = self.get_index(sta)
                 id2 = self.get_index(stp)
-                files.extend(self.files.iloc[id1:id2+1])
+                files.extend(self.files.iloc[id1:(id2 + 1)])
         elif hasattr(start, '__iter__') | hasattr(end, '__iter__'):
             estr = 'Either both or none of the inputs need to be iterable'
             raise ValueError(estr)
         else:
             id1 = self.get_index(start)
             id2 = self.get_index(end)
-            files = self.files[id1:id2+1].to_list()
+            files = self.files[id1:(id2 + 1)].to_list()
         return files
 
     def _remove_data_dir_path(self, inp=None):
@@ -523,8 +523,8 @@ class Files(object):
         """
 
         if data_path is None:
-            raise ValueError("Must supply instrument directory path " +
-                             "(dir_path)")
+            raise ValueError(" ".join(("Must supply instrument directory path",
+                                       "(dir_path)")))
 
         # parse format string to figure out the search string to use
         # to identify files in the filesystem

--- a/pysat/instruments/cosmic_gps.py
+++ b/pysat/instruments/cosmic_gps.py
@@ -50,6 +50,7 @@ Warnings
 from __future__ import print_function
 from __future__ import absolute_import
 import datetime as dt
+import logging
 import os
 import sys
 
@@ -57,8 +58,8 @@ import numpy as np
 import netCDF4
 import pandas as pds
 import pysat
+from pysat.utils import files as futils
 
-import logging
 logger = logging.getLogger(__name__)
 
 platform = 'cosmic'
@@ -116,15 +117,13 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
         format_str = ''.join(('*.*/*.{year:04d}.{day:03d}',
                               '.{hour:02d}.{minute:02d}.*_nc'))
     # process format string to get string to search for
-    search_dict = pysat._files.construct_searchstring_from_format(format_str)
+    search_dict = futils.construct_searchstring_from_format(format_str)
     search_str = search_dict['search_string']
     # perform local file search
-    files = pysat._files.search_local_system_formatted_filename(data_path,
-                                                                search_str)
+    files = futils.search_local_system_formatted_filename(data_path, search_str)
     # we have a list of files, now we need to extract the information
     # pull of data from the areas identified by format_str
-    stored = pysat._files.parse_delimited_filenames(files, format_str,
-                                                    delimiter='.')
+    stored = futils.parse_delimited_filenames(files, format_str, delimiter='.')
     if len(stored['year']) > 0:
         year = np.array(stored['year'])
         day = np.array(stored['day'])

--- a/pysat/instruments/methods/icon.py
+++ b/pysat/instruments/methods/icon.py
@@ -10,7 +10,7 @@ import numpy as np
 import os
 
 import pysat
-import pysat._files as pfiles
+from pysat.utils import files as futils
 
 
 logger = logging.getLogger(__name__)
@@ -241,13 +241,13 @@ def list_remote_files(tag, sat_id, user=None, password=None,
 
     # we now have a list of all files in the instrument data directories
     # need to whittle list down to the versions and revisions most appropriate
-    search_dict = pysat._files.construct_searchstring_from_format(remote_fname)
+    search_dict = futils.construct_searchstring_from_format(remote_fname)
     search_str = '*/' + search_dict['search_string']
     remote_files = fnmatch.filter(day_file_list, search_str)
 
     # pull out date information from the files
-    stored = pfiles.parse_fixed_width_filenames(remote_files, remote_fname)
-    output = pfiles.process_parsed_filenames(stored)
+    stored = futils.parse_fixed_width_filenames(remote_files, remote_fname)
+    output = futils.process_parsed_filenames(stored)
     # return information, limited to start and stop dates
     return output[start:stop]
 

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -14,7 +14,7 @@ import sys
 from bs4 import BeautifulSoup
 import pandas as pds
 
-import pysat
+from pysat.utils import files as futils
 
 import logging
 logger = logging.getLogger(__name__)
@@ -353,13 +353,13 @@ def list_remote_files(tag, sat_id,
 
     # Parse the path to find the number of levels to search
     format_dir = dir_split[0]
-    search_dir = pysat._files.construct_searchstring_from_format(format_dir)
+    search_dir = futils.construct_searchstring_from_format(format_dir)
     n_layers = len(search_dir['keys'])
 
     # only keep file portion of format
     format_str = dir_split[-1]
     # Generate list of targets to identify files
-    search_dict = pysat._files.construct_searchstring_from_format(format_str)
+    search_dict = futils.construct_searchstring_from_format(format_str)
     targets = [x.strip('?') for x in search_dict['string_blocks'] if len(x) > 0]
 
     remote_dirs = []
@@ -415,15 +415,13 @@ def list_remote_files(tag, sat_id,
 
     # parse remote filenames to get date information
     if delimiter is None:
-        stored = pysat._files.parse_fixed_width_filenames(full_files,
-                                                          format_str)
+        stored = futils.parse_fixed_width_filenames(full_files, format_str)
     else:
-        stored = pysat._files.parse_delimited_filenames(full_files,
-                                                        format_str, delimiter)
+        stored = futils.parse_delimited_filenames(full_files, format_str,
+                                                  delimiter)
 
     # process the parsed filenames and return a properly formatted Series
-    stored_list = pysat._files.process_parsed_filenames(stored,
-                                                        two_digit_year_break)
+    stored_list = futils.process_parsed_filenames(stored, two_digit_year_break)
     # Downselect to user-specified dates, if needed
     if start is not None:
         mask = (stored_list.index >= start)

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -140,8 +140,8 @@ class TestBasics():
         # filenames is added to routine travis end-to-end testing
         fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',
                          '_{minute:2d}_{second:2d}_{version:2s}_r02.cdf'))
-        year = np.ones(6)*2009
-        month = np.ones(6)*12
+        year = np.ones(6) * 2009
+        month = np.ones(6) * 12
         day = np.array([12, 15, 17, 19, 22, 24])
         hour = np.array([8, 10, 6, 18, 3, 23])
         minute = np.array([8, 10, 6, 18, 3, 59])
@@ -177,14 +177,11 @@ class TestBasics():
                                                         '{day:03d}_stuff.',
                                                         'pysat_testing_file')))
         # check overall length
-        check1 = len(files) == (365 + 366)
+        assert len(files) == (365 + 366)
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[365]) == \
-            dt.datetime(2008, 12, 31)
-        check4 = pds.to_datetime(files.index[-1]) == \
-            dt.datetime(2009, 12, 31)
-        assert(check1 & check2 & check3 & check4)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_doy_files_no_gap_in_name_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
@@ -201,14 +198,11 @@ class TestBasics():
                                                         'stuff.pysat_testing_',
                                                         'file')))
         # check overall length
-        check1 = len(files) == (365 + 366)
+        assert len(files) == (365 + 366)
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[365]) == \
-            dt.datetime(2008, 12, 31)
-        check4 = pds.to_datetime(files.index[-1]) == \
-            dt.datetime(2009, 12, 31)
-        assert(check1 & check2 & check3 & check4)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
@@ -226,14 +220,11 @@ class TestBasics():
                                                         '{month:02d}.pysat_',
                                                         'testing_file')))
         # check overall length
-        check1 = len(files) == (365 + 366)
+        assert len(files) == (365 + 366)
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[365]) == \
-            dt.datetime(2008, 12, 31)
-        check4 = pds.to_datetime(files.index[-1]) == \
-            dt.datetime(2009, 12, 31)
-        assert(check1 & check2 & check3 & check4)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_hour_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
@@ -253,14 +244,11 @@ class TestBasics():
                                                         '{hour:02d}.pysat_',
                                                         'testing_file')))
         # check overall length
-        check1 = len(files) == (365+366)*4-3
+        assert len(files) == (365 + 366) * 4 - 3
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[1460]) == \
-            dt.datetime(2008, 12, 31)
-        check4 = pds.to_datetime(files.index[-1]) == \
-            dt.datetime(2009, 12, 31)
-        assert(check1 & check2 & check3 & check4)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert pds.to_datetime(files.index[1460]) == dt.datetime(2008, 12, 31)
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_hour_minute_files_direct_call_to_from_os(self):
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
@@ -276,17 +264,14 @@ class TestBasics():
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
                                     format_str=root_fname)
         # check overall length
-        check1 = len(files) == 145
+        assert len(files) == 145
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[1]) == \
-            dt.datetime(2008, 1, 1, 0, 30)
-        check4 = pds.to_datetime(files.index[10]) == \
-            dt.datetime(2008, 1, 1, 5, 0)
-        check5 = pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 4)
-        assert(check1 & check2 & check3 & check4 & check5)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert pds.to_datetime(files.index[1]) == dt.datetime(2008, 1, 1, 0, 30)
+        assert pds.to_datetime(files.index[10]) == dt.datetime(2008, 1, 1, 5, 0)
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 4)
 
-    def test_year_month_day_hour_minute_second_files_direct_call_to_from_os(self):
+    def test_year_month_day_hour_minute_second_files_direct_call_from_os(self):
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
                               'stuff_{month:02d}_{hour:02d}_{minute:02d}_',
                               '{second:02d}.pysat_testing_file'))
@@ -299,14 +284,12 @@ class TestBasics():
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
                                     format_str=root_fname)
         # check overall length
-        check1 = len(files) == 5761
+        assert len(files) == 5761
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[1]) == \
-            dt.datetime(2008, 1, 1, 0, 0, 30)
-        check4 = pds.to_datetime(files.index[-1]) == \
-            dt.datetime(2008, 1, 3)
-        assert(check1 & check2 & check3 & check4)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert (pds.to_datetime(files.index[1])
+                == dt.datetime(2008, 1, 1, 0, 0, 30))
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 3)
 
     def test_year_month_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
@@ -323,14 +306,11 @@ class TestBasics():
                                                         'stuff_{month:02d}.',
                                                         'pysat_testing_file')))
         # check overall length
-        check1 = len(files) == 24
+        assert len(files) == 24
         # check specific dates
-        check2 = pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        check3 = pds.to_datetime(files.index[11]) == \
-            dt.datetime(2008, 12, 1)
-        check4 = pds.to_datetime(files.index[-1]) == \
-            dt.datetime(2009, 12, 1)
-        assert(check1 & check2 & check3 & check4)
+        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
+        assert pds.to_datetime(files.index[11]) == dt.datetime(2008, 12, 1)
+        assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 1)
 
     def test_instrument_has_no_files(self):
         import pysat.instruments.pysat_testing
@@ -538,8 +518,8 @@ class TestInstrumentWithFiles():
                      root_fname=self.root_fname)
         dates2 = pysat.utils.time.create_date_range(start, stop, freq='100min')
         new_files2 = self.testInst.files.get_new()
-        assert (np.all(new_files.index == dates) &
-                np.all(new_files2.index == dates2))
+        assert np.all(new_files.index == dates)
+        assert np.all(new_files2.index == dates2)
 
     def test_get_new_files_after_deleting_files_and_adding_files(self):
         # create new files and make sure that new files are captured
@@ -595,8 +575,8 @@ class TestInstrumentWithFiles():
 
         # get new files
         new_files = self.testInst.files.get_new()
-        assert (np.all(self.testInst.files.files.index == dates) &
-                np.all(new_files.index == dates))
+        assert np.all(self.testInst.files.files.index == dates)
+        assert np.all(new_files.index == dates)
 
     def test_files_non_standard_file_format_template(self):
         # create new files and make sure that new files are captured
@@ -692,8 +672,7 @@ def create_versioned_files(inst, start=None, stop=None, freq='1D',
                                                        second=date.second,
                                                        version=version,
                                                        revision=revision))
-                with open(fname, 'w') as f:
-                    pass
+                open(fname, 'w')
 
 
 def list_versioned_files(tag=None, sat_id=None, data_path=None,
@@ -852,8 +831,8 @@ class TestInstrumentWithVersionedFiles():
                                root_fname=self.root_fname)
         dates2 = pysat.utils.time.create_date_range(start, stop, freq='100min')
         new_files2 = self.testInst.files.get_new()
-        assert (np.all(new_files.index == dates) &
-                np.all(new_files2.index == dates2))
+        assert np.all(new_files.index == dates)
+        assert np.all(new_files2.index == dates2)
 
     def test_get_new_files_after_deleting_files_and_adding_files(self):
         # create new files and make sure that new files are captured
@@ -912,8 +891,8 @@ class TestInstrumentWithVersionedFiles():
 
         # get new files
         new_files = self.testInst.files.get_new()
-        assert (np.all(self.testInst.files.files.index == dates) &
-                np.all(new_files.index == dates))
+        assert np.all(self.testInst.files.files.index == dates)
+        assert np.all(new_files.index == dates)
 
     def test_files_non_standard_file_format_template(self):
         # create new files and make sure that new files are captured
@@ -970,8 +949,3 @@ class TestInstrumentWithVersionedFiles():
                              update_files=True,
                              temporary_file_list=self.temporary_file_list)
         assert (np.all(self.testInst.files.files.index == dates))
-
-
-class TestInstrumentWithVersionedFilesNoFileListStorage(TestInstrumentWithVersionedFiles):
-
-    temporary_file_list = True

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -12,6 +12,7 @@ import tempfile
 
 import pysat
 import pysat.instruments.pysat_testing
+from pysat.utils import files as futils
 
 from importlib import reload as re_load
 
@@ -154,8 +155,7 @@ class TestBasics():
                                           minute=minute[i], second=second[i],
                                           version=version[i]))
 
-        file_dict = pysat._files.parse_delimited_filenames(file_list, fname,
-                                                           '_')
+        file_dict = futils.parse_delimited_filenames(file_list, fname, '_')
         assert np.all(file_dict['year'] == year)
         assert np.all(file_dict['month'] == month)
         assert np.all(file_dict['day'] == day)

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -5,6 +5,7 @@ import datetime as dt
 import glob
 import numpy as np
 import os
+import warnings
 
 import pandas as pds
 import pytest
@@ -949,3 +950,56 @@ class TestInstrumentWithVersionedFiles():
                              update_files=True,
                              temporary_file_list=self.temporary_file_list)
         assert (np.all(self.testInst.files.files.index == dates))
+
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
+    def test_deprecation_warning_process_parsed_filenames(self):
+        """Test if _files.process_parsed_filenames is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            try:
+                pysat._files.process_parsed_filenames({})
+            except KeyError:
+                # Inputting empty dict will produce KeyError
+                pass
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_parse_fixed_width_filenames(self):
+        """Test if _files.parse_fixed_width_filenames is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.parse_fixed_width_filenames([], '')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_parse_delimited_filenames(self):
+        """Test if _files.parse_delimited_filenames is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.parse_delimited_filenames([], '', '')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_construct_searchstring_from_format(self):
+        """Test if _files.construct_searchstring_from_format is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.construct_searchstring_from_format('')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -9,5 +9,5 @@ of formats, loading of files, and user-supplied info
 for the pysat data directory structure.
 """
 
-from pysat.utils import coords, time, registry
+from pysat.utils import coords, files, time, registry
 from pysat.utils._core import set_data_dir, scale_units, load_netcdf4

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -19,10 +19,12 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     stored : orderedDict
         Dict produced by parse_fixed_width_filenames or
         parse_delimited_filenames
-    two_digit_year_break : int
+    two_digit_year_break : int or None
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.
+        If None, then four-digit years are assumed.
+        (default=None)
 
     Returns
     -------

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -1,3 +1,4 @@
+import collections
 import glob
 import numpy as np
 import os
@@ -5,6 +6,8 @@ import re
 import string
 
 import pandas as pds
+
+from pysat.utils.time import create_datetime_index
 
 
 def process_parsed_filenames(stored, two_digit_year_break=None):
@@ -34,8 +37,6 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
         for this filtering, revision is optional.
 
     """
-
-    from pysat.utils.time import create_datetime_index
 
     search_dict = construct_searchstring_from_format(stored['format_str'])
     keys = search_dict['keys']
@@ -131,8 +132,6 @@ def parse_fixed_width_filenames(files, format_str):
 
     """
 
-    import collections
-
     # create storage for data to be parsed from filenames
     ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',
                     'version', 'revision']
@@ -207,8 +206,6 @@ def parse_delimited_filenames(files, format_str, delimiter):
         'format_str' - formatted string from input
 
     """
-
-    import collections
 
     # create storage for data to be parsed from filenames
     ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -45,8 +45,8 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
         # years above or equal to break are considered to be 1900+
         # years below break are considered to be 2000+
         if two_digit_year_break is not None:
-            idx, = np.where(np.array(stored['year']) >=
-                            two_digit_year_break)
+            idx, = np.where(np.array(stored['year'])
+                            >= two_digit_year_break)
             stored['year'][idx] = stored['year'][idx] + 1900
             idx, = np.where(np.array(stored['year']) < two_digit_year_break)
             stored['year'][idx] = stored['year'][idx] + 2000
@@ -346,7 +346,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                         # store length and add to the search string
                         lengths.append(int(i))
                         if not wildcard:
-                            search_str += '?'*int(i)
+                            search_str += '?' * int(i)
                         else:
                             search_str += '*'
                         break

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -304,7 +304,11 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v??.cdf'
 
     """
-    out_dict = {'search_string': '', 'keys': [], 'lengths': [], 'string_blocks': []}
+
+    out_dict = {'search_string': '',
+                'keys': [],
+                'lengths': [],
+                'string_blocks': []}
     if format_str is None:
         raise ValueError("Must supply a filename template (format_str).")
 
@@ -317,8 +321,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         # numnber of ?s goes with length of data to be parsed
         # length grabbed from format keywords so we know
         # later on where to parse information out from
-        out_dict['search_str'] += snip[0]
-        out_dict['snips'].append(snip[0])
+        out_dict['search_string'] += snip[0]
+        out_dict['string_blocks'].append(snip[0])
         if snip[1] is not None:
             out_dict['keys'].append(snip[1])
             # try and determine formatting width
@@ -331,9 +335,9 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                         # store length and add to the search string
                         out_dict['lengths'].append(int(i))
                         if not wildcard:
-                            out_dict['search_str'] += '?' * int(i)
+                            out_dict['search_string'] += '?' * int(i)
                         else:
-                            out_dict['search_str'] += '*'
+                            out_dict['search_string'] += '*'
                         break
             else:
                 raise ValueError("Couldn't determine formatting width")

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -1,0 +1,396 @@
+import glob
+import numpy as np
+import os
+import re
+import string
+
+import pandas as pds
+
+
+def process_parsed_filenames(stored, two_digit_year_break=None):
+    """Accepts dict with data parsed from filenames and creates
+    a pandas Series object formatted for the Files class.
+
+    Parameters
+    ----------
+    stored : orderedDict
+        Dict produced by parse_fixed_width_filenames or
+        parse_delimited_filenames
+    two_digit_year_break : int
+        If filenames only store two digits for the year, then
+        '1900' will be added for years >= two_digit_year_break
+        and '2000' will be added for years < two_digit_year_break.
+
+    Returns
+    -------
+    pandas.Series
+        Series, indexed by datetime, with file strings
+
+    Note
+    ----
+        If two files have the same date and time information in the
+        filename then the file with the higher version/revision is used.
+        Series returned only has one file der datetime. Version is required
+        for this filtering, revision is optional.
+
+    """
+
+    from pysat.utils.time import create_datetime_index
+
+    search_dict = construct_searchstring_from_format(stored['format_str'])
+    keys = search_dict['keys']
+
+    if len(stored['files']) > 0:
+        # deal with the possibility of two digit years
+        # years above or equal to break are considered to be 1900+
+        # years below break are considered to be 2000+
+        if two_digit_year_break is not None:
+            idx, = np.where(np.array(stored['year']) >=
+                            two_digit_year_break)
+            stored['year'][idx] = stored['year'][idx] + 1900
+            idx, = np.where(np.array(stored['year']) < two_digit_year_break)
+            stored['year'][idx] = stored['year'][idx] + 2000
+
+        # need to sort the information for things to work
+        rec_arr = [stored[key] for key in keys]
+        rec_arr.append(stored['files'])
+        # sort all arrays
+        # create a sortable records array
+        # keys with files
+        val_keys = keys + ['files']
+        rec_arr = np.rec.fromarrays(rec_arr, names=val_keys)
+        rec_arr.sort(order=val_keys, axis=0)
+
+        # pull out sorted info
+        for key in keys:
+            stored[key] = rec_arr[key]
+        files = rec_arr['files']
+
+        # add hour and minute information to 'second'
+        if stored['second'] is None:
+            stored['second'] = np.zeros(len(files))
+        if stored['hour'] is not None:
+            stored['second'] += 3600 * stored['hour']
+        if stored['minute'] is not None:
+            stored['second'] += 60 * stored['minute']
+        # version shouldn't be set to zero
+        # version is required to remove duplicate datetimes
+        if stored['revision'] is None:
+            stored['revision'] = np.zeros(len(files))
+
+        index = create_datetime_index(year=stored['year'],
+                                      month=stored['month'],
+                                      day=stored['day'],
+                                      uts=stored['second'])
+
+        # if version and revision are supplied
+        # use these parameters to weed out files that have been replaced
+        # with updated versions
+        # first, check for duplicate index times
+        dups = index[index.duplicated()].unique()
+        if (len(dups) > 0) and (stored['version'] is not None):
+            # we have duplicates
+            # keep the highest version/revision combo
+            version = pds.Series(stored['version'], index=index)
+            revision = pds.Series(stored['revision'], index=index)
+            revive = version * 100000. + revision
+            frame = pds.DataFrame({'files': files, 'revive': revive,
+                                   'time': index}, index=index)
+            frame = frame.sort_values(by=['time', 'revive'],
+                                      ascending=[True, False])
+            frame = frame.drop_duplicates(subset='time', keep='first')
+
+            return frame['files']
+        else:
+            return pds.Series(files, index=index)
+    else:
+        return pds.Series(None, dtype='object')
+
+
+def parse_fixed_width_filenames(files, format_str):
+    """Parses list of files, extracting data identified by format_str
+
+    Parameters
+    ----------
+    files : list
+        List of files
+    format_str : string with python format codes
+        Provides the naming pattern of the instrument files and the
+        locations of date information so an ordered list may be produced.
+        Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
+        and 'revision'
+        Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+
+    Returns
+    -------
+    OrderedDict
+        Information parsed from filenames
+        'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
+        'revision'
+        'files' - input list of files
+
+    """
+
+    import collections
+
+    # create storage for data to be parsed from filenames
+    stored = collections.OrderedDict()
+    stored['year'] = []
+    stored['month'] = []
+    stored['day'] = []
+    stored['hour'] = []
+    stored['minute'] = []
+    stored['second'] = []
+    stored['version'] = []
+    stored['revision'] = []
+
+    if len(files) == 0:
+        stored['files'] = []
+        # include format string as convenience for later functions
+        stored['format_str'] = format_str
+        return stored
+
+    # parse format string to get information needed to parse filenames
+    search_dict = construct_searchstring_from_format(format_str)
+    snips = search_dict['string_blocks']
+    lengths = search_dict['lengths']
+    keys = search_dict['keys']
+
+    # determine the locations the date/version information in a filename is
+    # stored use these indices to slice out date from filenames
+    idx = 0
+    begin_key = []
+    end_key = []
+    for i, snip in enumerate(snips):
+        idx += len(snip)
+        if i < (len(lengths)):
+            begin_key.append(idx)
+            idx += lengths[i]
+            end_key.append(idx)
+    max_len = idx
+    # setting up negative indexing to pick out filenames
+    key_str_idx = [np.array(begin_key, dtype=int) - max_len,
+                   np.array(end_key, dtype=int) - max_len]
+    # need to parse out dates for datetime index
+    for i, temp in enumerate(files):
+        for j, key in enumerate(keys):
+            val = temp[key_str_idx[0][j]:key_str_idx[1][j]]
+            stored[key].append(val)
+    # convert to numpy arrays
+    for key in stored.keys():
+        stored[key] = np.array(stored[key]).astype(int)
+        if len(stored[key]) == 0:
+            stored[key] = None
+    # include files in output
+    stored['files'] = files
+    # include format string as convenience for later functions
+    stored['format_str'] = format_str
+
+    return stored
+
+
+def parse_delimited_filenames(files, format_str, delimiter):
+    """Parses list of files, extracting data identified by format_str
+
+    Parameters
+    ----------
+    files : list
+        List of files
+    format_str : string with python format codes
+        Provides the naming pattern of the instrument files and the
+        locations of date information so an ordered list may be produced.
+        Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
+        and 'revision'
+        Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+
+    Returns
+    -------
+    OrderedDict
+        Information parsed from filenames
+        'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
+        'revision'
+        'files' - input list of files
+        'format_str' - formatted string from input
+
+    """
+
+    import collections
+
+    # create storage for data to be parsed from filenames
+    ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',
+                    'version', 'revision']
+    stored = collections.OrderedDict({kk: list() for kk in ordered_keys})
+
+    # exit early if there are no files
+    if len(files) == 0:
+        stored['files'] = []
+        # include format string as convenience for later functions
+        stored['format_str'] = format_str
+        return stored
+
+    # parse format string to get information needed to parse filenames
+    search_dict = construct_searchstring_from_format(format_str, wildcard=True)
+    snips = search_dict['string_blocks']
+    keys = search_dict['keys']
+
+    # going to parse string on delimiter
+    # it is possible that other regions have the delimiter but aren't
+    # going to be parsed out
+    # so apply delimiter breakdown to the string blocks as a guide
+    pblock = []
+    parsed_block = [snip.split(delimiter) for snip in snips]
+    for _ in parsed_block:
+        if _ != ['', '']:
+            if _[0] == '':
+                _ = _[1:]
+            if _[-1] == '':
+                _ = _[:-1]
+            pblock.extend(_)
+        pblock.append('')
+    parsed_block = pblock[:-1]
+    # need to parse out dates for datetime index
+    for temp in files:
+        split_name = temp.split(delimiter)
+        idx = 0
+        for sname, bname in zip(split_name, parsed_block):
+            if bname == '':
+                # areas with data to be parsed are indicated with a
+                # '' in parsed_block
+                stored[keys[idx]].append(sname)
+                idx += 1
+
+    # convert to numpy arrays
+    for key in stored.keys():
+        try:
+            # Assume key value is numeric integer
+            stored[key] = np.array(stored[key]).astype(int)
+        except ValueError:
+            # Store key value as string
+            stored[key] = np.array(stored[key])
+        if len(stored[key]) == 0:
+            stored[key] = None
+    # include files in output
+    stored['files'] = files
+    # include format string as convenience for later functions
+    stored['format_str'] = format_str
+
+    return stored
+
+
+def construct_searchstring_from_format(format_str, wildcard=False):
+    """
+    Parses format file string and returns string formatted for searching.
+
+    Parameters
+    ----------
+    format_str : string with python format codes
+        Provides the naming pattern of the instrument files and the
+        locations of date information so an ordered list may be produced.
+        Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
+        and 'revision'
+        Ex: 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+    wildcard : bool
+        if True, replaces the ? sequence with a * . This option may be well
+        suited when dealing with delimited filenames.
+
+    Returns
+    -------
+    dict
+        'search_string' format_str with data to be parsed replaced with ?
+        'keys' keys for data to be parsed
+        'lengths' string length for data to be parsed
+        'string_blocks' the filenames are broken down into fixed width
+            segments and '' strings are placed in locations where data will
+            eventually be parsed from a list of filenames. A standards
+            compliant filename can be constructed by starting with
+            string_blocks, adding keys in order, and replacing the '' locations
+            with data of length length.
+
+    Note
+    ----
+        The '?' may be used to indicate a set number of spaces for a variable
+        part of the name that need not be extracted.
+        'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v??.cdf'
+
+    """
+
+    if format_str is None:
+        raise ValueError("Must supply a filename template (format_str).")
+
+    # parse format string to figure out how to construct the search string
+    # to identify files in the filesystem
+    search_str = ''
+    form = string.Formatter()
+    # stores the keywords extracted from format_string
+    keys = []
+    # and length of string
+    snips = []
+    lengths = []
+    for snip in form.parse(format_str):
+        # collect all of the format keywords
+        # replace them in the string with the '?' wildcard
+        # numnber of ?s goes with length of data to be parsed
+        # length grabbed from format keywords so we know
+        # later on where to parse information out from
+        search_str += snip[0]
+        snips.append(snip[0])
+        if snip[1] is not None:
+            keys.append(snip[1])
+            # try and determine formatting width
+            temp = re.findall(r'\d+', snip[2])
+            if temp:
+                # there are items, try and grab width
+                for i in temp:
+                    # make sure there is truly something there
+                    if i != 0:
+                        # store length and add to the search string
+                        lengths.append(int(i))
+                        if not wildcard:
+                            search_str += '?'*int(i)
+                        else:
+                            search_str += '*'
+                        break
+            else:
+                raise ValueError("Couldn't determine formatting width")
+
+    return {'search_string': search_str,
+            'keys': keys,
+            'lengths': lengths,
+            'string_blocks': snips}
+
+
+def search_local_system_formatted_filename(data_path, search_str):
+    """
+    Parses format file string and returns string formatted for searching.
+
+    Parameters
+    ----------
+    data_path : string
+        Top level directory to search files for. This directory
+        is provided by pysat to the instrument_module.list_files
+        functions as data_path.
+    search_str : string
+        String to search local file system for
+        Ex: 'cnofs_cindi_ivm_500ms_????????_v??.cdf'
+            'cnofs_cinfi_ivm_500ms_*_v??.cdf'
+
+    Returns
+    -------
+    list
+        list of files matching the format_str
+
+    Note
+    ----
+    The use of ?s (1 ? per character) rather than the full wildcard *
+    provides a more specific filename search string that limits the
+    false positive rate.
+
+    """
+
+    # perform local file search
+    abs_search_str = os.path.join(data_path, search_str)
+    files = glob.glob(abs_search_str)
+    # remove data_path portion
+    files = [sfile.split(data_path)[-1] for sfile in files]
+    # return info
+    return files

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,14 +17,12 @@ flake8-ignore =
   docs/conf.py ALL
   demo/cnofs_vefi_dc_b_orbit_plots.py E226 E241 W504
   pysat/__init__.py E402 F401
-  pysat/_files.py E126 E226 W504
   pysat/_instrument.py E226 E501 W504
   pysat/instruments/champ_star.py E722
   pysat/instruments/cosmic_gps.py E226 F821 W504
   pysat/instruments/superdarn_grdex.py E128 E226 E501 E502 W504
   pysat/instruments/supermag_magnetometer.py E126 E127 E128 E226 E251 E502 E722
   pysat/instruments/methods/__init__.py F401
-  pysat/tests/test_files.py E226 E501 F841 W504
   pysat/tests/test_instrument.py E226 F401 W504
   pysat/tests/test_utils.py E722
   pysat/utils/__init__.py F401


### PR DESCRIPTION
# Description

Addresses #336 

- Moves the methods from `pysat._files` to `pysat.utils.files`.  Includes deprecation warnings for the old methods, which point to the new methods.
- Includes a flake8 sweep of `_files.py` and `test_files.py`, as well as the removal of those exceptions.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

via pytest

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
