### PR TITLE
DOC: update docstrings for 3.0, add new methods to registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added a tutorial for developers of instrument libraries for pysat
   - Added .zenodo.json file, to improve specification of authors in citation
   - Improved __str__ and __repr__ functions for basic classes
+  - Improved docstring readability and consistency
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load
   - Improved string handling robustness when writing netCDF4 files in Python 3

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -78,6 +78,16 @@ Coordinates
 .. automodule:: pysat.utils.coords
    :members:
 
+Files
+^^^^^
+.. automodule:: pysat.utils.files
+  :members:
+
+Registry
+^^^^^^^^^^^
+.. automodule:: pysat.utils.registry
+   :members:
+
 Statistics
 ^^^^^^^^^^
 .. automodule:: pysat.utils.stats

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -5,7 +5,9 @@ class Constellation(object):
     """Manage and analyze data from multiple pysat Instruments.
 
     Created as part of a Spring 2018 UTDesign project.
+
     """
+
     def __init__(self, instruments=None, name=None):
         """
         Constructs a Constellation given a list of instruments or the name of
@@ -23,6 +25,7 @@ class Constellation(object):
         ----
         The name and instruments parameters should not both be set.
         If neither is given, an empty constellation will be created.
+
         """
 
         if instruments and name:
@@ -42,13 +45,17 @@ class Constellation(object):
     def __getitem__(self, *args, **kwargs):
         """
         Look up a member Instrument by index.
+
         """
+
         return self.instruments.__getitem__(*args, **kwargs)
 
     def __str__(self):
         """
         Print names of instruments within constellation.
+
         """
+
         output_str = '\npysat Constellation object:\n'
 
         for instr in self.instruments:
@@ -59,7 +66,9 @@ class Constellation(object):
     def set_bounds(self, start, stop):
         """
         Sets boundaries for all instruments in constellation
+
         """
+
         for instrument in self.instruments:
             instrument.bounds = (start, stop)
 
@@ -82,18 +91,19 @@ class Constellation(object):
                 name of function or function object to be added to queue
 
             kind : {'add, 'modify', 'pass'}
-                add
+                - add
                     Adds data returned from fuction to instrument object.
-                modify
+                - modify
                     pysat instrument object supplied to routine. Any and all
                     changes to object are retained.
-                pass
+                - pass
                     A copy of pysat object is passed to function. No
                     data is accepted from return.
 
             at_pos : string or int
                 insert at position. (default, insert at end).
-            args : extra arguments
+            args
+                extra arguments
 
         Note
         ----
@@ -109,6 +119,7 @@ class Constellation(object):
         - pandas Series, .name required
 
         - (string/list of strings, numpy array/list of arrays)
+
         """
 
         for instrument in self.instruments:
@@ -122,17 +133,18 @@ class Constellation(object):
         reproduced here.)
 
         Parameters
-        ---------
+        ----------
         yr : integer
             Year for desired data
         doy : integer
             day of year
         data : datetime object
             date to load
-        fname : 'string'
+        fname : string
             filename to be loaded
         verifyPad : boolean
             if true, padding data not removed (debug purposes)
+
         """
 
         for instrument in self.instruments:

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -37,8 +37,8 @@ class Custom(object):
 
     Note
     ----
-    User should interact with Custom through pysat.Instrument instance's
-    attribute, instrument.custom
+    User should interact with Custom through `pysat.Instrument` instance's
+    attribute, `instrument.custom`
 
     """
 
@@ -80,13 +80,13 @@ class Custom(object):
         function : string or function object
             name of function or function object to be added to queue
         kind : {'add', 'modify', 'pass}
-            add
+            - add
                 Adds data returned from function to instrument object.
                 A copy of pysat instrument object supplied to routine.
-            modify
+            - modify
                 pysat instrument object supplied to routine. Any and all
                 changes to object are retained.
-            pass
+            - pass
                 A copy of pysat object is passed to function. No
                 data is accepted from return.
             (default='modify')
@@ -275,7 +275,3 @@ class Custom(object):
         self._args = []
         self._kwargs = []
         self._kind = []
-
-#################################################
-# END CUSTOM CLASS ##############################
-#################################################

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -74,7 +74,6 @@ class Files(object):
         # update Files instance.
         vefi.files.refresh()
 
-
     """
 
     def __init__(self, sat, manual_org=False, directory_format=None,
@@ -240,14 +239,15 @@ class Files(object):
         """Attach results of instrument list_files routine to Instrument object
 
         Parameters
-        -----------
+        ----------
         file_info :
             Stored file information
 
         Returns
-        ---------
+        -------
         updates the file list (files), start_date, and stop_date attributes
         of the Files class object.
+
         """
 
         if not files_info.empty:
@@ -331,6 +331,7 @@ class Files(object):
         pandas.Series
             Full path file names are indexed by datetime
             Series is empty if there is no file list to load
+
         """
 
         fname = self.stored_file_name

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -656,6 +656,7 @@ class Instrument(object):
         Examples
         --------
         ..
+
             # standard renaming
             new_names = {'old_name': 'new_name',
                          'old_name2':, 'new_name2'}
@@ -666,6 +667,7 @@ class Instrument(object):
         Note that this rename will be invoked individually for all
         times in the dataset.
         ..
+
             # applies to higher-order datasets
             # that are loaded into pandas
             # general example
@@ -895,8 +897,8 @@ class Instrument(object):
         void
             Instrument.data modified in place.
 
-        Notes
-        -----
+        Note
+        ----
         For pandas, sort=False is passed along to the underlying
         pandas.concat method. If sort is supplied as a keyword, the
         user provided value is used instead.
@@ -2850,8 +2852,8 @@ def _get_supported_keywords(load_func):
         dict of supported keywords and default values
 
 
-    Notes
-    -----
+    Note
+    ----
         If the input is a partial function then the
         list of keywords returned only includes keywords
         that have not already been set as part of

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -78,8 +78,8 @@ class Meta(object):
         String used to label fill value in storage. Defaults to 'fill' per
         netCDF4 standard
 
-    Notes
-    -----
+    Note
+    ----
     Meta object preserves the case of variables and attributes as it first
     receives the data. Subsequent calls to set new metadata with the same
     variable or attribute will use case of first call. Accessing or setting
@@ -105,6 +105,7 @@ class Meta(object):
     Examples
     --------
     ::
+
         # instantiate Meta object, default values for attribute labels are used
         meta = pysat.Meta()
         # set a couple base units
@@ -670,13 +671,14 @@ class Meta(object):
         Examples
         --------
         :
-                @name_label.setter
-                def name_label(self, new_label):
-                    self._label_setter(new_label, self._name_label,
-                                        use_names_default=True)
 
-        Notes
-        -----
+            @name_label.setter
+            def name_label(self, new_label):
+                self._label_setter(new_label, self._name_label,
+                                    use_names_default=True)
+
+        Note
+        ----
         Not intended for end user
 
         """
@@ -847,8 +849,8 @@ class Meta(object):
 
         Case-insensitive check
 
-        Notes
-        -----
+        Note
+        ----
         Does not check higher order meta objects
 
         Parameters
@@ -910,14 +912,15 @@ class Meta(object):
         strict : bool
             if True, ensure there are no duplicate variable names
 
-        Notes
-        -----
+        Note
+        ----
         Uses units and name label of self if other is different
 
         Returns
         -------
         Meta
             Concatenated object
+
         """
 
         mdata = self.copy()

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -20,6 +20,7 @@ def set_data_dir(path=None, store=True):
         valid path to directory pysat uses to look for data
     store : bool
         if True, store data directory for future runs
+
     """
 
     # account for a user prefix in the path, such as ~
@@ -44,32 +45,33 @@ def scale_units(out_unit, in_unit):
     """ Determine the scaling factor between two units
 
     Parameters
-    -------------
+    ----------
     out_unit : str
         Desired unit after scaling
     in_unit : str
         Unit to be scaled
 
     Returns
-    -----------
+    -------
     unit_scale : float
         Scaling factor that will convert from in_units to out_units
 
-    Notes
-    -------
+    Note
+    ----
     Accepted units include degrees ('deg', 'degree', 'degrees'),
     radians ('rad', 'radian', 'radians'),
     hours ('h', 'hr', 'hrs', 'hour', 'hours'), and lengths ('m', 'km', 'cm').
     Can convert between degrees, radians, and hours or different lengths.
 
     Example
-    -----------
+    -------
     ::
-    import numpy as np
-    two_pi = 2.0 * np.pi
-    scale = scale_units("deg", "RAD")
-    two_pi *= scale
-    two_pi # will show 360.0
+
+        import numpy as np
+        two_pi = 2.0 * np.pi
+        scale = scale_units("deg", "RAD")
+        two_pi *= scale
+        two_pi # will show 360.0
 
 
     """
@@ -151,34 +153,36 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
 
     Parameters
     ----------
-    fnames : string or array_like of strings (None)
-        filenames to load
-    strict_meta : boolean (False)
-        check if metadata across fnames is the same
-    file_format : string (None)
+    fnames : string or array_like of strings
+        filenames to load (default=None)
+    strict_meta : boolean
+        check if metadata across fnames is the same (default=False)
+    file_format : string
         file_format keyword passed to netCDF4 routine
         NETCDF3_CLASSIC, NETCDF3_64BIT, NETCDF4_CLASSIC, and NETCDF4
-    epoch_name : string ('Epoch')
-    units_label : string ('units')
-        keyword for unit information
-    name_label : string ('long_name')
-        keyword for informative name label
-    notes_label : string ('notes')
-        keyword for file notes
-    desc_label : string ('desc')
-        keyword for data descriptions
-    plot_label : string ('label')
-        keyword for name to use on plot labels
-    axis_label : string ('axis')
-        keyword for axis labels
-    scale_label : string ('scale')
-        keyword for plot scaling
-    min_label : string ('value_min')
-        keyword for minimum in allowable value range
-    max_label : string ('value_max')
-        keyword for maximum in allowable value range
-    fill_label : string ('fill')
-        keyword for fill values
+        (default=None)
+    epoch_name : string
+        (default='Epoch')
+    units_label : string
+        keyword for unit information (default='units')
+    name_label : string
+        keyword for informative name label (default='long_name')
+    notes_label : string
+        keyword for file notes (default='notes')
+    desc_label : string
+        keyword for data descriptions (default='desc')
+    plot_label : string
+        keyword for name to use on plot labels (default='label')
+    axis_label : string
+        keyword for axis labels (default='axis')
+    scale_label : string
+        keyword for plot scaling (default='scale')
+    min_label : string
+        keyword for minimum in allowable value range (default='value_min')
+    max_label : string
+        keyword for maximum in allowable value range (defualt='value_max')
+    fill_label : string
+        keyword for fill values (default='fill')
 
     Returns
     --------
@@ -186,6 +190,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
         DataFrame output
     mdata : pysat._meta.Meta
         Meta data
+
     """
 
     import copy

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -45,7 +45,7 @@ def update_longitude(inst, lon_name=None, high=180.0, low=-180.0):
     """ Update longitude to the desired range
 
     Parameters
-    ------------
+    ----------
     inst : pysat.Instrument instance
         instrument object to be updated
     lon_name : string
@@ -56,7 +56,7 @@ def update_longitude(inst, lon_name=None, high=180.0, low=-180.0):
         Lowest allowed longitude value (default=-180.0)
 
     Returns
-    ---------
+    -------
     updates instrument data in column 'lon_name'
 
     """
@@ -64,7 +64,7 @@ def update_longitude(inst, lon_name=None, high=180.0, low=-180.0):
     from pysat.utils.coords import adjust_cyclic_data
 
     if lon_name not in inst.data.keys():
-        raise ValueError('uknown longitude variable name')
+        raise ValueError('unknown longitude variable name')
 
     new_lon = adjust_cyclic_data(inst[lon_name], high=high, low=low)
 
@@ -81,7 +81,7 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
     """ Append solar local time to an instrument object
 
     Parameters
-    ------------
+    ----------
     inst : pysat.Instrument instance
         instrument object to be updated
     lon_name : string
@@ -90,7 +90,7 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
         name of the output solar local time data key (default='slt')
 
     Returns
-    ---------
+    -------
     updates instrument data in column specified by slt_name
 
     """

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -18,17 +18,20 @@ example, assume there is an implementation for myInstrument in the
 module my.package.myInstrument with platform and name attributes
 'myplatform' and 'myname'. Such an instrument may be registered with
 ::
+
     registry.register('my.package.myInstrument')
 
 The full module name "my.package.myInstrument" will be
 registered in pysat_dir/user_modules.txt and is also listed in
 ::
+
     pysat.user_modules
 which is stored as a dict of dicts keyed by platform and name.
 
 Once registered, subsequent calls to Instrument may use the platform
 and name string identifiers.
 ::
+
     Instrument('myplatform', 'myname')
 
 """
@@ -52,6 +55,7 @@ def load_saved_modules():
         platform then name
 
     """
+
     saved_modules = {}
     fpath = os.path.join(pysat.pysat_dir, 'user_modules.txt')
     with open(fpath, 'r') as fopen:
@@ -91,10 +95,11 @@ def register(module_names, overwrite=False):
     Enables instantiation of a third-party Instrument
     module using
     ::
+
         inst = pysat.Instrument(platform, name, tag=tag, sat_id=sat_id)
 
     Parameters
-    -----------
+    ----------
     module_names : list-like of str
         specify package name and instrument modules
     overwrite : bool
@@ -117,6 +122,7 @@ def register(module_names, overwrite=False):
     ----
     Modules should be importable using
     ::
+
         from my.package.name import my_instrument
 
     Module names do not have to follow the pysat platform_name naming
@@ -124,6 +130,7 @@ def register(module_names, overwrite=False):
 
     Current registered modules bay be found at
     ::
+
         pysat.user_modules
 
     which is stored as a dict of dicts keyed by platform and name.
@@ -131,6 +138,7 @@ def register(module_names, overwrite=False):
     Examples
     --------
     ::
+
         from pysat import Instrument, user_modules
         from pysat.utils import registry
 
@@ -236,6 +244,7 @@ def register_by_module(module):
     Examples
     --------
     ::
+
         import pysat
         import pysatModels
         pysat.utils.registry.register_by_module(pysatModels.models)
@@ -280,6 +289,7 @@ def remove(platforms, names):
     Examples
     --------
     ::
+
         platforms = ['platform1', 'platform2']
         names = ['name1', 'name2']
 

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -50,14 +50,14 @@ def parse_date(str_yr, str_mo, str_day, str_hr='0', str_min='0', str_sec='0',
         String containing month digits
     str_day : string
         String containing day of month digits
-    str_hr : string ('0')
-        String containing the hour of day
-    str_min : string ('0')
-        String containing the minutes of hour
-    str_sec : string ('0')
-        String containing the seconds of minute
-    century : int (2000)
-        Century, only used if str_yr is a 2-digit year
+    str_hr : string
+        String containing the hour of day (default='0')
+    str_min : string
+        String containing the minutes of hour (default='0')
+    str_sec : string
+        String containing the seconds of minute (default='0')
+    century : int
+        Century, only used if str_yr is a 2-digit year (default=2000)
 
     Returns
     -------
@@ -78,16 +78,16 @@ def calc_freq(index):
 
     Parameters
     ----------
-    index : (array-like)
+    index : array-like
         Datetime list, array, or Index
 
     Returns
     -------
-    freq : (str)
+    freq : str
        Frequency string as described in Pandas Offset Aliases
 
-    Notes
-    -----
+    Note
+    ----
     Calculates the minimum time difference and sets that as the frequency.
 
     To reduce the amount of calculations done, the returned frequency is


### PR DESCRIPTION
# Description

Addresses #486, #528 (partial)

- Finishes the docstring scrub for improved formatting (#486)
- Adds new methods under `utils` to the api documentation (#528)

## Type of change

- This change is a documentation update

# How Has This Been Tested?

```make html``` followed by visual inspection of the api document in a web browser

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
