### PR TITLE
Update Carey's Zenodo entry and style

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -16,7 +16,8 @@
         "orcid": "0000-0001-8875-9326"
       }, 
       {
-        "name": "Carey Spence"
+        "name": "Carey Spence",
+        "orcid": "0000-0001-8340-5625"
       }, 
       {
         "name": "Asher Pembroke"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -52,6 +52,5 @@
     "resource_type": {
       "type": "software", 
       "title": "Software"
-    },
-  }
+    }
 }


### PR DESCRIPTION
# Description

Partially Addresses #495 

* Update Carey's Zenodo entry with an ORCID identifier.
* Remove an extra `}` that was causing JSON validation to fail. 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

I checked that the JSON file is valid JSON: 

```
% git log -1 --pretty=oneline
6a03a40c5aa4dde9b7ed0177b51609543dcde519 (HEAD -> zenodo-carey, origin/zenodo-carey) style(zenodo): Remove extra bracket
% git diff
% json_pp -V 
4.04
% json_pp < .zenodo.json > /dev/null && echo OK || echo FAIL 
OK
% 
```

**Test Configuration**:
* Operating system: Fedora 32
* Version number: pysat 3.0.0, json_pp 4.04

# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] [N/A] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] [N/A] I have commented my code, particularly in hard-to-understand areas
- [x] [N/A] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] [N/A] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
