### PR TITLE
Registry update

### DIFF
--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -79,20 +79,29 @@ if not os.path.isdir(pysat_dir):
     # user modules file
     with open(os.path.join(pysat_dir, 'user_modules.txt'), 'w') as f:
         f.write('')
-        user_modules = []
+        user_modules = {}
 
 else:
     # load up stored data path
     with open(os.path.join(pysat_dir, 'data_path.txt'), 'r') as f:
         data_dir = f.readline()
+
     # load up stored user modules
-    user_modules = []
+    user_modules = {}
     modules_file = os.path.join(pysat_dir, 'user_modules.txt')
     if os.path.exists(modules_file):
-        with open(modules_file, 'r') as f:
-            for _ in f:
-                if _ != '' and (_ is not None):
-                    user_modules.append(_.strip())
+        with open(modules_file, 'r') as fopen:
+            for line in fopen:
+                if line != '' and (line is not None):
+                    # remove trailing whitespace
+                    line = line.strip()
+                    # stored as platform, name, module string
+                    platform, name, inst_module = line.split(' ')
+                    # dict of dicts, keyed by platform then name
+                    if platform not in user_modules:
+                        user_modules[platform] = {}
+                    # store instrument module string
+                    user_modules[platform][name] = inst_module
     else:
         # write user modules file
         with open(os.path.join(pysat_dir, 'user_modules.txt'), 'w') as f:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -957,7 +957,7 @@ class Instrument(object):
                 try:
                     mod = user_modules[self.platform][self.name]
                     inst = importlib.import_module(mod)
-                except Exception as error:
+                except Exception:
                     estr = ' '.join(('pysat was either unable to locate the',
                                      'module in the registry or',
                                      'successfully import the module',

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -946,34 +946,20 @@ class Instrument(object):
         self.pandas_format = True
 
         if by_name:
-            # look for code with filename name, any errors passed up
-            # start with local areas
-            import_success = False
-            try:
+            if self.platform == 'pysat':
+                # look within pysat
                 inst = \
                     importlib.import_module(''.join(('.', self.platform, '_',
                                                      self.name)),
                                             package='pysat.instruments')
-                import_success = True
-            except ImportError:
-                # iterate through user set modules
-                for mod in user_modules:
-                    # get my.package.name from my.package.name.platform_name
-                    try:
-                        inst = importlib.import_module(mod)
-                        if ((inst.platform == self.platform)
-                                & (inst.name == self.name)):
-                            import_success = True
-                            # done!
-                            break
-                    except ImportError:
-                        pass
-                if not import_success:
-                    raise ImportError(' '.join(('Could not find a registered',
-                                                'module for', self.platform,
-                                                self.name, '\nAvailable',
-                                                'modules:',
-                                                ', '.join((user_modules)))))
+            else:
+                # not a native pysat.Instrument
+                try:
+                    mod = user_modules[self.platform][self.name]
+                    inst = importlib.import_module(mod)
+                except Exception as error:
+                    logger.error(error)
+                    raise
         elif inst_module is not None:
             # user supplied an object with relevant instrument routines
             inst = inst_module

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -958,7 +958,12 @@ class Instrument(object):
                     mod = user_modules[self.platform][self.name]
                     inst = importlib.import_module(mod)
                 except Exception as error:
-                    logger.error(error)
+                    estr = ' '.join(('pysat was either unable to locate the',
+                                     'module in the registry or',
+                                     'successfully import the module',
+                                     'for platform:', self.platform,
+                                     'and name:', self.name))
+                    logger.error(estr)
                     raise
         elif inst_module is not None:
             # user supplied an object with relevant instrument routines

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -123,12 +123,13 @@ class InstTestClass():
                   'acknowledgements': str, 'references': str}
 
     @pytest.mark.all_inst
-    def test_modules_standard(self, name):
+    def test_modules_standard(self, name, module=None):
         """Checks that modules are importable and have standard properties.
         """
         # ensure that each module is at minimum importable
-        module = import_module(''.join(('.', name)),
-                               package=self.package.__name__)
+        if module is None:
+            module = import_module(''.join(('.', name)),
+                                   package=self.package.__name__)
         # Check for presence of basic instrument module attributes
         for mattr in self.module_attrs:
             assert hasattr(module, mattr)
@@ -156,11 +157,12 @@ class InstTestClass():
                                       self.attr_types[iattr])
 
     @pytest.mark.all_inst
-    def test_standard_function_presence(self, name):
+    def test_standard_function_presence(self, name, module=None):
         """Check if each function is callable and all required functions exist
         """
-        module = import_module(''.join(('.', name)),
-                               package=self.package.__name__)
+        if module is None:
+            module = import_module(''.join(('.', name)),
+                                   package=self.package.__name__)
 
         # Test for presence of all standard module functions
         for mcall in self.inst_callable:

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -123,13 +123,12 @@ class InstTestClass():
                   'acknowledgements': str, 'references': str}
 
     @pytest.mark.all_inst
-    def test_modules_standard(self, name, module=None):
+    def test_modules_standard(self, name):
         """Checks that modules are importable and have standard properties.
         """
         # ensure that each module is at minimum importable
-        if module is None:
-            module = import_module(''.join(('.', name)),
-                                   package=self.package.__name__)
+        module = import_module(''.join(('.', name)),
+                               package=self.package.__name__)
         # Check for presence of basic instrument module attributes
         for mattr in self.module_attrs:
             assert hasattr(module, mattr)
@@ -157,12 +156,11 @@ class InstTestClass():
                                       self.attr_types[iattr])
 
     @pytest.mark.all_inst
-    def test_standard_function_presence(self, name, module=None):
+    def test_standard_function_presence(self, name):
         """Check if each function is callable and all required functions exist
         """
-        if module is None:
-            module = import_module(''.join(('.', name)),
-                                   package=self.package.__name__)
+        module = import_module(''.join(('.', name)),
+                               package=self.package.__name__)
 
         # Test for presence of all standard module functions
         for mcall in self.inst_callable:

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -186,7 +186,7 @@ class TestRegistration():
             # registered has been removed
             for platform, name in zip(self.platforms, self.platform_names):
                 registry.remove(platform, name)
-        except:
+        except Exception:
             # ok if a module has already been removed
             pass
         # ensure things are clean, all have been removed

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -386,7 +386,7 @@ class TestModuleRegistration():
                                module_names]
         self.platforms = ['pysat'] * len(self.platform_names)
         module_strings = ['.'.join((pkg_name, name)) for name in
-                           module_names]
+                          module_names]
         self.modules = [(mod, plat, nam) for mod, plat, nam in
                         zip(module_strings, self.platforms,
                             self.platform_names)]

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -283,9 +283,11 @@ class TestRegistration():
         # verify stored update
         ensure_updated_stored_modules(self.modules)
         # remove them using only platform
-        for platform in np.unique(self.platforms):
+        for i, platform in enumerate(np.unique(self.platforms)):
             registry.remove(platform)
-        # test for removal performed by teardown
+            # doing this one by one ensures more lines tested
+            ensure_not_in_stored_modules([self.modules[i]])
+        # test for removal also performed by teardown
 
         return
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -216,3 +216,19 @@ class TestRegistration():
         ensure_updated_stored_modules(self.modules)
 
         return
+
+    def test_platform_removal(self):
+        """Test registering multiple instruments at once"""
+
+        # register all modules at once
+        registry.register(self.module_names)
+        # verify instantiation
+        verify_platform_name_instantiation(self.modules)
+        # verify registration
+        ensure_live_registry_updated(self.modules)
+        # verify stored update
+        ensure_updated_stored_modules(self.modules)
+        # remove them using only platform
+        registry.remove(self.platform_names)
+
+        return

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -191,7 +191,7 @@ class TestRegistration():
             # remove singly to ensure everything that could've been
             # registered has been removed
             for platform, name in zip(self.platforms, self.platform_names):
-                registry.remove(platform, name)
+                registry.remove([platform], [name])
         except ValueError:
             # ok if a module has already been removed
             pass
@@ -271,7 +271,8 @@ class TestRegistration():
         # verify stored update
         ensure_updated_stored_modules(self.modules)
         # remove them using only platform
-        registry.remove(np.unique(self.platforms))
+        uplatforms = np.unique(self.platforms)
+        registry.remove(uplatforms, [None] * len(uplatforms))
         # test for removal performed by teardown
         return
 
@@ -288,7 +289,7 @@ class TestRegistration():
         ensure_updated_stored_modules(self.modules)
         # remove them using only platform
         for i, platform in enumerate(np.unique(self.platforms)):
-            registry.remove(platform)
+            registry.remove([platform], [None])
 
         # doing this one by one ensures more lines tested
 
@@ -308,7 +309,7 @@ class TestRegistration():
         # remove them using only platform
         count = 0
         for platform, name in zip(self.platforms, self.platform_names):
-            registry.remove(platform, name)
+            registry.remove([platform], [name])
             # doing this one by one allows for test that all names
             # for a platform aren't removed
             ensure_not_in_stored_modules([self.modules[count]])
@@ -325,16 +326,7 @@ class TestRegistration():
 
         # remove non-registered modules using only platform
         with pytest.raises(ValueError):
-            registry.remove(['made_up_name'])
-
-        return
-
-    def test_platform_string_removal_error(self):
-        """Test error raised when removing module not present"""
-
-        # remove non-registered modules using only platform
-        with pytest.raises(ValueError):
-            registry.remove('made_up_name')
+            registry.remove(['made_up_name'], [None])
 
         return
 
@@ -365,7 +357,7 @@ class TestRegistration():
             registry.remove(['made_up_name', 'second'], ['made_up_name'])
 
         with pytest.raises(ValueError):
-            registry.remove('made_up_name', ['made_up_name', 'second'])
+            registry.remove(['made_up_name'], ['made_up_name', 'second'])
 
         with pytest.raises(ValueError):
             registry.remove([], ['made_up_name', 'second'])
@@ -374,7 +366,7 @@ class TestRegistration():
             registry.remove([], ['made_up_name'])
 
         with pytest.raises(ValueError):
-            registry.remove([], 'made_up_name')
+            registry.remove([], ['made_up_name'])
 
         return
 
@@ -420,7 +412,7 @@ class TestModuleRegistration():
         # registered
         for plat_name in np.unique(self.platforms):
             try:
-                registry.remove(plat_name)
+                registry.remove([plat_name], [None])
             except ValueError:
                 pass
 
@@ -432,7 +424,7 @@ class TestModuleRegistration():
             # remove singly to ensure everything that could've been
             # registered has been removed
             for platform, name in zip(self.platforms, self.platform_names):
-                registry.remove(platform, name)
+                registry.remove([platform], [name])
         except ValueError:
             # ok if a module has already been removed
             pass

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -346,7 +346,12 @@ class TestRegistration():
 
         return
 
-    def test_platform_name_length_removal_error(self):
+    @pytest.mark.parametrize("platforms, names",
+                             [(['made_up_name', 'second'], ['made_up_name']),
+                              (['made_up_name'], ['made_up_name', 'second']),
+                              ([], ['made_up_name', 'second']),
+                              ([], ['made_up_name'])])
+    def test_platform_name_length_removal_error(self, platforms, names):
         """Test error raised when platforms and names unequal lengths"""
 
         # register all modules at once
@@ -354,19 +359,7 @@ class TestRegistration():
 
         # unequal lengths
         with pytest.raises(ValueError):
-            registry.remove(['made_up_name', 'second'], ['made_up_name'])
-
-        with pytest.raises(ValueError):
-            registry.remove(['made_up_name'], ['made_up_name', 'second'])
-
-        with pytest.raises(ValueError):
-            registry.remove([], ['made_up_name', 'second'])
-
-        with pytest.raises(ValueError):
-            registry.remove([], ['made_up_name'])
-
-        with pytest.raises(ValueError):
-            registry.remove([], ['made_up_name'])
+            registry.remove(platforms, names)
 
         return
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -310,7 +310,7 @@ class TestRegistration():
             ensure_not_in_stored_modules([self.modules[count]])
             # test other names still present
             if count < len(self.platforms) - 1:
-                ensure_updated_stored_modules(self.modules[count+1:])
+                ensure_updated_stored_modules(self.modules[count + 1:])
             count += 1
         # test for full removal also performed by teardown
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -181,8 +181,15 @@ class TestRegistration():
 
     def teardown(self):
         # clean up
-        registry.remove(self.platforms, self.platform_names)
-        # ensure things are clean
+        try:
+            # remove singly to ensure everything that could've been
+            # registered has been removed
+            for platform, name in zip(self.platforms, self.platform_names):
+                registry.remove(platform, name)
+        except:
+            # ok if a module has already been removed
+            pass
+        # ensure things are clean, all have been removed
         ensure_not_in_stored_modules(self.modules)
 
     def test_single_registration(self):
@@ -202,7 +209,7 @@ class TestRegistration():
 
         return
 
-    def test_multi_registration(self):
+    def test_array_registration(self):
         """Test registering multiple instruments at once"""
 
         # register all modules at once
@@ -217,8 +224,8 @@ class TestRegistration():
 
         return
 
-    def test_platform_removal(self):
-        """Test registering multiple instruments at once"""
+    def test_platform_removal_array(self):
+        """Test removing entire platform at once"""
 
         # register all modules at once
         registry.register(self.module_names)
@@ -229,6 +236,58 @@ class TestRegistration():
         # verify stored update
         ensure_updated_stored_modules(self.modules)
         # remove them using only platform
-        registry.remove(self.platform_names)
+        registry.remove(self.platforms)
+        # test for removal performed by teardown
+        return
+
+    def test_platform_removal_single_string(self):
+        """Test removing entire platform at once"""
+
+        # register all modules at once
+        registry.register(self.module_names)
+        # verify instantiation
+        verify_platform_name_instantiation(self.modules)
+        # verify registration
+        ensure_live_registry_updated(self.modules)
+        # verify stored update
+        ensure_updated_stored_modules(self.modules)
+        # remove them using only platform
+        for platform in self.platforms:
+            registry.remove(platform)
+        # test for removal performed by teardown
+
+        return
+
+    def test_platform_removal_error(self):
+        """Test error raised when removing module not present"""
+
+        # remove non-registered modules using only platform
+        with pytest.raises(ValueError):
+            registry.remove(['made_up_name'])
+
+        return
+
+    def test_platform_string_removal_error(self):
+        """Test error raised when removing module not present"""
+
+        # remove non-registered modules using only platform
+        with pytest.raises(ValueError):
+            registry.remove('made_up_name')
+
+        return
+
+    def test_platform_name_removal_error(self):
+        """Test error raised when removing module not present"""
+
+        # register all modules at once
+        registry.register(self.module_names)
+
+        # remove non-registered modules using platform and name
+        with pytest.raises(ValueError):
+            registry.remove(['made_up_name'], ['made_up_name'])
+
+        # remove non-registered modules using good platform and bad name
+        with pytest.raises(ValueError):
+            registry.remove([self.platforms[0]], ['made_up_name'])
 
         return

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -41,53 +41,165 @@ def create_fake_module(full_module_name, platform, name):
     sys.modules['.'.join([package_name, module_name])] = instrument
 
 
+def ensure_updated_stored_modules(modules):
+    """Ensure stored pysat.user_modules updated
+    to include modules
+
+    Parameters
+    ----------
+    modules : list
+        List of tuples (module_string, platform, name)
+        that will be checked against stored
+        pysat.user_modules
+
+    """
+    # make sure filesystem was updated
+    saved_modules = registry.load_saved_modules()
+    for module_name, platform, name in modules:
+        assert platform in saved_modules
+        assert name in saved_modules[platform]
+        assert module_name in saved_modules[platform][name]
+
+
+def ensure_live_registry_updated(modules):
+    """Ensure current pysat.user_modules updated
+    to include modules
+
+    Parameters
+    ----------
+    modules : list
+        List of tuples (module_string, platform, name)
+        that will be checked against stored
+        pysat.user_modules
+
+    """
+
+    for module_name, platform, name in modules:
+        # check that global registry was updated
+        assert platform in user_modules
+        assert name in user_modules[platform]
+        assert module_name in user_modules[platform][name]
+
+
+def ensure_not_in_stored_modules(modules):
+    """Ensure modules not in stored pysat.user_modules
+
+    Parameters
+    ----------
+    modules : list
+        List of tuples (module_string, platform, name)
+        that will be checked against stored
+        pysat.user_modules
+
+    """
+    # ensure input modules not in stored modules
+    saved_modules = registry.load_saved_modules()
+    for module_name, platform, name in modules:
+        if platform in saved_modules:
+            assert module_name not in saved_modules[platform]
+        else:
+            # platform not present, so not registered
+            assert True
+        with pytest.raises(KeyError):
+            Instrument(platform, name)
+
+
+def test_registration():
+    modules = [
+        ('package1.module1', 'platname1', 'name1'),
+        ('package2.module2', 'platname2', 'name2')]
+
+    module_names = [mod[0] for mod in modules]
+    platforms = [mod[1] for mod in modules]
+    platform_names = [mod[2] for mod in modules]
+
+    # do pre-cleanup
+    try:
+        registry.remove(platforms, platform_names)
+    except ValueError:
+        pass
+
+    # make sure instruments are not yet registered
+    ensure_not_in_stored_modules(modules)
+
+    # create modules
+    for module_name, platform, name in modules:
+        # create modules
+        create_fake_module(module_name, platform, name)
+        # import fake modules
+        test_mod = importlib.import_module(module_name)
+
+        # load module by keyword
+        inst = Instrument(inst_module=test_mod)
+        # ensure we have the correct one
+        assert inst.platform == platform
+        assert inst.name == name
+
+        # register package
+        registry.register(module_name)
+        # load by platform and name
+        inst2 = Instrument(platform, name)
+        # ensure we have the correct one
+        assert inst2.platform == platform
+        assert inst2.name == name
+
+        # check that global registry was updated
+        ensure_live_registry_updated([(module_name, platform, name)])
+
+    # verify update
+    ensure_updated_stored_modules(modules)
+    # clean up
+    registry.remove(platforms, platform_names)
+    # ensure things are clean
+    ensure_not_in_stored_modules(modules)
+
+
 def test_multi_registration():
     modules = [
         ('package1.module1', 'platname1', 'name1'),
         ('package2.module2', 'platname2', 'name2')]
 
     module_names = [mod[0] for mod in modules]
+    platforms = [mod[1] for mod in modules]
+    platform_names = [mod[2] for mod in modules]
 
-    registry.remove(*module_names)
-
-    # make sure modules are not yet created
-    for module_name in module_names:
-        with pytest.raises(ImportError):
-            importlib.import_module(module_name)
+    # do pre-cleanup
+    try:
+        registry.remove(platforms, platform_names)
+    except ValueError:
+        pass
 
     # make sure instruments are not yet registered
-    saved_modules = registry.load_saved_modules()
-    for module_name, platform, name in modules:
-        assert module_name not in saved_modules
-        with pytest.raises(ImportError):
-            Instrument(platform, name)
+    ensure_not_in_stored_modules(modules)
 
     # create modules
     for module_name, platform, name in modules:
-
+        # create modules
         create_fake_module(module_name, platform, name)
-
+        # import fake modules
         test_mod = importlib.import_module(module_name)
-
         # load module by keyword
-        Instrument(inst_module=test_mod)
+        inst = Instrument(inst_module=test_mod)
+        # ensure we have the correct one
+        assert inst.platform == platform
+        assert inst.name == name
 
+    # register all modules at once
+    registry.register(module_names)
+    # verify registration
+    ensure_live_registry_updated(modules)
+    # verify stored update
+    ensure_updated_stored_modules(modules)
+
+    # verify instantiation
+    for module_name, platform, name in modules:
         # load by platform and name
-        registry.register(module_name)
-        Instrument(platform, name)
-
-        # check that global registry was updated
-        assert module_name in user_modules
-
-    # make sure user_modules.txt was updated
-    saved_modules = registry.load_saved_modules()
-    for module_name in module_names:
-        assert module_name in saved_modules
+        inst2 = Instrument(platform, name)
+        # ensure we have the correct one
+        assert inst2.platform == platform
+        assert inst2.name == name
 
     # clean up
-    registry.remove(*module_names)
-
-    saved_modules = registry.load_saved_modules()
-    for module_name in module_names:
-        assert module_name not in user_modules
-        assert module_name not in saved_modules
+    registry.remove(platforms, platform_names)
+    # ensure things are clean
+    ensure_not_in_stored_modules(modules)

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -357,6 +357,14 @@ class TestRegistration():
 
         return
 
+    def test_module_registration_non_importable(self):
+        """Test registering a non-existent module"""
+
+        with pytest.raises(Exception):
+            registry.register(['made.up.module'])
+
+        return
+
 
 class TestModuleRegistration():
     def setup(self):

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -372,7 +372,7 @@ class TestRegistration():
 
 
 class TestModuleRegistration():
-    def setup(self, ):
+    def setup(self):
 
         self.inst_module = pysat.instruments
         # package name

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -6,10 +6,11 @@ import numpy as np
 import pytest
 import sys
 
-import pysat
+
 from pysat import user_modules
 from pysat.utils import registry
 from pysat import Instrument
+from pysat import instruments
 from pysat.instruments import pysat_testing
 import importlib
 
@@ -369,7 +370,7 @@ class TestRegistration():
 class TestModuleRegistration():
     def setup(self):
 
-        self.inst_module = pysat.instruments
+        self.inst_module = instruments
         # package name
         pkg_name = self.inst_module.__name__
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -354,7 +354,7 @@ class TestRegistration():
 
         return
 
-    def test_platform_name_removal_error(self):
+    def test_platform_name_length_removal_error(self):
         """Test error raised when platforms and names unequal lengths"""
 
         # register all modules at once

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -354,6 +354,30 @@ class TestRegistration():
 
         return
 
+    def test_platform_name_removal_error(self):
+        """Test error raised when platforms and names unequal lengths"""
+
+        # register all modules at once
+        registry.register(self.module_names)
+
+        # unequal lengths
+        with pytest.raises(ValueError):
+            registry.remove(['made_up_name', 'second'], ['made_up_name'])
+
+        with pytest.raises(ValueError):
+            registry.remove('made_up_name', ['made_up_name', 'second'])
+
+        with pytest.raises(ValueError):
+            registry.remove([], ['made_up_name', 'second'])
+
+        with pytest.raises(ValueError):
+            registry.remove([], ['made_up_name'])
+
+        with pytest.raises(ValueError):
+            registry.remove([], 'made_up_name')
+
+        return
+
     def test_module_registration_single(self):
         """Test registering a module containing an instrument"""
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -224,7 +224,6 @@ class TestRegistration():
 
         return
 
-
     def test_platform_removal_array(self):
         """Test removing entire platform at once"""
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -285,9 +285,34 @@ class TestRegistration():
         # remove them using only platform
         for i, platform in enumerate(np.unique(self.platforms)):
             registry.remove(platform)
-            # doing this one by one ensures more lines tested
-            ensure_not_in_stored_modules([self.modules[i]])
-        # test for removal also performed by teardown
+
+        # doing this one by one ensures more lines tested
+
+        return
+
+    def test_platform_name_removal_single_string(self):
+        """Test removing single platform/name at a time"""
+
+        # register all modules at once
+        registry.register(self.module_names)
+        # verify instantiation
+        verify_platform_name_instantiation(self.modules)
+        # verify registration
+        ensure_live_registry_updated(self.modules)
+        # verify stored update
+        ensure_updated_stored_modules(self.modules)
+        # remove them using only platform
+        count = 0
+        for platform, name in zip(self.platforms, self.platform_names):
+            registry.remove(platform, name)
+            # doing this one by one allows for test that all names
+            # for a platform aren't removed
+            ensure_not_in_stored_modules([self.modules[count]])
+            # test other names still present
+            if count < len(self.platforms) - 1:
+                ensure_updated_stored_modules(self.modules[count+1:])
+            count += 1
+        # test for full removal also performed by teardown
 
         return
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -1,8 +1,11 @@
 """
 tests the registration of user-defined modules
 """
+
+import numpy as np
 import pytest
 import sys
+
 import pysat
 from pysat import user_modules
 from pysat.utils import registry
@@ -160,6 +163,7 @@ class TestRegistration():
     def setup(self):
         self.modules = [
             ('package1.module1', 'platname1', 'name1'),
+            ('package11.module2', 'platname1', 'name2'),
             ('package2.module2', 'platname2', 'name2')]
 
         self.module_names = [mod[0] for mod in self.modules]
@@ -263,7 +267,7 @@ class TestRegistration():
         # verify stored update
         ensure_updated_stored_modules(self.modules)
         # remove them using only platform
-        registry.remove(self.platforms)
+        registry.remove(np.unique(self.platforms))
         # test for removal performed by teardown
         return
 
@@ -279,7 +283,7 @@ class TestRegistration():
         # verify stored update
         ensure_updated_stored_modules(self.modules)
         # remove them using only platform
-        for platform in self.platforms:
+        for platform in np.unique(self.platforms):
             registry.remove(platform)
         # test for removal performed by teardown
 

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -156,75 +156,63 @@ def ensure_not_in_stored_modules(modules):
             Instrument(platform, name)
 
 
-def test_registration():
-    modules = [
-        ('package1.module1', 'platname1', 'name1'),
-        ('package2.module2', 'platname2', 'name2')]
+class TestRegistration():
+    def setup(self):
+        self.modules = [
+            ('package1.module1', 'platname1', 'name1'),
+            ('package2.module2', 'platname2', 'name2')]
 
-    module_names = [mod[0] for mod in modules]
-    platforms = [mod[1] for mod in modules]
-    platform_names = [mod[2] for mod in modules]
+        self.module_names = [mod[0] for mod in self.modules]
+        self.platforms = [mod[1] for mod in self.modules]
+        self.platform_names = [mod[2] for mod in self.modules]
 
-    # do pre-cleanup
-    try:
-        registry.remove(platforms, platform_names)
-    except ValueError:
-        pass
+        # do pre-cleanup
+        try:
+            registry.remove(self.platforms, self.platform_names)
+        except ValueError:
+            pass
 
-    # make sure instruments are not yet registered
-    ensure_not_in_stored_modules(modules)
-    # create modules
-    create_and_verify_fake_modules(modules)
+        # make sure instruments are not yet registered
+        ensure_not_in_stored_modules(self.modules)
+        # create modules
+        create_and_verify_fake_modules(self.modules)
 
-    # create modules
-    for module_name, platform, name in modules:
-        # register package
-        registry.register(module_name)
+        return
 
-    # verify instantiation
-    verify_platform_name_instantiation(modules)
-    # check that global registry was updated
-    ensure_live_registry_updated(modules)
-    # verify update
-    ensure_updated_stored_modules(modules)
-    # clean up
-    registry.remove(platforms, platform_names)
-    # ensure things are clean
-    ensure_not_in_stored_modules(modules)
+    def teardown(self):
+        # clean up
+        registry.remove(self.platforms, self.platform_names)
+        # ensure things are clean
+        ensure_not_in_stored_modules(self.modules)
 
-    return
+    def test_single_registration(self):
+        """Test registering package one at a time"""
 
+        # create modules
+        for module_name, platform, name in self.modules:
+            # register package
+            registry.register(module_name)
 
-def test_multi_registration():
-    modules = [
-        ('package1.module1', 'platname1', 'name1'),
-        ('package2.module2', 'platname2', 'name2')]
+        # verify instantiation
+        verify_platform_name_instantiation(self.modules)
+        # check that global registry was updated
+        ensure_live_registry_updated(self.modules)
+        # verify update
+        ensure_updated_stored_modules(self.modules)
 
-    module_names = [mod[0] for mod in modules]
-    platforms = [mod[1] for mod in modules]
-    platform_names = [mod[2] for mod in modules]
+        return
 
-    # do pre-cleanup
-    try:
-        registry.remove(platforms, platform_names)
-    except ValueError:
-        pass
+    def test_multi_registration(self):
+        """Test registering multiple instruments at once"""
 
-    # make sure instruments are not yet registered
-    ensure_not_in_stored_modules(modules)
-    # create modules
-    create_and_verify_fake_modules(modules)
-    # register all modules at once
-    registry.register(module_names)
-    # verify registration
-    ensure_live_registry_updated(modules)
-    # verify stored update
-    ensure_updated_stored_modules(modules)
-    # verify instantiation
-    verify_platform_name_instantiation(modules)
-    # clean up
-    registry.remove(platforms, platform_names)
-    # ensure things are clean
-    ensure_not_in_stored_modules(modules)
+        # register all modules at once
+        registry.register(self.module_names)
 
-    return
+        # verify instantiation
+        verify_platform_name_instantiation(self.modules)
+        # verify registration
+        ensure_live_registry_updated(self.modules)
+        # verify stored update
+        ensure_updated_stored_modules(self.modules)
+
+        return

--- a/pysat/tests/test_registry.py
+++ b/pysat/tests/test_registry.py
@@ -209,6 +209,33 @@ class TestRegistration():
 
         return
 
+    def test_single_registration_invalid_error(self):
+        """Test registering bad package str"""
+
+        # register packages again, this should error
+        with pytest.raises(Exception):
+            registry.register('made.up.name')
+
+        return
+
+    def test_duplicate_registration_error(self):
+        """Test register error for duplicate package"""
+
+        # register all modules at once
+        registry.register(self.module_names)
+        # verify instantiation
+        verify_platform_name_instantiation(self.modules)
+        # check that global registry was updated
+        ensure_live_registry_updated(self.modules)
+        # verify update
+        ensure_updated_stored_modules(self.modules)
+
+        # register packages again, this should error
+        with pytest.raises(ValueError):
+            registry.register(self.module_names)
+
+        return
+
     def test_array_registration(self):
         """Test registering multiple instruments at once"""
 

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -95,7 +95,7 @@ def register(module_names):
 
     Parameters
     -----------
-    module_names : str or list-like of str
+    module_names : list-like of str
         specify package name and instrument modules
 
     Raises
@@ -152,23 +152,21 @@ def register(module_names):
 
         # second, check that module is itself pysat compatible
         validate = itc.InstTestClass()
-
-        # two options here
-        # first - work with test code as is and create dummy structure
-        # to make things work
+        # work with test code, create dummy structure to make things work
         class Foo(object):
             pass
+        validate.package = Foo()
         # parse string to get package part and instrument module part
         parse = module_name.split('.')
-
-        validate.package = Foo()
-        validate.package.__name__ = '.'.join(parse[:-1])
-        validate.test_modules_standard(parse[-1])
-        validate.test_standard_function_presence(parse[-1])
-
-        # second option, use a small mod to the test method signature
-        validate.test_modules_standard('', inst_module)
-        validate.test_standard_function_presence('', inst_module)
+        # module name without package
+        mod_part = parse[-1]
+        # the package preamble
+        pack_part = parse[:-1]
+        # assign package info to Test class
+        validate.package.__name__ = '.'.join(pack_part)
+        # run tests
+        validate.test_modules_standard(mod_part)
+        validate.test_standard_function_presence(mod_part)
 
         # registry is a dict of dicts
         # platform, name, module string

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -243,20 +243,19 @@ def register_by_module(module):
     return
 
 
-def remove(platforms, names=None):
+def remove(platforms, names):
     """Removes module from registered user modules
 
     Parameters
     ----------
-    platforms : str or list-like of str
-        One or more platform identifiers to remove
-    names : str or list-like of str
+    platforms : list-like of str
+        Platform identifiers to remove
+    names : list-like of str
         Name identifiers, paired with platforms, to remove.
         If the names element paired with the platform element is None,
         then all instruments under the specified platform will be
-        removed. Should be the same type as `platforms`. Supplying None
-        will default to removing all instruments for all specified
-        platforms. (default=None)
+        removed. Should be the same type as `platforms`.
+
     Raises
     ------
     ValueError
@@ -273,29 +272,16 @@ def remove(platforms, names=None):
         names = ['name1', 'name2']
 
         # remove all instruments with platform=='platform1'
-        registry.remove(platforms[0])
+        registry.remove(['platform1'], [None])
         # remove all instruments with platform 'platform1' or 'platform2'
-        registry.remove(platforms)
+        registry.remove(platforms, [None, None])
         # remove all instruments with 'platform1', and individual instrument
         # for 'platform2', 'name2'
         registry.remove(platforms, [None, 'name2']
         # remove 'platform1', 'name1', as well as 'platform2', 'name2'
         registry.remove(platforms, names)
-        # remove 'platform1', 'name1'
-        registry.remove('platform1', 'name1')
 
     """
-
-    # support input of both string and list-like of strings
-    if isinstance(platforms, str):
-        platforms = [platforms]
-    if isinstance(names, str):
-        names = [names]
-
-    # ensure names is as long as platforms under default input
-    # done after we ensure platforms is list-like
-    if names is None:
-        names = [None] * len(platforms)
 
     # ensure equal number of inputs
     if len(names) != len(platforms):

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -136,9 +136,6 @@ def register(module_names):
 
     """
 
-    if isinstance(module_names, str):
-        module_names = [module_names]
-
     for module_name in module_names:
         # first, ensure module string directs to something importable
         try:

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -186,6 +186,7 @@ def register_by_module(module):
         module_names = module.__all__
         # add in package preamble
         module_names = [module.__name__ + '.' + mod for mod in module_names]
+        # register all of them
         register(module_names)
     except Exception as error:
         logger.error(error)

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -117,11 +117,11 @@ def register(module_names):
 
     Module names do not have to follow the pysat platform_name naming
     convection.
-    
+
     Current registered modules bay be found at
     ::
         pysat.user_modules
-        
+
     which is stored as a dict of dicts keyed by platform and name.
 
     Examples

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -137,6 +137,21 @@ def register(module_names):
 
         # second, check that module is itself pysat compatible
         validate = itc.InstTestClass()
+
+        # two options here
+        # first - work with test code as is and create dummy structure
+        # to make things work
+        class Foo(object):
+            pass
+        # parse string to get package part and instrument module part
+        parse = module_name.split('.')
+
+        validate.package = Foo()
+        validate.package.__name__ = '.'.join(parse[:-1])
+        validate.test_modules_standard(parse[-1])
+        validate.test_standard_function_presence(parse[-1])
+
+        # second option, use a small mod to the test method signature
         validate.test_modules_standard('', inst_module)
         validate.test_standard_function_presence('', inst_module)
 

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -39,7 +39,7 @@ import logging
 import os
 
 import pysat
-
+import pysat.tests.instrument_test_class as itc
 logger = logging.getLogger(__name__)
 
 
@@ -136,6 +136,9 @@ def register(module_names):
             raise
 
         # second, check that module is itself pysat compatible
+        validate = itc.InstTestClass()
+        validate.test_modules_standard('', inst_module)
+        validate.test_standard_function_presence('', inst_module)
 
         # registry is a dict of dicts
         # platform, name, module string

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -150,6 +150,7 @@ def register(module_names):
         # second, check that module is itself pysat compatible
         validate = itc.InstTestClass()
         # work with test code, create dummy structure to make things work
+
         class Foo(object):
             pass
         validate.package = Foo()

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -87,24 +87,20 @@ def store():
 
 
 def register(module_names):
-    """Registers a user module by name
+    """Registers a user pysat.Instrument module by name
+
+    Enables instantiation of a third-party Instrument
+    module using
+    ::
+        inst = pysat.Instrument(platform, name)
 
     Parameters
     -----------
     module_names : str or list-like of str
-        specify package name and instrument module
-        examples:
-            my.package.name.my_instrument
-            my.pckage.name.myInstrument
+        specify package name and instrument modules
 
-    Returns
-    --------
-    Updates the user module registry specified in
-    pysat_dir/user_module.txt
-
-
-    Notes
-    ------
+    Note
+    ----
     Modules should be importable using
         from my.package.name import my_instrument
 
@@ -115,14 +111,15 @@ def register(module_names):
     pysat instrument files could result in unexpected consequences.
 
     Examples
-    ---------
-    from pysat import Instrument, user_modules
-    from pysat.utils import registry
+    --------
+    ::
+        from pysat import Instrument, user_modules
+        from pysat.utils import registry
 
-    registry.register('my.package.name.myInstrument')
-    assert 'my.package.name.myInstrument' in user_modules
+        registry.register('my.package.name.myInstrument')
+        assert 'my.package.name.myInstrument' in user_modules
 
-    testInst = Instrument()
+        testInst = Instrument(platform, name)
 
     """
 
@@ -170,14 +167,21 @@ def register(module_names):
 def register_by_module(module):
     """Register all sub-modules attached to input module
 
-    Gets a list of sub-modules by using the __all__ attribute,
-    defined in the module's __init__.py
+    Enables instantiation of a third-party Instrument
+    module using
+    ::
+        inst = pysat.Instrument(platform, name)
 
     Parameters
     ----------
     module : Python module
         Module with one or more pysat.Instrument support modules
         attached as sub-modules to the input `module`
+
+    Note
+    ----
+    Gets a list of sub-modules by using the __all__ attribute,
+    defined in the module's __init__.py
 
     """
 

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -248,22 +248,41 @@ def remove(platforms, names=None):
 
     Parameters
     ----------
-    platforms : str of list-like of str
+    platforms : str or list-like of str
         One or more platform identifiers to remove
-    names : str of list-like of str
+    names : str or list-like of str
         Name identifiers, paired with platforms, to remove.
-        If names is None, then all instruments under
-        `platforms` will be removed. Supports a mixed
-        combination of name labels and None. (default=None)
-
+        If the names element paired with the platform element is None,
+        then all instruments under the specified platform will be
+        removed. Should be the same type as `platforms`. Supplying None
+        will default to removing all instruments for all specified
+        platforms. (default=None)
     Raises
     ------
     ValueError
-        If platform and name are not currently registered
+        If platform and/or name are not currently registered
 
     Note
     ----
     Current registered user modules available at pysat.user_modules
+
+    Examples
+    --------
+    ::
+        platforms = ['platform1', 'platform2']
+        names = ['name1', 'name2']
+
+        # remove all instruments with platform=='platform1'
+        registry.remove(platforms[0])
+        # remove all instruments with platform 'platform1' or 'platform2'
+        registry.remove(platforms)
+        # remove all instruments with 'platform1', and individual instrument
+        # for 'platform2', 'name2'
+        registry.remove(platforms, [None, 'name2']
+        # remove 'platform1', 'name1', as well as 'platform2', 'name2'
+        registry.remove(platforms, names)
+        # remove 'platform1', 'name1'
+        registry.remove('platform1', 'name1')
 
     """
 
@@ -274,8 +293,16 @@ def remove(platforms, names=None):
         names = [names]
 
     # ensure names is as long as platforms under default input
+    # done after we ensure platforms is list-like
     if names is None:
         names = [None] * len(platforms)
+
+    # ensure equal number of inputs
+    if len(names) != len(platforms):
+        estr = "".join(("The number of 'platforms' and 'names' must be the ",
+                        "same, or names must be None, which removes all ",
+                        "instruments under each platform."))
+        raise ValueError(estr)
 
     # iterate over inputs and remove modules
     for platform, name in zip(platforms, names):

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -130,9 +130,11 @@ def register(module_names):
         # first, ensure module string directs to something importable
         try:
             inst_module = importlib.import_module(module_name)
-        except Exception as error:
-            # log error and then preserve trace and propagate error
-            logger.error(error)
+        except Exception:
+            # log then preserve trace and propagate error
+            estr = ' '.join(('There was a problem trying to import',
+                             module_name))
+            logger.error(estr)
             raise
 
         # second, check that module is itself pysat compatible
@@ -204,15 +206,11 @@ def register_by_module(module):
     """
 
     # get a list of all user specified modules attached to module
-    try:
-        module_names = module.__all__
-        # add in package preamble
-        module_names = [module.__name__ + '.' + mod for mod in module_names]
-        # register all of them
-        register(module_names)
-    except Exception as error:
-        logger.error(error)
-        raise
+    module_names = module.__all__
+    # add in package preamble
+    module_names = [module.__name__ + '.' + mod for mod in module_names]
+    # register all of them
+    register(module_names)
 
     return
 

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -200,7 +200,7 @@ def remove(platforms, names=None):
     for platform, name in zip(platforms, names):
 
         # error string if module not registered
-        estr = ''.join((platform, ', ', name, ': not a registered',
+        estr = ''.join((platform, ', ', name, ': not a registered ',
                         'instrument module.'))
 
         if platform in pysat.user_modules:


### PR DESCRIPTION
# Description

Addresses #516 and more

Updates the register package.
 - Changed format of .pysat/user_modules.txt to store packages by platform and name
 - Changed format of pysat.user_modules to be a dict of dicts keyed by platform and name
 - Restricted `pysat_*` instruments to those internal to pysat.instruments
 - Changed use of registry so that only requested module needs to be imported
 - Added support to add multiple packages at once using strings
 - Added support to register an entire instrument package like `pysat.instruments` or `pysatModels.models`
 - Added support to remove all instrument modules from registry by platform name along
 - Added support to remove multiple packages by string platform and name
 - Modified method calls and docstrings
 - Raises error if a module is removed but not registered
 - Raises error if a module is already registered for a given platform and name
 - Expanded unit tests

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Unit tests as well as through review of a pysatSpaceWeather instrument, ACE.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
