### PR TITLE
Address Warnings from use of dependent packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,7 +30,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - DeprecationWarning for strict_time_flag only triggered if sloppy data is
     found
   - Remove convenience methods imported from pandas
-  - Changed the default `custom.attatch` input to allow keyword arguement use
+  - Changed the default `custom.attach` input to allow keyword argument use
     when additional function input is required
   - Removed python 2.7 syntax
   - Removed utils.coords.geodetic_to_geocentric

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,16 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - custom.attach replaces custom.add
   - Unit tests are now pytest compatible and use parametrize
   - Added altitudes to test instruments
-  - New flags added to instruments to streamline unit testing: `_test_download`, `_test_download_travis`, `_password_req`
-  - Madrigal instruments migrated to pysatMadrigal
+  - New flags added to instruments to streamline unit testing:
+    `_test_download`, `_test_download_travis`, `_password_req`
   - methods.nasa_cdaweb.list_files moved to methods.general
   - `strict_time_flag` now defaults to True
   - Use of start / stop notation in remote_file_list
   - Added variable rename method to Instrument object (#91)
   - Migrated file methods to pysat.utils.files (#336)
 - Deprecations
+  - Migraged instruments to pysatMadrigal, pysatNASA, pysatSpaceWeather,
+    pysatIncubator, pysatModels, pysatCDAAC, and pysatMissions
   - Removed ssnl
   - Removed utils.stats
   - Removed model_utils
@@ -25,9 +27,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - import DataFrame and Series directly from pandas, not pysat
   - Removed coords.scale_units
   - Removed time.season_date_range
-  - DeprecationWarning for strict_time_flag only triggered if sloppy data is found
+  - DeprecationWarning for strict_time_flag only triggered if sloppy data is
+    found
   - Remove convenience methods imported from pandas
-  - Changed the default `custom.attatch` input to allow keyword arguement use when additional function input is required
+  - Changed the default `custom.attatch` input to allow keyword arguement use
+    when additional function input is required
   - Removed python 2.7 syntax
   - Removed utils.coords.geodetic_to_geocentric
   - Removed utils.coords.geodetic_to_geocentric_horizontal
@@ -35,6 +39,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed utils.coords.global_to_local_cartesian
   - Removed utils.coords.local_horizontal_to_global_geo
   - Deprecation Warnings for methods in `pysat._files`
+  - Addressed several Warnings raised by incorrect use of dependent packages
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and sat_id behaviour in testing instruments
@@ -47,7 +52,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed custom instrument attribute persistence upon load
   - Improved string handling robustness when writing netCDF4 files in Python 3
   - Improved pandas 1.1.0 compatibility in tests
-  - Fixed coupling of two_digit_year_break keyword to underlying method in methods.general.list_files
+  - Fixed coupling of two_digit_year_break keyword to underlying method in
+    methods.general.list_files
   - Fixed additional file date range for monthly data with gaps
 - Maintenance
   - nose dependency removed from unit tests
@@ -55,9 +61,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Remove wildcard imports, relative imports
   - Include flake8 check as part of testing suites
   - Improve unit testing coverage of instrument functions and instrument object
-    - Add tests for acknowledgements and references
-  - Removed implicit conversion to integers in methods.general.convert_timestamp_to_datetime
-  - Removed instruments (migrated to new libraries)
+  - Add tests for acknowledgements and references
+  - Removed implicit conversion to integers in
+    methods.general.convert_timestamp_to_datetime
 
 ## [2.2.1] - 2020-07-29
 - Documentation

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -484,6 +484,14 @@ class Instrument(object):
     def __setitem__(self, key, new):
         """Convenience method for adding data to instrument.
 
+        Parameters
+        ----------
+        key : str, tuple, dict
+            String label, or dict or tuple of indices for new data
+        new : dict, pandas.DataFrame, or xarray.Dataset
+            New data as a dict (assigned with key 'data'), DataFrame, or
+            Dataset
+
         Examples
         --------
         ::
@@ -511,6 +519,8 @@ class Instrument(object):
             if isinstance(key, tuple):
                 try:
                     # Pass directly through to loc
+                    # This line raises a FutureWarning, but will be caught
+                    # by TypeError, so may not be an issue
                     self.data.loc[key[0], key[1]] = new
                 except (KeyError, TypeError):
                     # TypeError for single integer

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -757,13 +757,17 @@ class Meta(object):
                 # get case preserved string for variable name
                 new_key = self.var_case_name(key)
 
-                # don't need to check if in lower, all variables
-                # are always in the lower metadata
-                meta_row = self.data.loc[new_key]
+                # Don't need to check if in lower, all variables are always in
+                # the lower metadata.
+                #
+                # Assign meta_row using copy to avoid pandas
+                # SettingWithCopyWarning, as suggested in
+                # https://www.dataquest.io/blog/settingwithcopywarning/
+                meta_row = self.data.loc[new_key].copy()
                 if new_key in self.keys_nD():
                     meta_row.at['children'] = self.ho_data[new_key].copy()
                 else:
-                    # Following line issues a pandas SettingWithCopyWarning
+
                     meta_row.at['children'] = None  # empty_meta
 
                 return meta_row

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -230,11 +230,12 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
                 # build up dictionary with all global ncattrs
                 # and add those attributes to a pysat meta object
                 ncattrsList = data.ncattrs()
-                for d in ncattrsList:
-                    if hasattr(mdata, d):
-                        mdata.__setattr__(d + '_', data.getncattr(d))
+                for ncattr in ncattrsList:
+                    if hasattr(mdata, ncattr):
+                        mdata.__setattr__('{:}_'.format(ncattr),
+                                          data.getncattr(ncattr))
                     else:
-                        mdata.__setattr__(d, data.getncattr(d))
+                        mdata.__setattr__(ncattr, data.getncattr(ncattr))
 
                 loadedVars = {}
                 for key in data.variables.keys():


### PR DESCRIPTION
# Description

This PR reduces the number of warnings raised from 1808 to 1749 and Addresses #546 

Please pay special attention to the changes in the documentation (files, inline comments, and docstrings) to ensure they are clear and make sense.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Formerly, this raised a pandas Warning, and now it won't
```
import pysat
inst = pysat.Instrument("pysat", "testing", clean_level="clean")
inst.load(2009, 1)
inst['new_data'] = inst['mlt']
inst['hi'] = inst['mlt']
inst.meta['hi'] = inst.meta['new_data']
```

Also, running the unit tests will show the reduction in Warnings.

**Test Configuration**:
* Operating system: OSX Mojave
* Version number: 3.7
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
