### PR TITLE
DOC/STY: Update instrument methods and templates based on 2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-08-10
+## [3.0.0] - 2020-08-12
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -48,6 +48,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Include flake8 check as part of testing suites
   - Improve unit testing coverage of instrument functions and instrument object
   - Updated path to rocsat data
+  - Removed implicit conversion to integers in methods.general.convert_timestamp_to_datetime
 
 ## [2.2.0] - 2020-07-06
 - New Features

--- a/pysat/instruments/methods/demeter.py
+++ b/pysat/instruments/methods/demeter.py
@@ -1,15 +1,13 @@
 # -*- coding: utf-8 -*-
 """Provides non-instrument routines for DEMETER microsatellite data"""
 
-from __future__ import absolute_import, division, print_function
-
 import datetime as dt
+import logging
 import numpy as np
 import warnings
 
 import pysat
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/pysat/instruments/methods/demeter.py
+++ b/pysat/instruments/methods/demeter.py
@@ -35,10 +35,10 @@ def list_remote_files(tag, sat_id):
 
     Parameters
     ----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
 
@@ -83,7 +83,7 @@ def load_general_header(fhandle):
 
     Parameters
     ------------
-    fhandle : (file handle)
+    fhandle : file handle
         File handle
 
     Returns
@@ -149,7 +149,7 @@ def load_location_parameters(fhandle):
 
     Parameters
     ------------
-    fhandle : (file handle)
+    fhandle : file handle
         File handle
 
     Returns
@@ -238,7 +238,7 @@ def load_attitude_parameters(fhandle):
 
     Parameters
     ------------
-    fhandle : (file handle)
+    fhandle : file handle
         File handle
 
     Returns
@@ -315,6 +315,7 @@ def load_binary_file(fname, load_experiment_data):
         Data from file stored in a numpy array
     meta : dict
         Meta data for file, including data names and units
+
     """
 
     data = list()

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -2,8 +2,6 @@
 """Provides generalized routines for integrating instruments into pysat.
 """
 
-from __future__ import absolute_import, division, print_function
-
 import datetime as dt
 import logging
 import pandas as pds

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -106,7 +106,7 @@ def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
     """
 
     inst.data[epoch_name] = pds.to_datetime(
-        [dt.datetime.utcfromtimestamp(x * sec_mult)
+        [dt.datetime.utcfromtimestamp(int(x * sec_mult))
          for x in inst.data[epoch_name]])
     return
 

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -123,12 +123,6 @@ def remove_leading_text(inst, target=None):
     target : str or list of strings
         Leading string to remove. If none supplied, returns unmodified
 
-    Returns
-    -------
-    None
-        Modifies Instrument object in place
-
-
     """
 
     if target is None:

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -4,6 +4,7 @@
 
 import datetime as dt
 import logging
+import numpy as np
 import pandas as pds
 
 import pysat
@@ -106,7 +107,7 @@ def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
     """
 
     inst.data[epoch_name] = pds.to_datetime(
-        [dt.datetime.utcfromtimestamp(int(x * sec_mult))
+        [dt.datetime.utcfromtimestamp(int(np.floor(x * sec_mult)))
          for x in inst.data[epoch_name]])
     return
 

--- a/pysat/instruments/methods/icon.py
+++ b/pysat/instruments/methods/icon.py
@@ -120,31 +120,33 @@ def list_remote_files(tag, sat_id, user=None, password=None,
     a particular UC-Berkeley SSL dataset related to ICON.
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    user : (string or NoneType)
+    user : string or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)
-    password : (string or NoneType)
+    password : string or NoneType
         User password to be passed along to resource with relevant data.
         (default=None)
-    start : (dt.datetime or NoneType)
+    start : dt.datetime or NoneType
         Starting time for file list. A None value will start with the first
         file found.
         (default=None)
-    stop : (dt.datetime or NoneType)
+    stop : dt.datetime or NoneType
         Ending time for the file list.  A None value will stop with the last
         file found.
         (default=None)
+
     Returns
     --------
     pandas.Series
         A Series formatted for the Files class (pysat._files.Files)
         containing filenames and indexed by date and time
+
     """
 
     if (user is not None) or (password is not None):
@@ -255,33 +257,31 @@ def list_remote_files(tag, sat_id, user=None, password=None,
 def ssl_download(date_array, tag, sat_id, data_path=None,
                  user=None, password=None, supported_tags=None):
     """Download ICON data from public area of SSL ftp server
+
     Parameters
     ----------
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for downloads this routine here must
-        error if user not supplied.
-    password : string (None)
-        Password for data download.
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
     **kwargs : dict
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this
         routine via kwargs.
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
+
     """
 
     # get a list of remote files

--- a/pysat/instruments/methods/icon.py
+++ b/pysat/instruments/methods/icon.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
 """Provides non-instrument specific routines for ICON data"""
 
-from __future__ import absolute_import, division, print_function
-
 import fnmatch
 import ftplib
 import logging

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -30,11 +30,11 @@ def load(fnames, tag=None, sat_id=None,
 
     Parameters
     ------------
-    fnames : (pandas.Series)
+    fnames : pandas.Series
         Series of filenames
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         satellite id or None (default=None)
     fake_daily_files_from_monthly : bool
         Some CDAWeb instrument data files are stored by month, interfering
@@ -48,9 +48,9 @@ def load(fnames, tag=None, sat_id=None,
 
     Returns
     ---------
-    data : (pandas.DataFrame)
+    data : pandas.DataFrame
         Object containing satellite data
-    meta : (pysat.Meta)
+    meta : pysat.Meta
         Object containing metadata such as column names and units
 
     Examples
@@ -115,31 +115,26 @@ def download(supported_tags, date_array, tag, sat_id,
         pre-set with functools.partial then assigned to new instrument code.
     date_array : array_like
         Array of datetimes to download data for. Provided by pysat.
-    tag : (str or NoneType)
+    tag : str or NoneType
         tag or None (default=None)
     sat_id : (str or NoneType)
         satellite id or None (default=None)
-    remote_site : (string or NoneType)
+    remote_site : string or NoneType
         Remote site to download data from
         (default='https://cdaweb.gsfc.nasa.gov')
-    data_path : (string or NoneType)
+    data_path : string or NoneType
         Path to data directory.  If None is specified, the value previously
         set in Instrument.files.data_path is used.  (default=None)
-    user : (string or NoneType)
+    user : string or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)
-    password : (string or NoneType)
+    password : string or NoneType
         User password to be passed along to resource with relevant data.
         (default=None)
     fake_daily_files_from_monthly : bool
         Some CDAWeb instrument data files are stored by month. This flag,
         when true, accomodates this reality with user feedback on a monthly
         time frame.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
 
     Examples
     --------
@@ -269,23 +264,23 @@ def list_remote_files(tag, sat_id,
 
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.
         (default=None)
-    remote_site : (string or NoneType)
+    remote_site : string or NoneType
         Remote site to download data from
         (default='https://cdaweb.gsfc.nasa.gov')
     supported_tags : dict
         dict of dicts. Keys are supported tag names for download. Value is
         a dict with 'dir', 'remote_fname', 'local_fname'. Inteded to be
         pre-set with functools.partial then assigned to new instrument code.
-    user : (string or NoneType)
+    user : string or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)
-    password : (string or NoneType)
+    password : string or NoneType
         User password to be passed along to resource with relevant data.
         (default=None)
     fake_daily_files_from_monthly : bool
@@ -293,19 +288,19 @@ def list_remote_files(tag, sat_id,
         when true, accomodates this reality with user feedback on a monthly
         time frame.
         (default=False)
-    two_digit_year_break : (int or NoneType)
+    two_digit_year_break : int or NoneType
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.
         (default=None)
-    delimiter : (string or NoneType)
+    delimiter : string or NoneType
         If filename is delimited, then provide delimiter alone e.g. '_'
         (default=None)
-    start : (dt.datetime or NoneType)
+    start : dt.datetime or NoneType
         Starting time for file list. A None value will start with the first
         file found.
         (default=None)
-    stop : (dt.datetime or NoneType)
+    stop : dt.datetime or NoneType
         Ending time for the file list.  A None value will stop with the last
         file found.
         (default=None)

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -5,7 +5,6 @@ intervention.
 
 """
 
-from __future__ import absolute_import, division, print_function
 import datetime as dt
 import os
 import requests

--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -6,6 +6,7 @@ intervention.
 """
 
 import datetime as dt
+import logging
 import os
 import requests
 import sys
@@ -15,7 +16,6 @@ import pandas as pds
 
 import pysat
 
-import logging
 logger = logging.getLogger(__name__)
 
 

--- a/pysat/instruments/methods/sw.py
+++ b/pysat/instruments/methods/sw.py
@@ -17,28 +17,28 @@ def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
 
     Parameters
     ----------
-    standard_inst : (pysat.Instrument or NoneType)
+    standard_inst : pysat.Instrument or NoneType
         Instrument object containing data for the 'sw' platform, 'kp' name,
         and '' tag or None to exclude (default=None)
-    recent_inst : (pysat.Instrument or NoneType)
+    recent_inst : pysat.Instrument or NoneType
         Instrument object containing data for the 'sw' platform, 'kp' name,
         and 'recent' tag or None to exclude (default=None)
-    forecast_inst : (pysat.Instrument or NoneType)
+    forecast_inst : pysat.Instrument or NoneType
         Instrument object containing data for the 'sw' platform, 'kp' name,
         and 'forecast' tag or None to exclude (default=None)
-    start : (dt.datetime or NoneType)
+    start : dt.datetime or NoneType
         Starting time for combining data, or None to use earliest loaded
         date from the pysat Instruments (default=None)
-    stop : (dt.datetime)
+    stop : dt.datetime
         Ending time for combining data, or None to use the latest loaded date
         from the pysat Instruments (default=None)
-    fill_val : (int or float)
+    fill_val : int or float
         Desired fill value (since the standard instrument fill value differs
         from the other sources) (default=np.nan)
 
     Returns
     -------
-    kp_inst : (pysat.Instrument)
+    kp_inst : pysat.Instrument
         Instrument object containing Kp observations for the desired period of
         time, merging the standard, recent, and forecasted values based on
         their reliability
@@ -51,6 +51,7 @@ def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
     Will not attempt to download any missing data, but will load data
 
     """
+
     notes = "Combines data from"
 
     # Create an ordered list of the Instruments, excluding any that are None
@@ -245,22 +246,22 @@ def combine_f107(standard_inst, forecast_inst, start=None, stop=None):
 
     Parameters
     ----------
-    standard_inst : (pysat.Instrument or NoneType)
+    standard_inst : pysat.Instrument or NoneType
         Instrument object containing data for the 'sw' platform, 'f107' name,
         and '', 'all', 'prelim', or 'daily' tag
-    forecast_inst : (pysat.Instrument or NoneType)
+    forecast_inst : pysat.Instrument or NoneType
         Instrument object containing data for the 'sw' platform, 'f107' name,
         and 'prelim', '45day' or 'forecast' tag
-    start : (dt.datetime or NoneType)
+    start : dt.datetime or NoneType
         Starting time for combining data, or None to use earliest loaded
         date from the pysat Instruments (default=None)
-    stop : (dt.datetime)
+    stop : dt.datetime
         Ending time for combining data, or None to use the latest loaded date
         from the pysat Instruments (default=None)
 
     Returns
     -------
-    f107_inst : (pysat.Instrument)
+    f107_inst : pysat.Instrument
         Instrument object containing F10.7 observations for the desired period
         of time, merging the standard, 45day, and forecasted values based on
         their reliability
@@ -273,6 +274,7 @@ def combine_f107(standard_inst, forecast_inst, start=None, stop=None):
     Will not attempt to download any missing data, but will load data
 
     """
+
     # Initialize metadata and flags
     notes = "Combines data from"
     stag = standard_inst.tag if len(standard_inst.tag) > 0 else 'default'
@@ -444,22 +446,18 @@ def calc_daily_Ap(ap_inst, ap_name='3hr_ap', daily_name='Ap',
 
     Parameters
     ----------
-    ap_inst : (pysat.Instrument)
+    ap_inst : pysat.Instrument
         pysat instrument containing 3-hourly ap data
-    ap_name : (str)
+    ap_name : str
         Column name for 3-hourly ap data (default='3hr_ap')
-    daily_name : (str)
+    daily_name : str
         Column name for daily Ap data (default='Ap')
-    running_name : (str or NoneType)
+    running_name : str or NoneType
         Column name for daily running average of ap, not output if None
         (default=None)
 
-    Returns
-    -------
-    Void : updates intrument to include daily Ap index under daily_name
-
-    Notes
-    -----
+    Note
+    ----
     Ap is the mean of the 3hr ap indices measured for a given day
 
     Option for running average is included since this information is used

--- a/pysat/instruments/methods/sw.py
+++ b/pysat/instruments/methods/sw.py
@@ -3,9 +3,6 @@
 
 """
 
-from __future__ import print_function
-from __future__ import absolute_import
-
 import pandas as pds
 import numpy as np
 import pysat

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -11,21 +11,21 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
 
     Parameters
     ----------
-    tag : (str)
+    tag : str
         pysat instrument tag (default=None)
-    sat_id : (str)
+    sat_id : str
         pysat satellite ID tag (default=None)
-    data_path : (str)
+    data_path : str
         pysat data path (default=None)
-    format_str : (str)
+    format_str : str
         file format string (default=None)
-    file_date_range : (pds.date_range)
+    file_date_range : pds.date_range
         File date range. The default mode generates a list of 3 years of daily
         files (1 year back, 2 years forward) based on the test_dates passed
         through below.  Otherwise, accepts a range of files specified by the
         user.
         (default=None)
-    test_dates : (dt.datetime)
+    test_dates : dt.datetime
         Pass the _test_date object through from the test instrument files
 
     Returns
@@ -59,23 +59,23 @@ def list_remote_files(tag=None, sat_id=None, data_path=None, format_str=None,
 
     Parameters
     ----------
-    tag : (str)
+    tag : str
         pysat instrument tag (default=None)
-    sat_id : (str)
+    sat_id : str
         pysat satellite ID tag (default=None)
-    data_path : (str)
+    data_path : str
         pysat data path (default=None)
-    format_str : (str)
+    format_str : str
         file format string (default=None)
-    start : (dt.datetime or NoneType)
+    start : dt.datetime or NoneType
         Starting time for file list. A None value will start 1 year before
         test_date
         (default=None)
-    stop : (dt.datetime or NoneType)
+    stop : dt.datetime or NoneType
         Ending time for the file list.  A None value will stop 2 years 1 month
         after test_date
         (default=None)
-    test_dates : (dt.datetime)
+    test_dates : dt.datetime
         Pass the _test_date object through from the test instrument files
 
     Returns
@@ -109,30 +109,24 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
     **kwargs : dict
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this
         routine via kwargs.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
 
     """
 
@@ -177,10 +171,10 @@ def generate_times(fnames, sat_id, freq='1S'):
 
     Parameters
     ----------
-    fnames : (list)
+    fnames : list
         List of filenames.  Currently, only the first is used.  Does not
         support multi-file days as of yet.
-    sat_id : (str or NoneType)
+    sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
     freq : string
@@ -189,11 +183,11 @@ def generate_times(fnames, sat_id, freq='1S'):
 
     Outputs
     -------
-    uts : (array)
+    uts : array
         Array of integers representing uts for a given day
-    index : (DatetimeIndex)
+    index : DatetimeIndex
         The DatetimeIndex to be used in the pysat test instrument objects
-    date : (datetime)
+    date : datetime
         The requested date reconstructed from the fake file name
     """
 
@@ -232,8 +226,8 @@ def define_period():
     period : dict
         Dictionary of periods to use in test instruments
 
-    Notes
-    -----
+    Note
+    ----
     Local time and longitude slightly out of sync to simulate motion of Earth
 
     """

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -130,7 +130,7 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
 
     """
 
-    pass
+    return
 
 
 def generate_fake_data(t0, num_array, period=5820, data_range=[0.0, 24.0],

--- a/pysat/instruments/templates/netcdf_pandas.py
+++ b/pysat/instruments/templates/netcdf_pandas.py
@@ -119,20 +119,20 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
+        This input is nominally provided by pysat itself. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
+        This input is nominally provided by pysat itself. (default='')
     data_path : string
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
+        at Instrument instantiation and it will appear here. (default=None)
+    format_str : string
         String template used to parse the datasets filenames. If a user
         supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
+        then it will appear here, otherwise defaults to None. (default=None)
 
     Returns
     -------
@@ -186,26 +186,20 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
+        is provided by pysat. (default='')
     data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
-        error if user not supplied.
-    password : string (None)
-        Password for data download.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
-
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
 
     """
 

--- a/pysat/instruments/templates/template_cdaweb_instrument.py
+++ b/pysat/instruments/templates/template_cdaweb_instrument.py
@@ -9,29 +9,37 @@ on the mission, operations, instrumenation, and measurements.
 Also a good place to provide contact information. This text will
 be included in the pysat API documentation.
 
-Parameters
+Properties
 ----------
-platform : string
+platform
     *List platform string here*
-name : string
+name
     *List name string here*
-sat_id : string
+sat_id
     *List supported sat_ids here*
-tag : string
+tag
     *List supported tag strings here*
 
 Note
 ----
-::
-
-    Notes
+- Optional section, remove if no notes
 
 Warnings
 --------
+- Optional section, remove if no warnings
+- Two blank lines needed afterward for proper formatting
+
+
+Examples
+--------
+::
+
+    Example code can go here
 
 
 Authors
 -------
+Author name and institution
 
 """
 
@@ -134,12 +142,6 @@ def default(self):
     self : pysat.Instrument
         This object
 
-    Returns
-    --------
-    Void : (NoneType)
-        Object modified in place.
-
-
     """
 
     return
@@ -164,17 +166,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/templates/template_cdaweb_instrument.py
+++ b/pysat/instruments/templates/template_cdaweb_instrument.py
@@ -155,20 +155,24 @@ def clean(inst):
     will accept user input for several strings. The clean_level is
     specified at instantiation of the Instrument object.
 
-    'clean' All parameters should be good, suitable for statistical and
-            case studies
-    'dusty' All paramers should generally be good though same may
-            not be great
-    'dirty' There are data areas that have issues, data should be used
-            with caution
-    'none'  No cleaning applied, routine not called in this case.
-
-
     Parameters
     -----------
     inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
+
+    Note
+    ----
+    In general, pysat uses the following nomenclature for cleaning levels
+
+    - 'clean'
+        All parameters should be good, suitable for statistical and case studies
+    - 'dusty'
+        All paramers should generally be good though same may not be great
+    - 'dirty'
+        There are data areas that have issues, data should be used with caution
+    - 'none'
+        No cleaning applied, routine not called in this case.
 
     """
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -385,4 +385,4 @@ def list_remote_files(tag, sat_id, user=None, password=None):
 
     """
 
-    pass
+    return

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -4,34 +4,43 @@ This is a template for a pysat.Instrument support file.
 Modify this file as needed when adding a new Instrument to pysat.
 
 This is a good area to introduce the instrument, provide background
-on the mission, operations, instrumenation, and measurements.
+on the mission, operations, instrumentation, and measurements.
 
 Also a good place to provide contact information. This text will
 be included in the pysat API documentation.
 
-Parameters
+Properties
 ----------
-platform : string
+platform
     *List platform string here*
-name : string
+name
     *List name string here*
-sat_id : string
+sat_id
     *List supported sat_ids here*
-tag : string
+tag
     *List supported tag strings here*
 
 Note
 ----
-::
-
-    Notes
+- Optional section, remove if no notes
 
 Warnings
 --------
+- Optional section, remove if no warnings
+- Two blank lines needed afterward for proper formatting
+
+
+Examples
+--------
+::
+
+    Example code can go here
 
 
 Authors
 -------
+Author name and institution
+
 
 """
 
@@ -162,6 +171,7 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     Examples
     --------
     ::
+
         inst = pysat.Instrument('ucar', 'tiegcm')
         inst.load(2019,1)
 
@@ -254,6 +264,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     Examples
     --------
     ::
+
         If a filename is SPORT_L2_IVM_2019-01-01_v01r0000.NC then the template
         is 'SPORT_L2_IVM_{year:04d}-{month:02d}-{day:02d}_' +
         'v{version:02d}r{revision:04d}.NC'
@@ -282,19 +293,18 @@ def list_remote_files(tag, sat_id, user=None, password=None):
 
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
-
     Parameters
     -----------
-    tag : (string or NoneType)
+    tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    sat_id : (string or NoneType)
+    sat_id : string or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    user : (string or NoneType)
+    user : string or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)
-    password : (string or NoneType)
+    password : string or NoneType
         User password to be passed along to resource with relevant data.
         (default=None)
 
@@ -321,30 +331,24 @@ def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string ('')
+    tag : string
         Tag identifier used for particular dataset. This input is provided by
-        pysat.
-    sat_id : string  ('')
+        pysat. (default='')
+    sat_id : string
         Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat.
-    data_path : string (None)
-        Path to directory to download data to.
-    user : string (None)
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
         User string input used for download. Provided by user and passed via
-        pysat. If an account
-        is required for dowloads this routine here must error if user not
-        supplied.
-    password : string (None)
-        Password for data download.
-    **kwargs : dict
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
+    custom_keywords : placeholder
         Additional keywords supplied by user when invoking the download
         routine attached to a pysat.Instrument object are passed to this
-        routine via kwargs.
-
-    Returns
-    --------
-    Void : (NoneType)
-        Downloads data to disk.
+        routine. Use of custom keywords here is discouraged.
 
     """
 
@@ -370,17 +374,9 @@ def clean(inst):
 
     Parameters
     -----------
-    inst : (pysat.Instrument)
+    inst : pysat.Instrument
         Instrument class object, whose attribute clean_level is used to return
         the desired level of data selectivity.
-
-    Returns
-    --------
-    Void : (NoneType)
-        data in inst is modified in-place.
-
-    Notes
-    -----
 
     """
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -144,18 +144,18 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     fnames : array-like
         iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. While
         tag defaults to None here, pysat provides '' as the default
-        tag unless specified by user at Instrument instantiation.
-    sat_id : string ('')
+        tag unless specified by user at Instrument instantiation. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    **kwargs : extra keywords
-        Passthrough for additional keyword arguments specified when
-        instantiating an Instrument object. These additional keywords
-        are passed through to this routine by pysat.
+        This input is nominally provided by pysat itself. (default='')
+    custom_keyword : type to be set
+        Developers may include any custom keywords, with default values
+        defined in the method signature. This is included here as a
+        place holder and should be removed.
 
     Returns
     -------
@@ -233,6 +233,75 @@ def load(fnames, tag=None, sat_id=None, **kwargs):
     return data, meta
 
 
+def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
+             **kwargs):
+    """Placeholder for PLATFORM/NAME downloads.
+
+    This routine is invoked by pysat and is not intended for direct use by the
+    end user.
+
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need not
+        be contiguous.
+    tag : string
+        Tag identifier used for particular dataset. This input is provided by
+        pysat. (default='')
+    sat_id : string
+        Satellite ID string identifier used for particular dataset. This input
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string
+        User string input used for download. Provided by user and passed via
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
+    custom_keywords : placeholder
+        Additional keywords supplied by user when invoking the download
+        routine attached to a pysat.Instrument object are passed to this
+        routine. Use of custom keywords here is discouraged.
+
+    """
+
+    return
+
+
+# code should be defined below as needed
+def clean(inst):
+    """Routine to return PLATFORM/NAME data cleaned to the specified level
+
+    Cleaning level is specified in inst.clean_level and pysat
+    will accept user input for several strings. The clean_level is
+    specified at instantiation of the Instrument object.
+
+    Parameters
+    -----------
+    inst : pysat.Instrument
+        Instrument class object, whose attribute clean_level is used to return
+        the desired level of data selectivity.
+
+    Note
+    ----
+    In general, pysat uses the following nomenclature for cleaning levels
+
+    - 'clean'
+        All parameters should be good, suitable for statistical and case studies
+    - 'dusty'
+        All paramers should generally be good though same may not be great
+    - 'dirty'
+        There are data areas that have issues, data should be used with caution
+    - 'none'
+        No cleaning applied, routine not called in this case.
+
+
+    """
+
+    return
+
+
 def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
     """Produce a list of files corresponding to PLATFORM/NAME.
 
@@ -241,20 +310,20 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string ('')
+    tag : string
         tag name used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    sat_id : string ('')
+        This input is nominally provided by pysat itself. (default='')
+    sat_id : string
         Satellite ID used to identify particular data set to be loaded.
-        This input is nominally provided by pysat itself.
-    data_path : string (None)
+        This input is nominally provided by pysat itself. (default='')
+    data_path : string
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
-        at Instrument instantiation and it will appear here.
-    format_str : string (None)
+        at Instrument instantiation and it will appear here. (default=None)
+    format_str : string
         String template used to parse the datasets filenames. If a user
         supplies a template string at Instrument instantiation
-        then it will appear here, otherwise defaults to None.
+        then it will appear here, otherwise defaults to None. (default=None)
 
     Returns
     -------
@@ -317,67 +386,3 @@ def list_remote_files(tag, sat_id, user=None, password=None):
     """
 
     pass
-
-
-def download(date_array, tag, sat_id, data_path=None, user=None, password=None,
-             **kwargs):
-    """Placeholder for PLATFORM/NAME downloads.
-
-    This routine is invoked by pysat and is not intended for direct use by the
-    end user.
-
-    Parameters
-    ----------
-    date_array : array-like
-        list of datetimes to download data for. The sequence of dates need not
-        be contiguous.
-    tag : string
-        Tag identifier used for particular dataset. This input is provided by
-        pysat. (default='')
-    sat_id : string
-        Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat. (default='')
-    data_path : string
-        Path to directory to download data to. (default=None)
-    user : string
-        User string input used for download. Provided by user and passed via
-        pysat. If an account is required for dowloads this routine here must
-        error if user not supplied. (default=None)
-    password : string
-        Password for data download. (default=None)
-    custom_keywords : placeholder
-        Additional keywords supplied by user when invoking the download
-        routine attached to a pysat.Instrument object are passed to this
-        routine. Use of custom keywords here is discouraged.
-
-    """
-
-    return
-
-
-# code should be defined below as needed
-def clean(inst):
-    """Routine to return PLATFORM/NAME data cleaned to the specified level
-
-    Cleaning level is specified in inst.clean_level and pysat
-    will accept user input for several strings. The clean_level is
-    specified at instantiation of the Instrument object.
-
-    'clean' All parameters should be good, suitable for statistical and
-            case studies
-    'dusty' All paramers should generally be good though same may
-            not be great
-    'dirty' There are data areas that have issues, data should be used
-            with caution
-    'none'  No cleaning applied, routine not called in this case.
-
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object, whose attribute clean_level is used to return
-        the desired level of data selectivity.
-
-    """
-
-    return


### PR DESCRIPTION
# Description

- Applies new docstring style to methods and templates.
- Declares integer in for input in `convert_timestamp_to_datetime` to supress futurewarnings in python 3.8 (~10,700 warning messages :scream: )

This is the last PR needed before instruments can be migrated out.

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest, as well as make html

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
