### PR TITLE
BUG: pandas 1.1.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-07-03
+## [3.0.0] - 2020-08-10
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
   - Improved string handling robustness when writing netCDF4 files in Python 3
+  - Improved pandas 1.1.0 compatibility in tests
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -333,8 +333,7 @@ class TestSwKpCombine():
         assert kp_inst.data.columns[0] == 'Kp'
         assert(kp_inst.meta['Kp'][kp_inst.meta.fill_label]
                == self.combine['fill_val'])
-        assert len(kp_inst['Kp'][kp_inst['Kp']]
-                   == self.combine['fill_val']) > 0
+        assert (kp_inst['Kp'] == self.combine['fill_val']).any()
 
         del kp_inst, combo_in
 
@@ -351,8 +350,7 @@ class TestSwKpCombine():
         assert kp_inst.data.columns[0] == 'Kp'
         assert (kp_inst.meta['Kp'][kp_inst.meta.fill_label]
                 == self.combine['fill_val'])
-        assert len(kp_inst['Kp'][kp_inst['Kp']]
-                   == self.combine['fill_val']) > 0
+        assert (kp_inst['Kp'] == self.combine['fill_val']).any()
 
         del kp_inst, combo_in
 


### PR DESCRIPTION
# Description

pandas 1.1.0 has been incorporated into the unit tests, and some updates to how indices are called are required.  

pandas no longer allows the call of `kp_inst['Kp'][kp_inst['Kp']]`.  This is only incorporated in the unit tests as part of several assert statements.  These have been updated.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested via pytest.  `develop-3` passes locally with pandas 1.0.5, but not 1.1.0.  The changes in this branch pass in both versions.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
