### PR TITLE
STY: python 2.7 cleanup

### DIFF
--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -36,12 +36,9 @@ Main Features
 
 """
 
-# -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import absolute_import
+import logging
 import os
 
-import logging
 logger = logging.getLogger(__name__)
 handler = logging.StreamHandler()
 formatter = logging.Formatter('%(name)s %(levelname)s: %(message)s')

--- a/pysat/_custom.py
+++ b/pysat/_custom.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 import numpy as np
 import pandas as pds
 import xarray as xr

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1,7 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import absolute_import
-
 import copy
 import datetime as dt
 import errno

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1,6 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 from copy import deepcopy as deepcopy
 import os
 import warnings

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -1,10 +1,8 @@
-from __future__ import print_function
-from __future__ import absolute_import
-
 import functools
-
 import numpy as np
+
 import pandas as pds
+
 from pysat import logger
 
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -43,10 +43,6 @@ Author name and institution
 
 """
 
-# python 2/3 comptability
-from __future__ import print_function
-from __future__ import absolute_import
-
 import datetime as dt
 import logging
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -15,7 +15,7 @@ import pysat
 import pysat.instruments.pysat_testing
 from pysat.utils import files as futils
 
-from importlib import reload as re_load
+from importlib import reload
 
 
 def create_dir(inst=None, temporary_file_list=False):
@@ -97,12 +97,12 @@ class TestNoDataDir():
         self.saved_data_path = pysat.data_dir
 
         pysat.data_dir = ''
-        re_load(pysat._files)
+        reload(pysat._files)
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         pysat.data_dir = self.saved_data_path
-        re_load(pysat._files)
+        reload(pysat._files)
 
     def test_no_data_dir(self):
         with pytest.raises(Exception):
@@ -336,7 +336,7 @@ class TestBasics():
         pysat.instruments.pysat_testing.list_files = list_files
         inst = pysat.Instrument(platform='pysat', name='testing',
                                 update_files=True)
-        re_load(pysat.instruments.pysat_testing)
+        reload(pysat.instruments.pysat_testing)
         assert(inst.files.files.empty)
 
     def test_instrument_has_files(self):
@@ -355,7 +355,7 @@ class TestBasics():
         pysat.instruments.pysat_testing.list_files = list_files
         inst = pysat.Instrument(platform='pysat', name='testing',
                                 update_files=True)
-        re_load(pysat.instruments.pysat_testing)
+        reload(pysat.instruments.pysat_testing)
         assert (np.all(inst.files.files.index == dates))
 
 
@@ -380,7 +380,7 @@ class TestInstrumentWithFiles():
 
         # create a test instrument, make sure it is getting files from
         # filesystem
-        re_load(pysat.instruments.pysat_testing)
+        reload(pysat.instruments.pysat_testing)
         pysat.instruments.pysat_testing.list_files = list_files
         # create a bunch of files by year and doy
         self.testInst = \
@@ -407,8 +407,8 @@ class TestInstrumentWithFiles():
         """Runs after every method to clean up previous testing."""
         remove_files(self.testInst)
         del self.testInst
-        re_load(pysat.instruments.pysat_testing)
-        re_load(pysat.instruments)
+        reload(pysat.instruments.pysat_testing)
+        reload(pysat.instruments)
         # make sure everything about instrument state is restored
         # restore original file list, no files
         pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
@@ -728,7 +728,7 @@ class TestInstrumentWithVersionedFiles():
 
         # create a test instrument, make sure it is getting files from
         # filesystem
-        re_load(pysat.instruments.pysat_testing)
+        reload(pysat.instruments.pysat_testing)
         pysat.instruments.pysat_testing.list_files = list_versioned_files
         # create a bunch of files by year and doy
         self.testInst = \
@@ -755,8 +755,8 @@ class TestInstrumentWithVersionedFiles():
         """Runs after every method to clean up previous testing."""
         remove_files(self.testInst)
         del self.testInst
-        re_load(pysat.instruments.pysat_testing)
-        re_load(pysat.instruments)
+        reload(pysat.instruments.pysat_testing)
+        reload(pysat.instruments)
         # make sure everything about instrument state is restored
         # restore original file list, no files
         pysat.Instrument(inst_module=pysat.instruments.pysat_testing,

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -1,7 +1,7 @@
 """
 tests the pysat utils area
 """
-from importlib import reload as re_load
+from importlib import reload
 import numpy as np
 import os
 import shutil
@@ -53,9 +53,9 @@ class TestBasics():
         check1 = (pysat.data_dir == '.')
 
         # Check if next load of pysat remembers the change
-        pysat._files = re_load(pysat._files)
-        pysat._instrument = re_load(pysat._instrument)
-        re_load(pysat)
+        pysat._files = reload(pysat._files)
+        pysat._instrument = reload(pysat._instrument)
+        reload(pysat)
         check2 = (pysat.data_dir == '.')
 
         assert check1 & check2
@@ -66,9 +66,9 @@ class TestBasics():
         assert (pysat.data_dir == '.')
 
         # Check if next load of pysat remembers old settings
-        pysat._files = re_load(pysat._files)
-        pysat._instrument = re_load(pysat._instrument)
-        re_load(pysat)
+        pysat._files = reload(pysat._files)
+        pysat._instrument = reload(pysat._instrument)
+        reload(pysat)
         assert (pysat.data_dir == self.data_path)
 
     def test_set_data_dir_wrong_path(self):
@@ -106,7 +106,7 @@ class TestCIonly():
         new_root = os.path.join(os.getenv('HOME'), '.saved_pysat')
         shutil.move(root, new_root)
 
-        re_load(pysat)
+        reload(pysat)
 
         captured = capsys.readouterr()
         assert captured.out.find("Hi there!") >= 0


### PR DESCRIPTION
# Description

Addresses #564

- Removes python 2.7 syntax (__future__ )
- Removes nickname for `importlib.reload` (left over from 2.7 compatibility days)
- Consistency in import order

## Type of change

Please delete options that are not relevant.

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via pytest of the changed files locally.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
