### PR TITLE
Clearer error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
   - custom.attach replaces custom.add
-  - Unit tests are now pytest compatible and use parametrize
+  - Unit tests are now pytest compatible, use parametrize, and have improved
+    messages when failures are encountered
   - Added altitudes to test instruments
   - New flags added to instruments to streamline unit testing:
     `_test_download`, `_test_download_travis`, `_password_req`

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -55,14 +55,14 @@ class InstTestClass():
                   'inst_ids': dict, 'tag': str, 'inst_id': str,
                   'acknowledgements': str, 'references': str}
 
-    def assert_hasattr(obj, attr_name):
+    def assert_hasattr(self, obj, attr_name):
         """ Nice assertion statement for `assert hasattr(obj, attr_name)`
         """
         estr = "Object {:} missing attribute {:}".format(obj.__repr__(),
                                                          attr_name)
         assert hasattr(obj, attr_name), estr
 
-    def assert_isinstance(obj, obj_type):
+    def assert_isinstance(self, obj, obj_type):
         """ Nice assertion statement for `assert isinstance(obj, obj_type)`
         """
         estr = "Object {:} is type {:}, but should be type {:}".format(

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -55,6 +55,20 @@ class InstTestClass():
                   'inst_ids': dict, 'tag': str, 'inst_id': str,
                   'acknowledgements': str, 'references': str}
 
+    def assert_hasattr(obj, attr_name):
+        """ Nice assertion statement for `assert hasattr(obj, attr_name)`
+        """
+        estr = "Object {:} missing attribute {:}".format(obj.__repr__(),
+                                                         attr_name)
+        assert hasattr(obj, attr_name), estr
+
+    def assert_isinstance(obj, obj_type):
+        """ Nice assertion statement for `assert isinstance(obj, obj_type)`
+        """
+        estr = "Object {:} is type {:}, but should be type {:}".format(
+            obj.__repr__(), type(obj), obj_type)
+        assert isinstance(obj, obj_type), estr
+
     @pytest.mark.all_inst
     def test_modules_standard(self, inst_name):
         """Checks that modules are importable and have standard properties.
@@ -64,10 +78,10 @@ class InstTestClass():
                                package=self.inst_loc.__name__)
         # Check for presence of basic instrument module attributes
         for mattr in self.module_attrs:
-            assert hasattr(module, mattr)
+            self.assert_hasattr(module, mattr)
             if mattr in self.attr_types.keys():
-                assert isinstance(getattr(module, mattr),
-                                  self.attr_types[mattr])
+                self.assert_isinstance(getattr(module, mattr),
+                                       self.attr_types[mattr])
 
         # Check for presence of required instrument attributes
         for inst_id in module.inst_ids.keys():
@@ -76,7 +90,7 @@ class InstTestClass():
                                         inst_id=inst_id)
 
                 # Test to see that the class parameters were passed in
-                assert isinstance(inst, pysat.Instrument)
+                self.assert_isinstance(inst, pysat.Instrument)
                 assert inst.platform == module.platform
                 assert inst.name == module.name
                 assert inst.inst_id == inst_id
@@ -84,10 +98,9 @@ class InstTestClass():
 
                 # Test the required class attributes
                 for iattr in self.inst_attrs:
-                    assert hasattr(inst, iattr), \
-                        "Instrument missing {:}".format(iattr)
-                    assert isinstance(getattr(inst, iattr),
-                                      self.attr_types[iattr])
+                    self.assert_hasattr(inst, iattr)
+                    self.assert_isinstance(getattr(inst, iattr),
+                                           self.attr_types[iattr])
 
     @pytest.mark.all_inst
     def test_standard_function_presence(self, inst_name):
@@ -113,7 +126,7 @@ class InstTestClass():
         info = module._test_dates
         for inst_id in info.keys():
             for tag in info[inst_id].keys():
-                assert isinstance(info[inst_id][tag], dt.datetime)
+                self.assert_isinstance(info[inst_id][tag], dt.datetime)
 
     @pytest.mark.first
     @pytest.mark.download


### PR DESCRIPTION
# Description

The inspection from `assert` statements are not always informative.  This has proved problematic when trying to figure out what's going on (see, for example, Issue #550).

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- Ran unit tests locally
- Registration of instrument module with old attribute (sat_id) on current pysat branch.  Previously, this would fail thusly:

```
     65         # Check for presence of basic instrument module attributes
     66         for mattr in self.module_attrs:
---> 67             assert hasattr(module, mattr)
     68             if mattr in self.attr_types.keys():
     69                 assert isinstance(getattr(module, mattr),

AssertionError: 

```

Now, there will be a message that tells you `inst_ids` is missing.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7
* Any details about your local setup that are relevant: pysat on develop-3, not all dependent modules updated to current state for testing purposes.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
