### PR TITLE
BUG: Monthly file padding fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-08-12
+## [3.0.0] - 2020-08-28
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed description of tag and sat_id behaviour in testing instruments
   - Added a tutorial for developers of instrument libraries for pysat
   - Added .zenodo.json file, to improve specification of authors in citation
+  - Improved __str__ and __repr__ functions for basic classes
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
   - Improved string handling robustness when writing netCDF4 files in Python 3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Improved string handling robustness when writing netCDF4 files in Python 3
   - Improved pandas 1.1.0 compatibility in tests
   - Fixed coupling of two_digit_year_break keyword to underlying method in methods.general.list_files
+  - Fixed additional file date range for monthly data with gaps
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -58,7 +58,7 @@ class Custom(object):
         out_str = "Custom Functions: {:d} applied\n".format(num_funcs)
         if num_funcs > 0:
             for i, func in enumerate(self._functions):
-                out_str += "    {:d}: {:}\n".format(func.__repr__())
+                out_str += "    {:d}: {:}\n".format(i, func.__repr__())
                 if len(self._args[i]) > 0:
                     out_str += "     : Args={:}\n".format(self._args[i])
                 if len(self._kwargs[i]) > 0:

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -50,6 +50,22 @@ class Custom(object):
         self._args = []
         self._kwargs = []
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        num_funcs = len(self._functions)
+        out_str = "Custom Functions: {:d} applied\n".format(num_funcs)
+        if num_funcs > 0:
+            for i, func in enumerate(self._functions):
+                out_str += "    {:d}: {:}\n".format(func.__repr__())
+                if len(self._args[i]) > 0:
+                    out_str += "     : Args={:}\n".format(self._args[i])
+                if len(self._kwargs[i]) > 0:
+                    out_str += "     : Kwargs={:}\n".format(self._kwargs[i])
+
+        return out_str
+
     def attach(self, function, kind='modify', at_pos='end', args=[],
                kwargs={}):
         """Attach a function to custom processing queue.

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -51,7 +51,8 @@ class Custom(object):
         self._kwargs = []
 
     def __repr__(self):
-        out_str = "Custom({:d} functions applied)".format(len(self._functions))
+        out_str = "Custom -> {:d} functions applied".format(
+            len(self._functions))
         return out_str
 
     def __str__(self):

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -51,7 +51,8 @@ class Custom(object):
         self._kwargs = []
 
     def __repr__(self):
-        return self.__str__()
+        out_str = "Custom({:d} functions applied)".format(len(self._functions))
+        return out_str
 
     def __str__(self):
         num_funcs = len(self._functions)

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -183,13 +183,21 @@ class Files(object):
                 self.refresh()
 
     def __repr__(self):
-        out_str = "".join(["Files(", self._sat.__repr__(), ", manual_org=",
-                           "{:}, directory_format=".format(self.manual_org),
-                           self.directory_format, ", update_files=",
+        # Because the local Instrument object is weakly referenced, it may
+        # not always be accessible
+        try:
+            inst_repr = self._sat.__repr__()
+        except ReferenceError:
+            inst_repr = "Instrument(weakly referenced)"
+
+        out_str = "".join(["Files(", inst_repr, ", manual_org=",
+                           "{:}, directory_format='".format(self.manual_org),
+                           self.directory_format, "', update_files=",
                            "{:}, file_format=".format(self._update_files),
-                           "{:}, write_to_disk".format(self.file_format),
-                           "{:}, ignore_empty_".format(self.write_to_disk),
-                           "files={:})".format(self.ignore_empty_files),
+                           "{:}, ".format(self.file_format.__repr__()),
+                           "write_to_disk={:}, ".format(self.write_to_disk),
+                           "ignore_empty_files=",
+                           "{:})".format(self.ignore_empty_files),
                            " -> {:d} Local files".format(len(self.files))])
 
         return out_str

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -180,6 +180,23 @@ class Files(object):
                 # couldn't find stored info, load file list and then store
                 self.refresh()
 
+    def __repr__(self):
+        return self.__str__()
+
+    def __str__(self):
+        num_files = len(self.files)
+        output_str += 'Local File Statistics\n'
+        output_str += '---------------------\n'
+        output_str += 'Number of files: {:d}\n'.format(num_files)
+
+        if num_files > 0:
+            output_str += 'Date Range: '
+            output_str += self.files.index[0].strftime('%d %B %Y')
+            output_str += ' --- '
+            output_str += self.files.index[-1].strftime('%d %B %Y')
+
+        return output_str
+
     def _filter_empty_files(self):
         """Update the file list (files) with empty files ignored"""
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -114,8 +114,10 @@ class Files(object):
             removed from the stored list of files.
         """
 
-        # pysat.Instrument object
+        # Set the hidden variables
         self._sat = weakref.proxy(sat)
+        self._update_files = update_files
+
         # location of .pysat file
         self.home_path = os.path.join(os.path.expanduser('~'), '.pysat')
         self.start_date = None
@@ -181,7 +183,16 @@ class Files(object):
                 self.refresh()
 
     def __repr__(self):
-        return self.__str__()
+        out_str = "".join(["Files(", self._sat.__repr__(), ", manual_org=",
+                           "{:}, directory_format=".format(self.manual_org),
+                           self.directory_format, ", update_files=",
+                           "{:}, file_format=".format(self._update_files),
+                           "{:}, write_to_disk".format(self.file_format),
+                           "{:}, ignore_empty_".format(self.write_to_disk),
+                           "files={:})".format(self.ignore_empty_files),
+                           " -> {:d} Local files".format(len(self.files))])
+
+        return out_str
 
     def __str__(self):
         num_files = len(self.files)

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -185,7 +185,7 @@ class Files(object):
 
     def __str__(self):
         num_files = len(self.files)
-        output_str += 'Local File Statistics\n'
+        output_str = 'Local File Statistics\n'
         output_str += '---------------------\n'
         output_str += 'Number of files: {:d}\n'.format(num_files)
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1074,7 +1074,7 @@ class Instrument(object):
         output_str += 'Cleaning Level: ' + self.clean_level + '\n'
         output_str += 'Data Padding: ' + self.pad.__repr__() + '\n'
         output_str += 'Keyword Arguments Passed to load(): '
-        output_str += self.kwargs.__repr__() + '\n'
+        output_str += self.kwargs.__str__() + '\n'
         output_str += self.custom.__repr__()
 
         # Print out the orbit settings

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1116,10 +1116,14 @@ class Instrument(object):
             if num_vars <= max_vars:
                 output_str += '\nVariable Names:\n'
                 num = len(self.variables) // 3
+
+                # Print out groups of three variables at a time on one line
                 for i in np.arange(num):
                     output_str += self.variables[3 * i].ljust(30)
                     output_str += self.variables[3 * i + 1].ljust(30)
                     output_str += self.variables[3 * i + 2].ljust(30) + '\n'
+
+                # Print out remaining variables one at a time on one line
                 for i in np.arange(len(self.variables) - 3 * num):
                     output_str += self.variables[i + 3 * num].ljust(30)
                 output_str += '\n'

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1054,16 +1054,19 @@ class Instrument(object):
             self._password_req = False
 
     def __repr__(self):
-        return self.__str__()
-
-    def __str__(self):
-        # Print the Instrument properties
+        # Print the basic Instrument properties
         output_str = 'pysat Instrument object\n'
         output_str += '-----------------------\n'
         output_str += 'Platform: ' + self.platform + '\n'
         output_str += 'Name: ' + self.name + '\n'
         output_str += 'Tag: ' + self.tag + '\n'
         output_str += 'Satellite id: ' + self.sat_id + '\n'
+
+        return output_str
+
+    def __str__(self):
+        # Get the basic Instrument properties
+        output_str = self.__repr__()
 
         # Print out the data processing information
         output_str += '\nData Processing\n'
@@ -1075,11 +1078,9 @@ class Instrument(object):
         output_str += self.custom.__repr__()
 
         # Print out the orbit settings
-        output_str += '\nOrbit Settings' + '\n'
-        output_str += '--------------' + '\n'
-        if self.orbits.orbit_index is None:
-            output_str += 'Orbit properties not set.\n'
-        else:
+        if self.orbits.orbit_index is not None:
+            output_str += '\nOrbit Settings' + '\n'
+            output_str += '--------------' + '\n'
             output_str += 'Orbit Kind: ' + self.orbit_info['kind'] + '\n'
             output_str += 'Orbit Index: ' + self.orbit_info['index'] + '\n'
             output_str += 'Orbit Period: '
@@ -1092,15 +1093,7 @@ class Instrument(object):
                 output_str += 'None\n'
 
         # Print the local file information
-        output_str += '\nLocal File Statistics' + '\n'
-        output_str += '---------------------' + '\n'
-        output_str += 'Number of files: ' + str(len(self.files.files)) + '\n'
-
-        if len(self.files.files) > 0:
-            output_str += 'Date Range: '
-            output_str += self.files.files.index[0].strftime('%d %B %Y')
-            output_str += ' --- '
-            output_str += self.files.files.index[-1].strftime('%d %B %Y')
+        output_str += self.files.__repr__()
 
         # Display loaded data
         output_str += '\n\nLoaded Data Statistics' + '\n'

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1075,7 +1075,7 @@ class Instrument(object):
         output_str += 'Data Padding: ' + self.pad.__repr__() + '\n'
         output_str += 'Keyword Arguments Passed to load(): '
         output_str += self.kwargs.__str__() + '\n'
-        output_str += self.custom.__repr__()
+        output_str += self.custom.__str__()
 
         # Print out the orbit settings
         if self.orbits.orbit_index is not None:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1057,7 +1057,7 @@ class Instrument(object):
                            self.name, "', sat_id='", self.sat_id,
                            "', clean_level='", self.clean_level,
                            "', pad={:}, orbit_info=".format(self.pad),
-                           "{:})".format(self.orbit_info)])
+                           "{:}, **{:})".format(self.orbit_info, self.kwargs)])
 
         return out_str
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1053,9 +1053,12 @@ class Instrument(object):
             # Either flags are not specified, or this combo is not
             self._password_req = False
 
+    def __repr__(self):
+        return self.__str__()
+
     def __str__(self):
 
-        output_str = '\npysat Instrument object\n'
+        output_str = 'pysat Instrument object\n'
         output_str += '-----------------------\n'
         output_str += 'Platform: ' + self.platform + '\n'
         output_str += 'Name: ' + self.name + '\n'
@@ -1103,24 +1106,32 @@ class Instrument(object):
         output_str += '\n\nLoaded Data Statistics' + '\n'
         output_str += '----------------------' + '\n'
         if not self.empty:
+            # Display loaded data
+            num_vars = len(self.variables)
+            max_vars = 6
+
             output_str += 'Date: ' + self.date.strftime('%d %B %Y') + '\n'
             output_str += 'DOY: {:03d}'.format(self.doy) + '\n'
             output_str += 'Time range: '
             output_str += self.index[0].strftime('%d %B %Y %H:%M:%S')
             output_str += ' --- '
             output_str += self.index[-1].strftime('%d %B %Y %H:%M:%S\n')
-            output_str += 'Number of Times: ' + str(len(self.index)) + '\n'
-            output_str += 'Number of variables: ' + str(len(self.variables))
+            output_str += 'Number of Times: {:d}\n'.format(len(self.index))
+            output_str += 'Number of variables: {:d}\n'.format(num_vars)
 
-            output_str += '\n\nVariable Names:' + '\n'
-            num = len(self.variables) // 3
-            for i in np.arange(num):
-                output_str += self.variables[3 * i].ljust(30)
-                output_str += self.variables[3 * i + 1].ljust(30)
-                output_str += self.variables[3 * i + 2].ljust(30) + '\n'
-            for i in np.arange(len(self.variables) - 3 * num):
-                output_str += self.variables[i + 3 * num].ljust(30)
-            output_str += '\n'
+            if num_vars <= max_vars:
+                output_str += '\nVariable Names:' + '\n'
+                num = len(self.variables) // 3
+                for i in np.arange(num):
+                    output_str += self.variables[3 * i].ljust(30)
+                    output_str += self.variables[3 * i + 1].ljust(30)
+                    output_str += self.variables[3 * i + 2].ljust(30) + '\n'
+                for i in np.arange(len(self.variables) - 3 * num):
+                    output_str += self.variables[i + 3 * num].ljust(30)
+                output_str += '\n'
+            else:
+                output_str += "\nSee variable names using "
+                output_str += "print(inst.variables)\n"
         else:
             output_str += 'No loaded data.\n'
         output_str += '\n'

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1057,7 +1057,7 @@ class Instrument(object):
         return self.__str__()
 
     def __str__(self):
-
+        # Print the Instrument properties
         output_str = 'pysat Instrument object\n'
         output_str += '-----------------------\n'
         output_str += 'Platform: ' + self.platform + '\n'
@@ -1065,18 +1065,16 @@ class Instrument(object):
         output_str += 'Tag: ' + self.tag + '\n'
         output_str += 'Satellite id: ' + self.sat_id + '\n'
 
+        # Print out the data processing information
         output_str += '\nData Processing\n'
         output_str += '---------------\n'
         output_str += 'Cleaning Level: ' + self.clean_level + '\n'
         output_str += 'Data Padding: ' + self.pad.__repr__() + '\n'
         output_str += 'Keyword Arguments Passed to load(): '
-        output_str += self.kwargs.__repr__() + '\nCustom Functions : \n'
-        if len(self.custom._functions) > 0:
-            for func in self.custom._functions:
-                output_str += '    ' + func.__repr__() + '\n'
-        else:
-            output_str += '    ' + 'No functions applied.\n'
+        output_str += self.kwargs.__repr__() + '\n'
+        output_str += self.custom.__repr__()
 
+        # Print out the orbit settings
         output_str += '\nOrbit Settings' + '\n'
         output_str += '--------------' + '\n'
         if self.orbits.orbit_index is None:
@@ -1093,6 +1091,7 @@ class Instrument(object):
             else:
                 output_str += 'None\n'
 
+        # Print the local file information
         output_str += '\nLocal File Statistics' + '\n'
         output_str += '---------------------' + '\n'
         output_str += 'Number of files: ' + str(len(self.files.files)) + '\n'
@@ -1103,10 +1102,10 @@ class Instrument(object):
             output_str += ' --- '
             output_str += self.files.files.index[-1].strftime('%d %B %Y')
 
+        # Display loaded data
         output_str += '\n\nLoaded Data Statistics' + '\n'
         output_str += '----------------------' + '\n'
         if not self.empty:
-            # Display loaded data
             num_vars = len(self.variables)
             max_vars = 6
 

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -92,7 +92,7 @@ def list_files(tag=None, sat_id=None, data_path=None, format_str=None,
         out.loc[out.index[-1] + pds.DateOffset(months=1)
                 - pds.DateOffset(days=1)] = out.iloc[-1]
         new_out = out.asfreq('D')
-            
+
         for i, out_month in enumerate(out.index):
             if(out_month.month == emonth.month
                and out_month.year == emonth.year):

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -49,6 +49,38 @@ class TestBasics():
         """
         del self.testInst, self.ncols
 
+    def test_basic_repr(self):
+        """The repr output will match the str output"""
+        output_repr = self.testInst.custom.__repr__()
+        output_str = self.testInst.custom.__str__()
+        assert isinstance(output_repr, str)
+        assert isinstance(output_str, str)
+        assert output_str == output_repr
+
+    def test_basic_str(self):
+        """Check for lines from each decision point in str"""
+        output = self.testInst.custom.__str__()
+        assert isinstance(output, str)
+        # No custom functions
+        assert output.find('0 applied') > 0
+
+    def test_basic_str_w_function(self):
+        """Check for lines from each decision point in str"""
+        def mult_data(inst, mult, dkey="mlt"):
+            out_key = '{:.0f}x{:s}'.format(mult, dkey)
+            inst.data[out_key] = mult * inst.data[dkey]
+            return
+
+        self.testInst.custom.attach(mult_data, 'modify', args=[2.0],
+                                    kwargs={"dkey": "mlt"})
+        output = self.testInst.custom.__str__()
+        assert isinstance(output, str)
+        # No custom functions
+        assert output.find('1 applied') > 0
+        assert output.find('mult_data') > 0
+        assert output.find('Args') > 0
+        assert output.find('Kwargs') > 0
+
     def test_single_modifying_custom_function_error(self):
         """Test for error when custom function loaded as modify returns a value
         """

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -43,26 +43,25 @@ class TestBasics():
                                          clean_level='clean')
         self.testInst.load(2008, 1)
         self.ncols = len(self.testInst.data.columns)
+        self.out = None
 
     def teardown(self):
         """Runs after every method to clean up previous testing.
         """
-        del self.testInst, self.ncols
+        del self.testInst, self.ncols, self.out
 
     def test_basic_repr(self):
         """The repr output will match the str output"""
-        output_repr = self.testInst.custom.__repr__()
-        output_str = self.testInst.custom.__str__()
-        assert isinstance(output_repr, str)
-        assert isinstance(output_str, str)
-        assert output_str == output_repr
+        self.out = self.testInst.custom.__repr__()
+        assert isinstance(self.out, str)
+        assert self.out.find("functions applied") > 0
 
     def test_basic_str(self):
         """Check for lines from each decision point in str"""
-        output = self.testInst.custom.__str__()
-        assert isinstance(output, str)
+        self.out = self.testInst.custom.__str__()
+        assert isinstance(self.out, str)
         # No custom functions
-        assert output.find('0 applied') > 0
+        assert self.out.find('0 applied') > 0
 
     def test_basic_str_w_function(self):
         """Check for lines from each decision point in str"""
@@ -73,13 +72,13 @@ class TestBasics():
 
         self.testInst.custom.attach(mult_data, 'modify', args=[2.0],
                                     kwargs={"dkey": "mlt"})
-        output = self.testInst.custom.__str__()
-        assert isinstance(output, str)
+        self.out = self.testInst.custom.__str__()
+        assert isinstance(self.out, str)
         # No custom functions
-        assert output.find('1 applied') > 0
-        assert output.find('mult_data') > 0
-        assert output.find('Args') > 0
-        assert output.find('Kwargs') > 0
+        assert self.out.find('1 applied') > 0
+        assert self.out.find('mult_data') > 0
+        assert self.out.find('Args') > 0
+        assert self.out.find('Kwargs') > 0
 
     def test_single_modifying_custom_function_error(self):
         """Test for error when custom function loaded as modify returns a value

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -135,6 +135,23 @@ class TestBasics():
         pysat.utils.set_data_dir(self.data_path, store=False)
         del self.testInst
 
+    def test_basic_repr(self):
+        """The repr output will match the str output"""
+        output_repr = self.testInst.files.__repr__()
+        output_str = self.testInst.files.__str__()
+        assert isinstance(output_repr, str)
+        assert isinstance(output_str, str)
+        assert output_str == output_repr
+
+    def test_basic_str(self):
+        """Check for lines from each decision point in str"""
+        output = self.testInst.files.__str__()
+        assert isinstance(output, str)
+        # Test basic file output
+        assert output.find('Number of files') > 0
+        # Test no files
+        assert output.find('Date Range') > 0
+
     def test_parse_delimited_filename(self):
         """Check ability to parse delimited files"""
         # Note: Can be removed if future instrument that uses delimited

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -115,6 +115,8 @@ class TestBasics():
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
+        self.out = ''
+
         # store current pysat directory
         self.data_path = pysat.data_dir
 
@@ -133,24 +135,22 @@ class TestBasics():
         """Runs after every method to clean up previous testing."""
         remove_files(self.testInst)
         pysat.utils.set_data_dir(self.data_path, store=False)
-        del self.testInst
+        del self.testInst, self.out
 
     def test_basic_repr(self):
         """The repr output will match the str output"""
-        output_repr = self.testInst.files.__repr__()
-        output_str = self.testInst.files.__str__()
-        assert isinstance(output_repr, str)
-        assert isinstance(output_str, str)
-        assert output_str == output_repr
+        self.out = self.testInst.files.__repr__()
+        assert isinstance(self.out, str)
+        assert self.out.find("Local files") > 0
 
     def test_basic_str(self):
         """Check for lines from each decision point in str"""
-        output = self.testInst.files.__str__()
-        assert isinstance(output, str)
+        self.out = self.testInst.files.__str__()
+        assert isinstance(self.out, str)
         # Test basic file output
-        assert output.find('Number of files') > 0
+        assert self.out.find('Number of files') > 0
         # Test no files
-        assert output.find('Date Range') > 0
+        assert self.out.find('Date Range') > 0
 
     def test_parse_delimited_filename(self):
         """Check ability to parse delimited files"""

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -29,10 +29,13 @@ class TestBasics():
                                          sat_id='10',
                                          clean_level='clean',
                                          update_files=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
+        self.out = None
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.out, self.ref_time, self.ref_doy
 
     # -------------------------------------------------------------------------
     #
@@ -42,12 +45,11 @@ class TestBasics():
     def test_basic_instrument_load(self):
         """Test if the correct day is being loaded (checking object date and
         data)."""
-        self.testInst.load(2009, 1)
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2009, 1, 1))
-        assert (test_date == self.testInst.date)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_basic_instrument_bad_keyword(self):
         """Checks for error when instantiating with bad load_rtn keywords"""
@@ -59,146 +61,143 @@ class TestBasics():
 
     def test_basic_instrument_load_yr_no_doy(self):
         with pytest.raises(TypeError):
-            self.testInst.load(2009)
+            self.testInst.load(self.ref_time.year)
 
     def test_basic_instrument_load_no_input(self):
         with pytest.raises(TypeError):
             self.testInst.load()
 
     def test_basic_instrument_load_by_file_and_multifile(self):
-        testInst = pysat.Instrument(platform=self.testInst.platform,
+        self.out = pysat.Instrument(platform=self.testInst.platform,
                                     name=self.testInst.name,
                                     sat_id='10',
                                     clean_level='clean',
                                     update_files=True,
                                     multi_file_day=True)
         with pytest.raises(ValueError):
-            testInst.load(fname=testInst.files[0])
+            self.out.load(fname=self.out.files[0])
 
     def test_basic_instrument_load_by_date(self):
-        date = dt.datetime(2009, 1, 1)
-        self.testInst.load(date=date)
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2009, 1, 1))
-        assert (test_date == self.testInst.date)
+        self.testInst.load(date=self.ref_time)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_basic_instrument_load_by_date_with_extra_time(self):
         # put in a date that has more than year, month, day
-        date = dt.datetime(2009, 1, 1, 1, 1, 1)
-        self.testInst.load(date=date)
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2009, 1, 1))
-        assert (test_date == self.testInst.date)
+        self.testInst.load(date=dt.datetime(2009, 1, 1, 1, 1, 1))
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_basic_instrument_load_data(self):
         """Test if the correct day is being loaded (checking down to the sec).
         """
-        self.testInst.load(2009, 1)
-        assert self.testInst.index[0] == dt.datetime(2009, 1, 1, 0, 0, 0)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        assert (self.testInst.index[0] == self.ref_time)
 
     def test_basic_instrument_load_leap_year(self):
         """Test if the correct day is being loaded (Leap-Year)."""
-        self.testInst.load(2008, 366)
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2008, 12, 31))
-        assert (test_date == self.testInst.date)
+        self.ref_time = dt.datetime(2008, 12, 31)
+        self.ref_doy = 366
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_next_load_default(self):
         """Test if first day is loaded by default when first invoking .next.
         """
+        self.ref_time = dt.datetime(2008, 1, 1)
         self.testInst.next()
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert test_date == dt.datetime(2008, 1, 1)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert self.out == self.ref_time
 
     def test_prev_load_default(self):
         """Test if last day is loaded by default when first invoking .prev.
         """
+        self.ref_time = dt.datetime(2010, 12, 31)
         self.testInst.prev()
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert test_date == dt.datetime(2010, 12, 31)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert self.out == self.ref_time
 
     def test_basic_fid_instrument_load(self):
         """Test if first day is loaded by default when first invoking .next.
         """
+        self.ref_time = dt.datetime(2008, 1, 1)
         self.testInst.load(fid=0)
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2008, 1, 1))
-        assert (test_date == self.testInst.date)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_next_fid_load_default(self):
         """Test next day is being loaded (checking object date)."""
+        self.ref_time = dt.datetime(2008, 1, 2)
         self.testInst.load(fid=0)
         self.testInst.next()
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2008, 1, 2))
-        assert (test_date == self.testInst.date)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_prev_fid_load_default(self):
         """Test prev day is loaded when invoking .prev."""
+        self.ref_time = dt.datetime(2008, 1, 3)
         self.testInst.load(fid=3)
         self.testInst.prev()
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2008, 1, 3))
-        assert (test_date == self.testInst.date)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time)
+        assert (self.out == self.testInst.date)
 
     def test_filename_load(self):
         """Test if file is loadable by filename, relative to
         top_data_dir/platform/name/tag"""
-        self.testInst.load(fname='2010-12-31.nofile')
-        assert self.testInst.index[0] == dt.datetime(2010, 12, 31)
+        self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'))
+        assert self.testInst.index[0] == self.ref_time
 
     def test_next_filename_load_default(self):
         """Test next day is being loaded (checking object date)."""
-        self.testInst.load(fname='2010-12-30.nofile')
+        self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'))
         self.testInst.next()
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2010, 12, 31))
-        assert (test_date == self.testInst.date)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time + dt.timedelta(days=1))
+        assert (self.out == self.testInst.date)
 
     def test_prev_filename_load_default(self):
         """Test prev day is loaded when invoking .prev."""
-        self.testInst.load(fname='2009-01-04.nofile')
+        self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'))
         self.testInst.prev()
-        test_date = self.testInst.index[0]
-        test_date = dt.datetime(test_date.year, test_date.month,
-                                test_date.day)
-        assert (test_date == dt.datetime(2009, 1, 3))
-        assert (test_date == self.testInst.date)
+        self.out = self.testInst.index[0]
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        assert (self.out == self.ref_time - dt.timedelta(days=1))
+        assert (self.out == self.testInst.date)
 
     def test_list_files(self):
         files = self.testInst.files.files
         assert isinstance(files, pds.Series)
 
     def test_remote_file_list(self):
-        files = self.testInst.remote_file_list(start=dt.datetime(2009, 1, 1),
-                                               stop=dt.datetime(2009, 1, 31))
-        assert files.index[0] == dt.datetime(2009, 1, 1)
-        assert files.index[-1] == dt.datetime(2009, 1, 31)
+        stop = self.ref_time + dt.timedelta(days=30)
+        self.out = self.testInst.remote_file_list(start=self.ref_time,
+                                                  stop=stop)
+        assert self.out.index[0] == self.ref_time
+        assert self.out.index[-1] == stop
 
     def test_remote_date_range(self):
-        files = self.testInst.remote_date_range(start=dt.datetime(2009, 1, 1),
-                                                stop=dt.datetime(2009, 1, 31))
-        assert len(files) == 2
-        assert files[0] == dt.datetime(2009, 1, 1)
-        assert files[-1] == dt.datetime(2009, 1, 31)
+        stop = self.ref_time + dt.timedelta(days=30)
+        self.out = self.testInst.remote_date_range(start=self.ref_time,
+                                                   stop=stop)
+        assert len(self.out) == 2
+        assert self.out[0] == self.ref_time
+        assert self.out[-1] == stop
 
     def test_download_updated_files(self, caplog):
         with caplog.at_level(logging.INFO, logger='pysat'):
@@ -228,22 +227,25 @@ class TestBasics():
     #
     # -------------------------------------------------------------------------
     def test_today_yesterday_and_tomorrow(self):
-        now = dt.datetime.now()
-        today = dt.datetime(now.year, now.month, now.day)
-        assert today == self.testInst.today()
-        assert today - pds.DateOffset(days=1) == self.testInst.yesterday()
-        assert today + pds.DateOffset(days=1) == self.testInst.tomorrow()
+        self.ref_time = dt.datetime.now()
+        self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
+                               self.ref_time.day)
+        assert self.out == self.testInst.today()
+        assert self.out - pds.DateOffset(days=1) == self.testInst.yesterday()
+        assert self.out + pds.DateOffset(days=1) == self.testInst.tomorrow()
 
     def test_filter_datetime(self):
-        now = dt.datetime.now()
-        today = dt.datetime(now.year, now.month, now.day)
-        assert today == self.testInst._filter_datetime_input(now)
+        self.ref_time = dt.datetime.now()
+        self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
+                               self.ref_time.day)
+        assert self.out == self.testInst._filter_datetime_input(self.ref_time)
 
     def test_filtered_date_attribute(self):
-        now = dt.datetime.now()
-        today = dt.datetime(now.year, now.month, now.day)
-        self.testInst.date = now
-        assert today == self.testInst.date
+        self.ref_time = dt.datetime.now()
+        self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
+                               self.ref_time.day)
+        self.testInst.date = self.ref_time
+        assert self.out == self.testInst.date
 
     # -------------------------------------------------------------------------
     #
@@ -253,10 +255,10 @@ class TestBasics():
 
     def test_concat_data(self):
         # data set #2
-        self.testInst.load(2009, 2)
+        self.testInst.load(self.ref_time.year, self.ref_doy + 1)
         data2 = self.testInst.data
         len2 = len(self.testInst.index)
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         # data set #1
         data1 = self.testInst.data
         len1 = len(self.testInst.index)
@@ -264,8 +266,8 @@ class TestBasics():
         # concat together
         self.testInst.data = self.testInst.concat_data([data1, data2])
         # basic test for concatenation
-        len3 = len(self.testInst.index)
-        assert (len3 == len1 + len2)
+        self.out = len(self.testInst.index)
+        assert (self.out == len1 + len2)
 
         if self.testInst.pandas_format:
             # test concat from above
@@ -276,8 +278,8 @@ class TestBasics():
             self.testInst.data = self.testInst.concat_data([data1, data2],
                                                            sort=True)
             # test for concatenation
-            len3 = len(self.testInst.index)
-            assert (len3 == len1 + len2)
+            self.out = len(self.testInst.index)
+            assert (self.out == len1 + len2)
             assert np.all(self.testInst[0:len1, data1.columns] == data1.values)
             assert np.all(self.testInst[len1:, data2.columns] == data2.values)
         else:
@@ -299,8 +301,8 @@ class TestBasics():
                                                       xarray_epoch_name})
             # test for concatenation
             # Instrument.data must have a 'Epoch' index
-            len3 = len(self.testInst.index)
-            assert (len3 == len1 + len2)
+            self.out = len(self.testInst.index)
+            assert (self.out == len1 + len2)
             assert (self.testInst[0:len1, :]
                     == data1.to_array()[:, :]).all().all()
             assert (self.testInst[len1:, :]
@@ -315,7 +317,7 @@ class TestBasics():
         assert self.testInst.empty
 
     def test_empty_flag_data_not_empty(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert not self.testInst.empty
 
     # -------------------------------------------------------------------------
@@ -327,12 +329,12 @@ class TestBasics():
         # empty Instrument test
         assert isinstance(self.testInst.index, pds.Index)
         # now repeat the same test but with data loaded
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert isinstance(self.testInst.index, pds.Index)
 
     def test_index_return(self):
         # load data
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         # ensure we get the index back
         if self.testInst.pandas_format:
             assert np.all(self.testInst.index == self.testInst.data.index)
@@ -360,26 +362,25 @@ class TestBasics():
     # -------------------------------------------------------------------------
     def test_basic_repr(self):
         """The repr output will match the beginning of the str output"""
-        output_repr = self.testInst.__repr__()
-        output_str = self.testInst.__str__()
-        assert isinstance(output_repr, str)
-        assert output_str.find(output_repr) == 0
+        self.out = self.testInst.__repr__()
+        assert isinstance(self.out, str)
+        assert self.out.find("Instrument(") == 0
 
     def test_basic_str(self):
         """Check for lines from each decision point in repr"""
-        output = self.testInst.__str__()
-        assert isinstance(output, str)
-        assert output.find('pysat Instrument object') == 0
+        self.out = self.testInst.__str__()
+        assert isinstance(self.out, str)
+        assert self.out.find('pysat Instrument object') == 0
         # No custom functions
-        assert output.find('Custom Functions: 0') > 0
+        assert self.out.find('Custom Functions: 0') > 0
         # No orbital info
-        assert output.find('Orbit Settins') < 0
+        assert self.out.find('Orbit Settins') < 0
         # Files exist for test inst
-        assert output.find('Date Range:') > 0
+        assert self.out.find('Date Range:') > 0
         # No loaded data
-        assert output.find('No loaded data') > 0
-        assert output.find('Number of variables') < 0
-        assert output.find('uts') < 0
+        assert self.out.find('No loaded data') > 0
+        assert self.out.find('Number of variables') < 0
+        assert self.out.find('uts') < 0
 
     def test_str_w_orbit(self):
         """Test string output with Orbit data """
@@ -393,52 +394,52 @@ class TestBasics():
                                     update_files=True,
                                     orbit_info=orbit_info)
 
-        output = testInst.__str__()
+        self.out = testInst.__str__()
         # Check that orbit info is passed through
-        assert output.find('Orbit properties not set') < 0
-        assert output.find('Orbit Kind:') > 0
-        assert output.find('Loaded Orbit Number: None') > 0
+        assert self.out.find('Orbit properties not set') < 0
+        assert self.out.find('Orbit Kind:') > 0
+        assert self.out.find('Loaded Orbit Number: None') > 0
         # Activate orbits, check that message has changed
-        testInst.load(2009, 1)
+        testInst.load(self.ref_time.year, self.ref_doy)
         testInst.orbits.next()
-        output = testInst.__str__()
-        assert output.find('Loaded Orbit Number: None') < 0
-        assert output.find('Loaded Orbit Number: ') > 0
+        self.out = testInst.__str__()
+        assert self.out.find('Loaded Orbit Number: None') < 0
+        assert self.out.find('Loaded Orbit Number: ') > 0
 
     def test_str_w_padding(self):
         """Test string output with data padding """
         self.testInst.pad = pds.DateOffset(minutes=5)
-        output = self.testInst.__str__()
-        assert output.find('DateOffset: minutes=5') > 0
+        self.out = self.testInst.__str__()
+        assert self.out.find('DateOffset: minutes=5') > 0
 
     def test_str_w_custom_func(self):
         """Test string output with custom function """
         def testfunc(self):
             pass
         self.testInst.custom.attach(testfunc, 'modify')
-        output = self.testInst.__str__()
-        assert output.find('testfunc') > 0
+        self.out = self.testInst.__str__()
+        assert self.out.find('testfunc') > 0
 
     def test_str_w_load_lots_data(self):
         """Test string output with loaded data """
-        self.testInst.load(2009, 1)
-        output = self.testInst.__str__()
-        assert output.find('Number of variables:') > 0
-        assert output.find('uts') < 0
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        self.out = self.testInst.__str__()
+        assert self.out.find('Number of variables:') > 0
+        assert self.out.find('uts') < 0
 
     def test_str_w_load_less_data(self):
         """Test string output with loaded data """
         # Load the test data
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
 
         # Ensure the desired data variable is present and delete all others
         self.testInst.data = self.testInst.data[['mlt']]
 
         # Test output with one data variable
-        output = self.testInst.__str__()
-        assert output.find('Number of variables:') > 0
-        assert output.find('Variable Names') > 0
-        assert output.find('mlt') > 0
+        self.out = self.testInst.__str__()
+        assert self.out.find('Number of variables:') > 0
+        assert self.out.find('Variable Names') > 0
+        assert self.out.find('mlt') > 0
 
     # -------------------------------------------------------------------------
     #
@@ -455,10 +456,12 @@ class TestBasics():
         with no instrument file but routines are passed.
         """
         import pysat.instruments.pysat_testing as test
-        testInst = pysat.Instrument(inst_module=test, tag='',
+        self.out = pysat.Instrument(inst_module=test, tag='',
                                     clean_level='clean')
-        testInst.load(2009, 32)
-        assert testInst.date == dt.datetime(2009, 2, 1)
+        self.ref_time = dt.datetime(2009, 2, 1)
+        self.ref_doy = 32
+        self.out.load(self.ref_time.year, self.ref_doy)
+        assert self.out.date == self.ref_time
 
     def test_custom_instrument_load_2(self):
         """
@@ -490,50 +493,50 @@ class TestBasics():
     #
     # -------------------------------------------------------------------------
     def test_basic_data_access_by_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst['uts'] == self.testInst.data['uts'])
 
     def test_basic_data_access_by_name_list(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[['uts', 'mlt']]
                       == self.testInst.data[['uts', 'mlt']])
 
     def test_data_access_by_row_slicing_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[0:10, 'uts']
                       == self.testInst.data['uts'].values[0:10])
 
     def test_data_access_by_row_slicing_and_name_slicing(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         result = self.testInst[0:10, :]
         for variable, array in result.items():
             assert len(array) == len(self.testInst.data[variable].values[0:10])
             assert np.all(array == self.testInst.data[variable].values[0:10])
 
     def test_data_access_by_row_slicing_w_ndarray_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[np.arange(0, 10), 'uts']
                       == self.testInst.data['uts'].values[0:10])
 
     def test_data_access_by_row_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[0, 'uts']
                       == self.testInst.data['uts'].values[0])
 
     def test_data_access_by_row_index(self):
-        self.testInst.load(2009, 1)
-        idx = np.arange(10)
-        assert np.all(self.testInst[idx]['uts']
-                      == self.testInst.data['uts'].values[idx])
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        self.out = np.arange(10)
+        assert np.all(self.testInst[self.out]['uts']
+                      == self.testInst.data['uts'].values[self.out])
 
     def test_data_access_by_datetime_and_name(self):
-        self.testInst.load(2009, 1)
-        ind = dt.datetime(2009, 1, 1, 0, 0, 0)
-        assert np.all(self.testInst[ind, 'uts']
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        self.out = dt.datetime(2009, 1, 1, 0, 0, 0)
+        assert np.all(self.testInst[self.out, 'uts']
                       == self.testInst.data['uts'].values[0])
 
     def test_data_access_by_datetime_slicing_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
         offset = pds.DateOffset(seconds=(10 * time_step))
@@ -543,12 +546,12 @@ class TestBasics():
                       == self.testInst.data['uts'].values[0:11])
 
     def test_setting_data_by_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         assert np.all(self.testInst['doubleMLT'] == 2. * self.testInst['mlt'])
 
     def test_setting_series_data_by_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = \
             2. * pds.Series(self.testInst['mlt'].values,
                             index=self.testInst.index)
@@ -558,7 +561,7 @@ class TestBasics():
         assert np.all(np.isnan(self.testInst['blankMLT']))
 
     def test_setting_pandas_dataframe_by_names(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst[['doubleMLT', 'tripleMLT']] = \
             pds.DataFrame({'doubleMLT': 2. * self.testInst['mlt'].values,
                            'tripleMLT': 3. * self.testInst['mlt'].values},
@@ -567,7 +570,7 @@ class TestBasics():
         assert np.all(self.testInst['tripleMLT'] == 3. * self.testInst['mlt'])
 
     def test_setting_data_by_name_single_element(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2.
         assert np.all(self.testInst['doubleMLT'] == 2.)
 
@@ -575,7 +578,7 @@ class TestBasics():
         assert np.all(np.isnan(self.testInst['nanMLT']))
 
     def test_setting_data_by_name_with_meta(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = {'data': 2. * self.testInst['mlt'],
                                       'units': 'hours',
                                       'long_name': 'double trouble'}
@@ -584,18 +587,18 @@ class TestBasics():
         assert self.testInst.meta['doubleMLT'].long_name == 'double trouble'
 
     def test_setting_partial_data(self):
-        self.testInst.load(2009, 1)
-        cloneInst = self.testInst
+        self.testInst.load(self.ref_time.year, self.ref_doy)
+        self.out = self.testInst
         if self.testInst.pandas_format:
             self.testInst[0:3] = 0
-            assert np.all(self.testInst[3:] == cloneInst[3:])
+            assert np.all(self.testInst[3:] == self.out[3:])
             assert np.all(self.testInst[0:3] == 0)
         else:
             # This command does not work for xarray
             assert True
 
     def test_setting_partial_data_by_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[0, 'doubleMLT'] = 0
         assert np.all(self.testInst[1:, 'doubleMLT']
@@ -603,7 +606,7 @@ class TestBasics():
         assert self.testInst[0, 'doubleMLT'] == 0
 
     def test_setting_partial_data_by_integer_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[[0, 1, 2, 3], 'doubleMLT'] = 0
         assert np.all(self.testInst[4:, 'doubleMLT']
@@ -611,7 +614,7 @@ class TestBasics():
         assert np.all(self.testInst[[0, 1, 2, 3], 'doubleMLT'] == 0)
 
     def test_setting_partial_data_by_slice_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[0:10, 'doubleMLT'] = 0
         assert np.all(self.testInst[10:, 'doubleMLT']
@@ -619,7 +622,7 @@ class TestBasics():
         assert np.all(self.testInst[0:10, 'doubleMLT'] == 0)
 
     def test_setting_partial_data_by_index_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[self.testInst.index[0:10], 'doubleMLT'] = 0
         assert np.all(self.testInst[10:, 'doubleMLT']
@@ -627,7 +630,7 @@ class TestBasics():
         assert np.all(self.testInst[0:10, 'doubleMLT'] == 0)
 
     def test_setting_partial_data_by_numpy_array_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[np.array([0, 1, 2, 3]), 'doubleMLT'] = 0
         assert np.all(self.testInst[4:, 'doubleMLT']
@@ -635,7 +638,7 @@ class TestBasics():
         assert np.all(self.testInst[0:4, 'doubleMLT'] == 0)
 
     def test_setting_partial_data_by_datetime_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[dt.datetime(2009, 1, 1, 0, 0, 0), 'doubleMLT'] = 0
         assert np.all(self.testInst[0, 'doubleMLT']
@@ -643,7 +646,7 @@ class TestBasics():
         assert np.all(self.testInst[0, 'doubleMLT'] == 0)
 
     def test_setting_partial_data_by_datetime_slicing_and_name(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
@@ -656,14 +659,14 @@ class TestBasics():
         assert np.all(self.testInst[0:11, 'doubleMLT'] == 0)
 
     def test_modifying_data_inplace(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst['doubleMLT'] += 100
         assert np.all(self.testInst['doubleMLT']
                       == 2. * self.testInst['mlt'] + 100)
 
     def test_getting_all_data_by_index(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         a = self.testInst[[0, 1, 2, 3, 4]]
         if self.testInst.pandas_format:
             assert len(a) == 5
@@ -671,7 +674,7 @@ class TestBasics():
             assert a.sizes[xarray_epoch_name] == 5
 
     def test_getting_all_data_by_numpy_array_of_int(self):
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         a = self.testInst[np.array([0, 1, 2, 3, 4])]
         if self.testInst.pandas_format:
             assert len(a) == 5
@@ -690,7 +693,7 @@ class TestBasics():
                                         {'uts': 'long change with spaces'}])
     def test_basic_variable_renaming(self, values):
         # test single variable
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst.rename(values)
         for key in values:
             # check for new name
@@ -706,7 +709,7 @@ class TestBasics():
                                         {'utS': 'uts'}])
     def test_unknown_variable_error_renaming(self, values):
         # check for error for unknown variable name
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         with pytest.raises(ValueError):
             self.testInst.rename(values)
 
@@ -716,7 +719,7 @@ class TestBasics():
                                         {'uts': 'Long Change with spaces'}])
     def test_basic_variable_renaming_lowercase(self, values):
         # test single variable
-        self.testInst.load(2009, 1)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst.rename(values, lowercase_data_labels=True)
         for key in values:
             # check for new name
@@ -736,7 +739,7 @@ class TestBasics():
         # check for pysat_testing2d instrument
         if self.testInst.platform == 'pysat':
             if self.testInst.name == 'testing2d':
-                self.testInst.load(2009, 1)
+                self.testInst.load(self.ref_time.year, self.ref_doy)
                 self.testInst.rename(values)
                 for key in values:
                     for ikey in values[key]:
@@ -770,7 +773,7 @@ class TestBasics():
         # check for pysat_testing2d instrument
         if self.testInst.platform == 'pysat':
             if self.testInst.name == 'testing2d':
-                self.testInst.load(2009, 1)
+                self.testInst.load(self.ref_time.year, self.ref_doy)
                 # check for error for unknown column or HO variable name
                 with pytest.raises(ValueError):
                     self.testInst.rename(values)
@@ -783,7 +786,7 @@ class TestBasics():
         # check for pysat_testing2d instrument
         if self.testInst.platform == 'pysat':
             if self.testInst.name == 'testing2d':
-                self.testInst.load(2009, 1)
+                self.testInst.load(self.ref_time.year, self.ref_doy)
                 self.testInst.rename(values)
                 for key in values:
                     for ikey in values[key]:
@@ -1092,10 +1095,13 @@ class TestBasicsXarray(TestBasics):
                                          sat_id='10',
                                          clean_level='clean',
                                          update_files=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
+        self.out = None
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.out, self.ref_time, self.ref_doy
 
 
 # -----------------------------------------------------------------------------
@@ -1111,10 +1117,13 @@ class TestBasics2D(TestBasics):
                                          sat_id='50',
                                          clean_level='clean',
                                          update_files=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
+        self.out = None
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.out, self.ref_time, self.ref_doy
 
 
 # -----------------------------------------------------------------------------
@@ -1133,10 +1142,13 @@ class TestBasicsShiftedFileDates(TestBasics):
                                          update_files=True,
                                          mangle_file_dates=True,
                                          strict_time_flag=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
+        self.out = None
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.out, self.ref_time, self.ref_doy
 
 
 # -----------------------------------------------------------------------------
@@ -1154,10 +1166,12 @@ class TestMalformedIndex():
                                          malformed_index=True,
                                          update_files=True,
                                          strict_time_flag=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy
 
     # -------------------------------------------------------------------------
     #
@@ -1166,7 +1180,7 @@ class TestMalformedIndex():
     # -------------------------------------------------------------------------
     def test_ensure_unique_index(self):
         with pytest.raises(ValueError):
-            self.testInst.load(2009, 1)
+            self.testInst.load(self.ref_time.year, self.ref_doy)
 
 
 # -----------------------------------------------------------------------------
@@ -1185,10 +1199,12 @@ class TestMalformedIndexXarray(TestMalformedIndex):
                                          malformed_index=True,
                                          update_files=True,
                                          strict_time_flag=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy
 
 
 # -----------------------------------------------------------------------------
@@ -1210,26 +1226,26 @@ class TestDataPaddingbyFile():
                                         clean_level='clean',
                                         update_files=True)
         self.rawInst.bounds = self.testInst.bounds
+        self.delta = 0
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
-        del self.rawInst
+        del self.testInst, self.rawInst, self.delta
 
     def test_fid_data_padding(self):
         self.testInst.load(fid=1, verifyPad=True)
         self.rawInst.load(fid=1)
-        delta = pds.DateOffset(minutes=5)
-        assert (self.testInst.index[0] == self.rawInst.index[0] - delta)
-        assert (self.testInst.index[-1] == self.rawInst.index[-1] + delta)
+        self.delta = pds.DateOffset(minutes=5)
+        assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
+        assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
     def test_fid_data_padding_next(self):
         self.testInst.load(fid=1, verifyPad=True)
         self.testInst.next(verifyPad=True)
         self.rawInst.load(fid=2)
-        delta = pds.DateOffset(minutes=5)
-        assert (self.testInst.index[0] == self.rawInst.index[0] - delta)
-        assert (self.testInst.index[-1] == self.rawInst.index[-1] + delta)
+        self.delta = pds.DateOffset(minutes=5)
+        assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
+        assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
     def test_fid_data_padding_multi_next(self):
         """This also tests that _prev_data and _next_data cacheing"""
@@ -1237,17 +1253,17 @@ class TestDataPaddingbyFile():
         self.testInst.next()
         self.testInst.next(verifyPad=True)
         self.rawInst.load(fid=3)
-        delta = pds.DateOffset(minutes=5)
-        assert (self.testInst.index[0] == self.rawInst.index[0] - delta)
-        assert (self.testInst.index[-1] == self.rawInst.index[-1] + delta)
+        self.delta = pds.DateOffset(minutes=5)
+        assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
+        assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
     def test_fid_data_padding_prev(self):
         self.testInst.load(fid=2, verifyPad=True)
         self.testInst.prev(verifyPad=True)
         self.rawInst.load(fid=1)
-        delta = pds.DateOffset(minutes=5)
-        assert (self.testInst.index[0] == self.rawInst.index[0] - delta)
-        assert (self.testInst.index[-1] == self.rawInst.index[-1] + delta)
+        self.delta = pds.DateOffset(minutes=5)
+        assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
+        assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
     def test_fid_data_padding_multi_prev(self):
         """This also tests that _prev_data and _next_data cacheing"""
@@ -1255,17 +1271,17 @@ class TestDataPaddingbyFile():
         self.testInst.prev()
         self.testInst.prev(verifyPad=True)
         self.rawInst.load(fid=8)
-        delta = pds.DateOffset(minutes=5)
-        assert (self.testInst.index[0] == self.rawInst.index[0] - delta)
-        assert (self.testInst.index[-1] == self.rawInst.index[-1] + delta)
+        self.delta = pds.DateOffset(minutes=5)
+        assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
+        assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
     def test_fid_data_padding_jump(self):
         self.testInst.load(fid=1, verifyPad=True)
         self.testInst.load(fid=10, verifyPad=True)
         self.rawInst.load(fid=10)
-        delta = pds.DateOffset(minutes=5)
-        assert (self.testInst.index[0] == self.rawInst.index[0] - delta)
-        assert (self.testInst.index[-1] == self.rawInst.index[-1] + delta)
+        self.delta = pds.DateOffset(minutes=5)
+        assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
+        assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
     def test_fid_data_padding_uniqueness(self):
         self.testInst.load(fid=1, verifyPad=True)
@@ -1273,9 +1289,9 @@ class TestDataPaddingbyFile():
 
     def test_fid_data_padding_all_samples_present(self):
         self.testInst.load(fid=1, verifyPad=True)
-        test_index = pds.date_range(self.testInst.index[0],
+        self.delta = pds.date_range(self.testInst.index[0],
                                     self.testInst.index[-1], freq='S')
-        assert (np.all(self.testInst.index == test_index))
+        assert (np.all(self.testInst.index == self.delta))
 
     def test_fid_data_padding_removal(self):
         self.testInst.load(fid=1)
@@ -1306,11 +1322,11 @@ class TestDataPaddingbyFileXarray(TestDataPaddingbyFile):
                                         clean_level='clean',
                                         update_files=True)
         self.rawInst.bounds = self.testInst.bounds
+        self.delta = 0
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
-        del self.rawInst
+        del self.testInst, self.rawInst, self.delta
 
 
 class TestOffsetRightFileDataPaddingBasics(TestDataPaddingbyFile):
@@ -1329,6 +1345,11 @@ class TestOffsetRightFileDataPaddingBasics(TestDataPaddingbyFile):
                                         sim_multi_file_right=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
+        self.delta = 0
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.rawInst, self.delta
 
 
 class TestOffsetRightFileDataPaddingBasicsXarray(TestDataPaddingbyFile):
@@ -1348,6 +1369,11 @@ class TestOffsetRightFileDataPaddingBasicsXarray(TestDataPaddingbyFile):
                                         sim_multi_file_right=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
+        self.delta = 0
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.rawInst, self.delta
 
 
 class TestOffsetLeftFileDataPaddingBasics(TestDataPaddingbyFile):
@@ -1365,6 +1391,11 @@ class TestOffsetLeftFileDataPaddingBasics(TestDataPaddingbyFile):
                                         sim_multi_file_left=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
+        self.delta = 0
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.rawInst, self.delta
 
 
 class TestDataPadding():
@@ -1375,13 +1406,15 @@ class TestDataPadding():
                                          clean_level='clean',
                                          pad={'minutes': 5},
                                          update_files=True)
+        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_doy = 2
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy
 
     def test_data_padding(self):
-        self.testInst.load(2009, 2, verifyPad=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         assert (self.testInst.index[0]
                 == self.testInst.date - pds.DateOffset(minutes=5))
         assert (self.testInst.index[-1] == self.testInst.date
@@ -1393,7 +1426,7 @@ class TestDataPadding():
                                     clean_level='clean',
                                     pad=pds.DateOffset(minutes=5),
                                     update_files=True)
-        testInst.load(2009, 2, verifyPad=True)
+        testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         assert (testInst.index[0] == testInst.date - pds.DateOffset(minutes=5))
         assert (testInst.index[-1] == testInst.date
                 + pds.DateOffset(hours=23, minutes=59, seconds=59)
@@ -1429,7 +1462,7 @@ class TestDataPadding():
         assert True
 
     def test_data_padding_next(self):
-        self.testInst.load(2009, 2, verifyPad=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.testInst.next(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
                 - pds.DateOffset(minutes=5))
@@ -1439,7 +1472,7 @@ class TestDataPadding():
 
     def test_data_padding_multi_next(self):
         """This also tests that _prev_data and _next_data cacheing"""
-        self.testInst.load(2009, 2)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst.next()
         self.testInst.next(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
@@ -1449,7 +1482,7 @@ class TestDataPadding():
                 + pds.DateOffset(minutes=5))
 
     def test_data_padding_prev(self):
-        self.testInst.load(2009, 2, verifyPad=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.testInst.prev(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
                 - pds.DateOffset(minutes=5))
@@ -1459,7 +1492,8 @@ class TestDataPadding():
 
     def test_data_padding_multi_prev(self):
         """This also tests that _prev_data and _next_data cacheing"""
-        self.testInst.load(2009, 10)
+        self.ref_doy = 10
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst.prev()
         self.testInst.prev(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
@@ -1469,8 +1503,9 @@ class TestDataPadding():
                 + pds.DateOffset(minutes=5))
 
     def test_data_padding_jump(self):
-        self.testInst.load(2009, 2, verifyPad=True)
-        self.testInst.load(2009, 11, verifyPad=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy + 10,
+                           verifyPad=True)
         assert (self.testInst.index[0]
                 == self.testInst.date - pds.DateOffset(minutes=5))
         assert (self.testInst.index[-1]
@@ -1479,17 +1514,20 @@ class TestDataPadding():
                 + pds.DateOffset(minutes=5))
 
     def test_data_padding_uniqueness(self):
-        self.testInst.load(2009, 1, verifyPad=True)
+        self.ref_doy = 1
+        self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         assert (self.testInst.index.is_unique)
 
     def test_data_padding_all_samples_present(self):
-        self.testInst.load(2009, 1, verifyPad=True)
+        self.ref_doy = 1
+        self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         test_index = pds.date_range(self.testInst.index[0],
                                     self.testInst.index[-1], freq='S')
         assert (np.all(self.testInst.index == test_index))
 
     def test_data_padding_removal(self):
-        self.testInst.load(2009, 1)
+        self.ref_doy = 1
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert (self.testInst.index[0] == self.testInst.date)
         assert (self.testInst.index[-1] == self.testInst.date
                 + pds.DateOffset(hour=23, minutes=59, seconds=59))
@@ -1504,6 +1542,12 @@ class TestDataPaddingXarray(TestDataPadding):
                                          clean_level='clean',
                                          pad={'minutes': 5},
                                          update_files=True)
+        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_doy = 2
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.ref_time, self.ref_doy
 
 
 class TestMultiFileRightDataPaddingBasics(TestDataPadding):
@@ -1516,10 +1560,12 @@ class TestMultiFileRightDataPaddingBasics(TestDataPadding):
                                          sim_multi_file_right=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
+        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_doy = 2
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy
 
 
 class TestMultiFileRightDataPaddingBasicsXarray(TestDataPadding):
@@ -1533,10 +1579,12 @@ class TestMultiFileRightDataPaddingBasicsXarray(TestDataPadding):
                                          sim_multi_file_right=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
+        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_doy = 2
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy
 
 
 class TestMultiFileLeftDataPaddingBasics(TestDataPadding):
@@ -1550,10 +1598,12 @@ class TestMultiFileLeftDataPaddingBasics(TestDataPadding):
                                          sim_multi_file_left=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
+        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_doy = 2
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy
 
 
 class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
@@ -1567,7 +1617,9 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
                                          sim_multi_file_left=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
+        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_doy = 2
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.testInst
+        del self.testInst, self.ref_time, self.ref_doy

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -432,13 +432,12 @@ class TestBasics():
         self.testInst.load(2009, 1)
 
         # Ensure the desired data variable is present and delete all others
-        self.testInst.data = self.testInst.data[['dummy1', 'mlt']]
+        self.testInst.data = self.testInst.data[['mlt']]
 
         # Test output with one data variable
         output = self.testInst.__str__()
         assert output.find('Number of variables:') > 0
         assert output.find('Variable Names') > 0
-        assert output.find('dummy1') > 0
         assert output.find('mlt') > 0
 
     # -------------------------------------------------------------------------

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -433,13 +433,16 @@ class TestBasics():
         self.testInst.load(self.ref_time.year, self.ref_doy)
 
         # Ensure the desired data variable is present and delete all others
-        self.testInst.data = self.testInst.data[['mlt']]
+        # 4-6 variables are needed to test all lines; choose the lesser limit
+        nvar = 4
+        self.testInst.data = self.testInst.data[self.testInst.variables[:nvar]]
 
         # Test output with one data variable
         self.out = self.testInst.__str__()
-        assert self.out.find('Number of variables:') > 0
+        assert self.out.find('Number of variables: 4') > 0
         assert self.out.find('Variable Names') > 0
-        assert self.out.find('mlt') > 0
+        for n in range(nvar):
+            assert self.out.find(self.testInst.variables[n]) > 0
 
     # -------------------------------------------------------------------------
     #

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -16,11 +16,11 @@ import pysat.instruments.pysat_testing2d
 xarray_epoch_name = 'time'
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Test Instrument object basics
 #
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 class TestBasics():
     def setup(self):
         re_load(pysat.instruments.pysat_testing)
@@ -34,11 +34,11 @@ class TestBasics():
         """Runs after every method to clean up previous testing."""
         del self.testInst
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test basic loads, by date, filename, file id, as well as prev/next
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_basic_instrument_load(self):
         """Test if the correct day is being loaded (checking object date and
         data)."""
@@ -95,8 +95,8 @@ class TestBasics():
         assert (test_date == self.testInst.date)
 
     def test_basic_instrument_load_data(self):
-        """Test if the correct day is being loaded (checking data down to the
-        second)."""
+        """Test if the correct day is being loaded (checking down to the sec).
+        """
         self.testInst.load(2009, 1)
         assert self.testInst.index[0] == dt.datetime(2009, 1, 1, 0, 0, 0)
 
@@ -110,7 +110,8 @@ class TestBasics():
         assert (test_date == self.testInst.date)
 
     def test_next_load_default(self):
-        """Test if first day is loaded by default when first invoking .next."""
+        """Test if first day is loaded by default when first invoking .next.
+        """
         self.testInst.next()
         test_date = self.testInst.index[0]
         test_date = dt.datetime(test_date.year, test_date.month,
@@ -118,7 +119,8 @@ class TestBasics():
         assert test_date == dt.datetime(2008, 1, 1)
 
     def test_prev_load_default(self):
-        """Test if last day is loaded by default when first invoking .prev."""
+        """Test if last day is loaded by default when first invoking .prev.
+        """
         self.testInst.prev()
         test_date = self.testInst.index[0]
         test_date = dt.datetime(test_date.year, test_date.month,
@@ -126,7 +128,8 @@ class TestBasics():
         assert test_date == dt.datetime(2010, 12, 31)
 
     def test_basic_fid_instrument_load(self):
-        """Test if first day is loaded by default when first invoking .next."""
+        """Test if first day is loaded by default when first invoking .next.
+        """
         self.testInst.load(fid=0)
         test_date = self.testInst.index[0]
         test_date = dt.datetime(test_date.year, test_date.month,
@@ -219,11 +222,11 @@ class TestBasics():
         # Update local file list
         assert "Updating pysat file list" in caplog.text
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test date helpers
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_today_yesterday_and_tomorrow(self):
         now = dt.datetime.now()
         today = dt.datetime(now.year, now.month, now.day)
@@ -246,7 +249,7 @@ class TestBasics():
     #
     # Test concat_data method
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     def test_concat_data(self):
         # data set #2
@@ -303,11 +306,11 @@ class TestBasics():
             assert (self.testInst[len1:, :]
                     == data2.to_array()[:, :]).all().all()
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test empty property flags, if True, no data
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_empty_flag_data_empty(self):
         assert self.testInst.empty
 
@@ -315,11 +318,11 @@ class TestBasics():
         self.testInst.load(2009, 1)
         assert not self.testInst.empty
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test index attribute, should always be a datetime index
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_index_attribute(self):
         # empty Instrument test
         assert isinstance(self.testInst.index, pds.Index)
@@ -337,11 +340,11 @@ class TestBasics():
             assert np.all(self.testInst.index
                           == self.testInst.data.indexes[xarray_epoch_name])
 
-    # #--------------------------------------------------------------------------
+    # #------------------------------------------------------------------------
     # #
     # # Test custom attributes
     # #
-    # #--------------------------------------------------------------------------
+    # #------------------------------------------------------------------------
     def test_retrieve_bad_attribute(self):
         with pytest.raises(AttributeError):
             self.testInst.bad_attr
@@ -350,28 +353,36 @@ class TestBasics():
         self.testInst._base_attr
         assert '_base_attr' in dir(self.testInst)
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # test textual representations
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_basic_repr(self):
+        """The repr output will match the beginning of the str output"""
+        output_repr = self.testInst.__repr__()
+        output_str = self.testInst.__str__()
+        assert isinstance(output_repr, str)
+        assert output_str.find(output_repr) == 0
+
+    def test_basic_str(self):
         """Check for lines from each decision point in repr"""
         output = self.testInst.__str__()
         assert isinstance(output, str)
-        assert output.find('pysat Instrument object') > 0
+        assert output.find('pysat Instrument object') == 0
         # No custom functions
-        assert output.find('No functions applied') > 0
+        assert output.find('Custom Functions: 0') > 0
         # No orbital info
-        assert output.find('Orbit properties not set') > 0
+        assert output.find('Orbit Settins') < 0
         # Files exist for test inst
         assert output.find('Date Range:') > 0
         # No loaded data
         assert output.find('No loaded data') > 0
-        assert output.find('Number of variables:') < 0
+        assert output.find('Number of variables') < 0
         assert output.find('uts') < 0
 
-    def test_repr_w_orbit(self):
+    def test_str_w_orbit(self):
+        """Test string output with Orbit data """
         re_load(pysat.instruments.pysat_testing)
         orbit_info = {'index': 'mlt',
                       'kind': 'local time',
@@ -394,30 +405,50 @@ class TestBasics():
         assert output.find('Loaded Orbit Number: None') < 0
         assert output.find('Loaded Orbit Number: ') > 0
 
-    def test_repr_w_padding(self):
+    def test_str_w_padding(self):
+        """Test string output with data padding """
         self.testInst.pad = pds.DateOffset(minutes=5)
         output = self.testInst.__str__()
         assert output.find('DateOffset: minutes=5') > 0
 
-    def test_repr_w_custom_func(self):
+    def test_str_w_custom_func(self):
+        """Test string output with custom function """
         def testfunc(self):
             pass
         self.testInst.custom.attach(testfunc, 'modify')
         output = self.testInst.__str__()
         assert output.find('testfunc') > 0
 
-    def test_repr_w_load_data(self):
+    def test_str_w_load_lots_data(self):
+        """Test string output with loaded data """
         self.testInst.load(2009, 1)
         output = self.testInst.__str__()
-        assert output.find('No loaded data') < 0
         assert output.find('Number of variables:') > 0
+        assert output.find('uts') < 0
+
+    def test_str_w_load_less_data(self):
+        """Test string output with loaded data """
+        # Load the test data
+        self.testInst.load(2009, 1)
+
+        # Ensure the desired data variable is present and delete all others
+        dvars = self.testInst.variables
+        assert 'uts' in dvars
+        for dkey in dvars:
+            if dkey != 'uts':
+                del self.testInst.data[dkey]
+
+        # Test output with one data variable
+        output = self.testInst.__str__()
+        assert output.find('Number of variables:') > 0
+        assert output.find('Variable Names') > 0
         assert output.find('uts') > 0
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # test instrument initialization functions
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_instrument_init(self):
         """Test if init function supplied by instrument can modify object"""
         assert self.testInst.new_thing
@@ -457,11 +488,11 @@ class TestBasics():
             pysat.Instrument(inst_module=test, tag='',
                              clean_level='clean')
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test basic data access features, both getting and setting data
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_basic_data_access_by_name(self):
         self.testInst.load(2009, 1)
         assert np.all(self.testInst['uts'] == self.testInst.data['uts'])
@@ -651,11 +682,11 @@ class TestBasics():
         else:
             assert a.sizes[xarray_epoch_name] == 5
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test variable renaming
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
 
     @pytest.mark.parametrize("values", [{'uts': 'uts1'},
                                         {'uts': 'uts2',
@@ -777,11 +808,11 @@ class TestBasics():
                         check_var = self.testInst.meta[key]['children']
                         assert ikey not in check_var
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test iteration behaviors
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_left_bounds_with_prev(self):
         """Test if passing bounds raises StopIteration."""
         # load first data
@@ -1051,11 +1082,11 @@ class TestBasics():
             _ = pysat.Instrument(inst_module=Dummy)
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Repeat tests above with xarray data
 #
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 class TestBasicsXarray(TestBasics):
     def setup(self):
         re_load(pysat.instruments.pysat_testing_xarray)
@@ -1071,11 +1102,11 @@ class TestBasicsXarray(TestBasics):
         del self.testInst
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Repeat tests above with 2d data
 #
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 class TestBasics2D(TestBasics):
     def setup(self):
         re_load(pysat.instruments.pysat_testing2d)
@@ -1090,11 +1121,11 @@ class TestBasics2D(TestBasics):
         del self.testInst
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Repeat TestBasics above with shifted file dates
 #
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 
 class TestBasicsShiftedFileDates(TestBasics):
     def setup(self):
@@ -1112,13 +1143,11 @@ class TestBasicsShiftedFileDates(TestBasics):
         del self.testInst
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Test Instrument with a non-unique and non-monotonic index
 #
-# ------------------------------------------------------------------------------
-
-
+# -----------------------------------------------------------------------------
 class TestMalformedIndex():
     def setup(self):
         re_load(pysat.instruments.pysat_testing)
@@ -1134,22 +1163,21 @@ class TestMalformedIndex():
         """Runs after every method to clean up previous testing."""
         del self.testInst
 
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     #
     # Test checks on time uniqueness and monotonicity
     #
-    # --------------------------------------------------------------------------
+    # -------------------------------------------------------------------------
     def test_ensure_unique_index(self):
         with pytest.raises(ValueError):
             self.testInst.load(2009, 1)
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Repeat tests above with xarray data
 #
-# ------------------------------------------------------------------------------
-
+# -----------------------------------------------------------------------------
 class TestMalformedIndexXarray(TestMalformedIndex):
     def setup(self):
         re_load(pysat.instruments.pysat_testing_xarray)
@@ -1167,11 +1195,11 @@ class TestMalformedIndexXarray(TestMalformedIndex):
         del self.testInst
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Test data padding, loading by file
 #
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 class TestDataPaddingbyFile():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
@@ -1261,12 +1289,11 @@ class TestDataPaddingbyFile():
         assert len(self.rawInst.data) == len(self.testInst.data)
 
 
-# ------------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 #
 # Repeat tests above with xarray data
 #
-# ------------------------------------------------------------------------------
-
+# -----------------------------------------------------------------------------
 class TestDataPaddingbyFileXarray(TestDataPaddingbyFile):
     def setup(self):
         """Runs before every method to create a clean testing setup."""

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -432,17 +432,14 @@ class TestBasics():
         self.testInst.load(2009, 1)
 
         # Ensure the desired data variable is present and delete all others
-        dvars = self.testInst.variables
-        assert 'uts' in dvars
-        for dkey in dvars:
-            if dkey != 'uts':
-                del self.testInst.data[dkey]
+        self.testInst.data = self.testInst.data[['dummy1', 'mlt']]
 
         # Test output with one data variable
         output = self.testInst.__str__()
         assert output.find('Number of variables:') > 0
         assert output.find('Variable Names') > 0
-        assert output.find('uts') > 0
+        assert output.find('dummy1') > 0
+        assert output.find('mlt') > 0
 
     # -------------------------------------------------------------------------
     #


### PR DESCRIPTION
# Description

Currently, when you have a gap in monthly files the file routine assumes that the last monthly file between two dates lasts for the entire period of time.  The changes introduced here fix that problem.

Partially addresses #58 

Created this branch off of PR #523, so that needs to be merged first.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

My 1 min omni hro data has some gaps in it.  Go check yours out and if it doesn't have a gap, move one file away temporarily to create one.

```
import pysat
out = pysat.instruments.methods.general.list_files('1min', '', '{:s}/omni/hro/1min/'.format(pysat.data_dir), supported_tags = {'': {'1min': 'omni_hro_1min_{year:4d}{month:02d}{day:02d}_v01.cdf'}}, fake_daily_files_from_monthly=True)
print(out)
```

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7

I was unable to add unit tests because it seems that we can't test this routines success yet.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
