### PR TITLE
TST: updates to tests in core code after instrument migration

### DIFF
--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import numpy as np
 import os
+import warnings
 
 import pandas as pds
 
@@ -137,6 +138,9 @@ def download(date_array, tag, sat_id, data_path=None, user=None,
         routine via kwargs.
 
     """
+
+    if tag == 'no_download':
+        warnings.warn('This simulates an instrument without download support')
 
     return
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -27,14 +27,16 @@ tags = {'': 'Regular testing data set',
         'plus10': 'Ascending Integers from 10 testing data set',
         'fives': 'All 5s testing data set',
         'mlt_offset': 'dummy1 is offset by five from regular testing set',
-        'no_download': 'simulate an instrument without download support'}
+        'no_download': 'simulate an instrument without download support',
+        'non_strict': 'simulate an instrument without strict_time_flag'}
 
 # dictionary of satellite IDs, list of corresponding tags
 # a numeric string can be used in sat_id to change the number of points per day
 sat_ids = {'': ['', 'ascend', 'descend', 'plus10', 'fives', 'mlt_offset',
                 'no_download']}
 _test_dates = {'': {'': dt.datetime(2009, 1, 1),
-                    'no_download': dt.datetime(2009, 1, 1)}}
+                    'no_download': dt.datetime(2009, 1, 1),
+                    'non_strict': dt.datetime(2009, 1, 1)}}
 _test_download = {'': {'no_download': False}}
 
 
@@ -211,7 +213,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     data['int32_dummy'] = np.ones(len(data), dtype=np.int32)
     data['int64_dummy'] = np.ones(len(data), dtype=np.int64)
 
-    if malformed_index:
+    # Activate for testing malformed_index, and for instrument_test_class
+    if malformed_index or tag == 'non_strict':
         index = index.tolist()
         # nonmonotonic
         index[0:3], index[3:6] = index[3:6], index[0:3]

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -26,12 +26,16 @@ tags = {'': 'Regular testing data set',
         'descend': 'Descending Integers from 0 testing data set',
         'plus10': 'Ascending Integers from 10 testing data set',
         'fives': 'All 5s testing data set',
-        'mlt_offset': 'dummy1 is offset by five from regular testing set'}
+        'mlt_offset': 'dummy1 is offset by five from regular testing set',
+        'no_download': 'simulate an instrument without download support'}
 
 # dictionary of satellite IDs, list of corresponding tags
 # a numeric string can be used in sat_id to change the number of points per day
-sat_ids = {'': ['', 'ascend', 'descend', 'plus10', 'fives', 'mlt_offset']}
-_test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+sat_ids = {'': ['', 'ascend', 'descend', 'plus10', 'fives', 'mlt_offset',
+                'no_download']}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1),
+                    'no_download': dt.datetime(2009, 1, 1)}}
+_test_download = {'': {'no_download': False}}
 
 
 def init(self):

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -225,7 +225,12 @@ class InstTestClass():
                     # Check if instrument is failing due to strict time flag
                     if str(verr).find('Loaded data') > 0:
                         inst.strict_time_flag = False
-                        inst.load(date=start)
+                        with warnings.catch_warnings(record=True) as war:
+                            inst.load(date=start)
+                        assert len(war) >= 1
+                        categories = [war[j].category for j in range(0,
+                                                                     len(war))]
+                        assert UserWarning in categories
                     else:
                         # If error message does not match, raise error anyway
                         raise(verr)

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -54,8 +54,8 @@ def generate_instrument_list(package=None):
     package : python module
         The instrument library package to test, eg, 'pysat.instruments'
 
-    Notes
-    -----
+    Note
+    ----
     Only want to do this once per instrument library being tested.
 
     """

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -45,7 +45,7 @@ def remove_files(inst):
                                'ensure temp directory is used')))
 
 
-def generate_instrument_list(package=None):
+def generate_instrument_list(package):
     """Iterate through and create all of the test Instruments needed.
 
 
@@ -59,9 +59,6 @@ def generate_instrument_list(package=None):
     Only want to do this once per instrument library being tested.
 
     """
-
-    if package is None:
-        package = pysat.instruments
 
     instrument_names = package.__all__
     instrument_download = []

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -1003,3 +1003,14 @@ class TestDeprecation():
 
         assert len(war) >= 1
         assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_search_local_system_formatted_filename(self):
+        """Test if _files.search_local_system_formatted_filename is deprecated
+        """
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.search_local_system_formatted_filename('', '')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning


### PR DESCRIPTION
# Description

- Adjusts the local test instruments to engage all options in `instrument_test_class`
- Removes default package in `instrument_test_class`
- Adds a deprecation warning test for `search_local_system_formatted_filename`, which was deprecated in #505 

After the removal of the instruments in #515, some covered areas (instruments without download support, non strict_time data) have become uncovered.  These are still engaged by the downstream packages, but troubleshooting becomes difficult in changes in pysat manifest downstream and are not tested here.

Also, when working with downstream packages, the test class should error if a package is not supplied.  Otherwise, tests are run on the main pysat instruments and a false positive will be seen downstream.  Better to have an error right away to let other package developers know something is wrong right away.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

via pytest

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes (NOTE: changes to instrument_test_class, which is already in the log for 3.0)
