### PR TITLE
BUG: GNSS Integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed custom instrument attribute persistence upon load
   - Improved string handling robustness when writing netCDF4 files in Python 3
   - Improved pandas 1.1.0 compatibility in tests
+  - Fixed coupling of two_digit_year_break keyword to underlying method in methods.general.list_files
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -77,7 +77,8 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
                 raise ValueError(' '.join(('Unknown sat_id or tag:',
                                            str(estr))))
         out = pysat.Files.from_os(data_path=data_path,
-                                  format_str=format_str)
+                                  format_str=format_str,
+                                  two_digit_year_break=two_digit_year_break)
 
         if (not out.empty) and fake_daily_files_from_monthly:
             out.loc[out.index[-1] + pds.DateOffset(months=1)


### PR DESCRIPTION
# Description

Addresses # (issue)

The general method for listing_files, `pysat.instruments.methods.general` does not correctly support the advertised two_digit_year_break keyword.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested in practice using TEC Instrument


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
