### PR TITLE
Improve Instrument input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Use of start / stop notation in remote_file_list
   - Added variable rename method to Instrument object (#91)
   - Migrated file methods to pysat.utils.files (#336)
+  - Allow the Instrument object to be initialized with optional kwargs for any
+    of the standard methods (not just load).
 - Deprecations
   - Migraged instruments to pysatMadrigal, pysatNASA, pysatSpaceWeather,
     pysatIncubator, pysatModels, pysatCDAAC, and pysatMissions
@@ -57,6 +59,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed coupling of two_digit_year_break keyword to underlying method in
     methods.general.list_files
   - Fixed additional file date range for monthly data with gaps
+  - Removed unused input arguments
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/docs/tutorial_basics.rst
+++ b/docs/tutorial_basics.rst
@@ -69,7 +69,7 @@ Further, the dictionary::
 is keyed by ``tag`` with a description of each type of data
 the ``tag`` parameter selects. The dictionary::
 
-    pysatMadrigall.instruments.dmsp_ivm.inst_ids
+    pysatMadrigal.instruments.dmsp_ivm.inst_ids
 
 indicates which instrument or satellite ids (``inst_id``) support which tag.
 The combination of ``tag`` and ``inst_id`` select the particular dataset

--- a/docs/tutorial_basics.rst
+++ b/docs/tutorial_basics.rst
@@ -1,5 +1,5 @@
 Basics
-------
+======
 
 The core functionality of pysat is exposed through the pysat.Instrument object.
 The intent of the Instrument object is to offer a single interface for
@@ -24,9 +24,8 @@ upon the first import,
 .. note:: A data directory must be set before any pysat.Instruments may be used
    or an error will be raised.
 
-**Basic Instrument Discovery**
-
-----
+Basic Instrument Discovery
+--------------------------
 
 Support for each instrument in pysat is enabled by a suite of methods that
 interact with the particular files for that dataset and supply the data within
@@ -53,71 +52,95 @@ is available via help,
 
 Each instrument listed will support one or more data sets for analysis. The
 submodules are named with the convention platform_name. To get
-a description of an instrument, along with the supported datasets, use help
-again,
+a description of an instrument from a pysat package, you can use a searching
+function.  This example uses the ``pysatMadrigal`` package.
 
 .. code:: python
 
-   help(pysat.instruments.dmsp_ivm)
+   import pysatMadrigal as pysatMad
+   mad_inst = pysat.utils.generate_instrument_list(pysatMad.instruments)
+   print(mad_inst['names'])
+
 
 Further, the dictionary::
 
-    pysat.instruments.dmsp_ivm.tags
+    pysatMadrigal.instruments.dmsp_ivm.tags
 
 is keyed by ``tag`` with a description of each type of data
 the ``tag`` parameter selects. The dictionary::
 
-    pysat.instruments.dmsp_ivm.inst_ids
+    pysatMadrigall.instruments.dmsp_ivm.inst_ids
 
 indicates which instrument or satellite ids (``inst_id``) support which tag.
 The combination of ``tag`` and ``inst_id`` select the particular dataset
 a pysat.Instrument object will provide and interact with.
 
 
-**Instantiation**
+Instantiation
+-------------
 
-----
+To create a pysat.Instrument object, select a ``platform`` and instrument
+``name`` or an ``inst_module`` along side (potentially) a ``tag`` and
+``inst_id``, consistent with the desired data from a supported instrument.
 
-To create a pysat.Instrument object, select a ``platform``, instrument ``name``,
-and potentially a ``tag`` and ``inst_id``, consistent with
-the desired data to be analyzed, from one the supported instruments.
+To work with plasma velocity data from the Ion Velocity Meter (IVM) onboard the
+Defense Meteorological Satellite Program (DMSP) constellation (specifically, the
+F12 spacecraft), use:
 
-To work with plasma data from the
-Ion Velocity Meter (IVM) onboard the Defense Meteorological
-Satellite Program (DMSP) constellation, use:
+.. code:: python
+
+   import pysatMadrigal as pysatMad
+   dmsp = pysat.Instrument(inst_module=pysatMad.instruments.dmsp_ivm, tag='utd', inst_id='f12')
+
+Behind the scenes pysat uses a python module named dmsp_ivm that understands
+how to interact with 'utd' data for 'f12'.
+
+If you have previously registered the instruments in ``pysatMadrigal``, you
+can specify the desired Instrument using the ``platform`` and ``name`` keywords.
 
 .. code:: python
 
    dmsp = pysat.Instrument(platform='dmsp', name='ivm', tag='utd', inst_id='f12')
 
-Behind the scenes pysat uses a python module named dmsp_ivm that understands
-how to interact with 'utd' data for 'f12'.
-
-
-**Download**
-
-----
-
-Let's download some data. DMSP data is hosted by the `Madrigal database
+You can also specify the specific keyword arguements needed for the standard
+``pysat`` methods.  DMSP data is hosted by the `Madrigal database
 <http://cedar.openmadrigal.org/openmadrigal/>`_, a community resource for
 geospace data. The proper process for downloading DMSP and other Madrigal data
 is built into the open source
-tool `madrigalWeb <http://cedar.openmadrigal.org/docs/name/rr_python.html>`_, which
-is invoked appropriately by pysat within the dmsp_ivm module. To get DMSP
-data specifically all we have to do is invoke the ``.download()`` method
-attached to the DMSP object. Madrigal requires that users provide their name
-and email address as their username and password.
+tool `madrigalWeb <http://cedar.openmadrigal.org/docs/name/rr_python.html>`_,
+which is invoked appropriately by ``pysat`` within the
+``pysatMadrigal.instruments.dmsp_ivm`` sub-module. Madrigal requires that users
+provide their name and email address as their username and password.
 
 .. code:: python
 
    # set user and password for Madrigal
-   user = 'Firstname+Lastname'
+   username = 'Firstname+Lastname'
    password = 'email@address.com'
+
+   # Initalize the instrument, passing the username and password to the
+   # standard routines that need it
+   dmsp = pysat.Instrument(platform='dmsp', name='ivm', tag='utd', inst_id='f12', user=username, password=password)
+
+Download
+--------
+
+Let's download some data. To get DMSP data specifically all we have to do is
+invoke the ``.download()`` method attached to the DMSP object. If the username
+and password have't been provided to the instrument already, be sure to
+include them here.
+
+.. code:: python
+
+
+   import datetime as dt
+
    # define date range to download data
    start = dt.datetime(2001, 1, 1)
    stop = dt.datetime(2001, 1, 2)
-   # download data to local system
-   dmsp.download(start, stop, user=user, password=password)
+   
+   # download data, assuming username and password were not set
+   dmsp.download(start, stop, user=username, password=password)
 
 The data is downloaded to pysat_data_dir/platform/name/tag/, in this case
 pysat_data_dir/dmsp/ivm/utd/. At the end of the download, pysat
@@ -131,16 +154,15 @@ the local system is fully up to date compared to the data source. The command,
     dmsp.download_updated_files()
 
 will obtain the full set of files present on the server and compare the
-version and revision numbers for the server files with those on the local system.
-Any files missing or out of date on the local system are downloaded from the
-server. This command downloads, as needed, the entire dataset.
+version and revision numbers for the server files with those on the local
+system.  Any files missing or out of date on the local system are downloaded
+from the server. This command downloads, as needed, the entire dataset.
 
 .. note:: Science data servers may not have the same reliability and
    bandwidth as commercial providers
 
-**Load Data**
-
-----
+Load Data
+---------
 
 Data is loaded into a pysat.Instrument object, in this case dmsp, using the
 ``.load`` method using year, day of year; date; or filename.
@@ -200,16 +222,17 @@ the instrument level.
 See :any:`Instrument` for more.
 
 To load data over a season, pysat provides a convenience function that returns
-an array of dates over a season. The season need not be continuous.
+an array of dates over a specfied period of time. This time period does not
+need to be continuous (e.g., load both the vernal and autumnal equinoxes).
 
 .. code:: python
 
     import matplotlib.pyplot as plt
     import numpy as np
-    import pandas
+    import pandas as pds
 
     # create empty series to hold result
-    mean_ti = pandas.Series()
+    mean_ti = pds.Series()
 
     # get list of dates between start and stop
     start = dt.datetime(2001, 1, 1)
@@ -231,8 +254,8 @@ an array of dates over a season. The season need not be continuous.
 
     # plot the result using pandas functionality
     mean_ti.plot(title='Mean Ion Temperature near Magnetic Equator')
-    plt.ylabel(dmsp.meta['ti', dmsp.desc_label] + ' (' +
-               dmsp.meta['ti', dmsp.units_label] + ')')
+    plt.ylabel(dmsp.meta['ti', dmsp.meta.name_label] + ' (' +
+               dmsp.meta['ti', dmsp.meta.units_label] + ')')
 
 Note, the numpy.where may be removed using the convenience access to the
 attached pandas data object.
@@ -249,9 +272,8 @@ is equivalent to
    dmsp.data = vefi[(dmsp['mlat'] < 5) & (dmsp['mlat'] > -5)]
 
 
-**Clean Data**
-
------
+Clean Data
+----------
 
 Before data is available in .data it passes through an instrument specific
 cleaning routine. The amount of cleaning is set by the clean_level keyword,
@@ -279,9 +301,8 @@ The user provided cleaning level is stored on the Instrument object at
 ``dmsp.clean_level``. The details of the cleaning will generally vary greatly
 between instruments.
 
-**Metadata**
-
-----
+Metadata
+--------
 
 Metadata is also stored along with the main science data. pysat presumes
 a minimum default set of metadata that may be arbitrarily expanded.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -686,6 +686,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
         and 'revision'
         Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+    delimiter : string
+        Delimiter string upon which files will be split (e.g., '.')
 
     Returns
     -------

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -369,7 +369,7 @@ class Files(object):
                                        name=self._sat.name, tag=self._sat.tag,
                                        inst_id=self._sat.inst_id)
         output_str = " ".join(("pysat is searching for", output_str, "files."))
-        output_str = " ".join(output_str.split())
+        output_str = " ".join(output_str.split())  # Remove duplicate whitespace
         logger.info(output_str)
 
         info = self._sat._list_files_rtn(tag=self._sat.tag,

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -547,8 +547,9 @@ class Files(object):
             and '2000' will be added for years < two_digit_year_break.
             If None, then four-digit years are assumed. (default=None)
         delimiter : string or NoneType
-            If set, then filename will be processed using delimiter rather
-            than assuming a fixed width (default=None)
+            Delimiter string upon which files will be split (e.g., '.'). If
+            None, filenames will be parsed presuming a fixed width format.
+            (default=None)
 
         Note
         ----

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -356,7 +356,7 @@ class Files(object):
     def refresh(self):
         """Update list of files, if there are changes.
 
-        Calls underlying list_rtn for the particular science instrument.
+        Calls underlying list_files_rtn for the particular science instrument.
         Typically, these routines search in the pysat provided path,
         pysat_data_dir/platform/name/tag/,
         where pysat_data_dir is set by pysat.utils.set_data_dir(path=path).
@@ -372,10 +372,10 @@ class Files(object):
         output_str = " ".join(output_str.split())
         logger.info(output_str)
 
-        info = self._sat._list_rtn(tag=self._sat.tag,
-                                   inst_id=self._sat.inst_id,
-                                   data_path=self.data_path,
-                                   format_str=self.file_format)
+        info = self._sat._list_files_rtn(tag=self._sat.tag,
+                                         inst_id=self._sat.inst_id,
+                                         data_path=self.data_path,
+                                         format_str=self.file_format)
         info = self._remove_data_dir_path(info)
         if not info.empty:
             if self.ignore_empty_files:

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -372,7 +372,8 @@ class Files(object):
         output_str = " ".join(output_str.split())
         logger.info(output_str)
 
-        info = self._sat._list_rtn(tag=self._sat.tag, inst_id=self._sat.inst_id,
+        info = self._sat._list_rtn(tag=self._sat.tag,
+                                   inst_id=self._sat.inst_id,
                                    data_path=self.data_path,
                                    format_str=self.file_format)
         info = self._remove_data_dir_path(info)
@@ -545,7 +546,7 @@ class Files(object):
             '1900' will be added for years >= two_digit_year_break
             and '2000' will be added for years < two_digit_year_break.
             If None, then four-digit years are assumed. (default=None)
-        delimiter : string
+        delimiter : string or NoneType
             If set, then filename will be processed using delimiter rather
             than assuming a fixed width (default=None)
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -208,7 +208,7 @@ class Instrument(object):
                     setattr(self, iattr, getattr(inst_module, iattr).lower())
                 else:
                     raise AttributeError(''.join(['Supplied module ',
-                                                  inst_module.__repr__(),
+                                                  "{:}".format(inst_module),
                                                   'is missing required ',
                                                   'attribute: ', iattr]))
 
@@ -843,7 +843,7 @@ class Instrument(object):
         # update normal metadata parameters in a single go
         # case must always be preserved in Meta object
         new_fdict = {}
-        for kfey in fdict:
+        for fkey in fdict:
             case_old = self.meta.var_case_name(fkey)
             new_fdict[case_old] = fdict[fkey]
         self.meta.data.rename(index=new_fdict, inplace=True)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1186,9 +1186,9 @@ class Instrument(object):
         output_str += '---------------\n'
         output_str += "Cleaning Level: '{:s}'\n".format(self.clean_level)
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
-        if '_load_rtn' in self.kwargs.keys():
-            output_str += 'Keyword Arguments Passed to load(): '
-            output_str += "{:s}\n".format(self.kwargs['_load_rtn'].__str__())
+        for routine in self.kwargs.keys():
+            output_str += 'Keyword Arguments Passed to {:s}: '.format(routine)
+            output_str += "{:s}\n".format(self.kwargs[routine].__str__())
         output_str += "{:s}\n".format(self.custom.__str__())
 
         # Print out the orbit settings

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1498,7 +1498,7 @@ class Instrument(object):
                     self._curr_data = self._next_data
                     self._curr_meta = self._next_meta
                     self._next_data, self._next_meta = self._load_next()
-                elif self._prev_data_track == cur:
+                elif self._prev_data_track == curr:
                     # moving backward in time
                     del self._next_data
                     self._next_data = self._curr_data

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1631,11 +1631,11 @@ class Instrument(object):
 
         # apply default instrument routine, if data present
         if not self.empty:
-            self._default_rtn(self)
+            self._default_rtn()
 
         # clean data, if data is present and cleaning requested
         if (not self.empty) & (self.clean_level != 'none'):
-            self._clean_rtn(self)
+            self._clean_rtn()
 
         # apply custom functions via the nanokernel in self.custom
         if not self.empty:
@@ -2927,7 +2927,7 @@ def _get_supported_keywords(local_func):
     # account for keywords that exist for the standard functions
     pre_kws = ['fnames', 'inst_id', 'tag', 'date_array', 'data_path',
                'format_str', 'supported_tags', 'fake_daily_files_from_monthly',
-               'two_digit_year_break', 'delimiter']
+               'two_digit_year_break', 'delimiter', 'start', 'stop']
 
     # insert 'missing' default for 'fnames'
     defaults.insert(0, None)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1801,7 +1801,9 @@ class Instrument(object):
         Parameters
         ----------
         **kwargs : dict
-            Dictionary of keywords that may be options for specific instruments
+            Dictionary of keywords that may be options for specific instruments.
+            The keyword arguments 'user' and 'password' are expected for remote
+            databases requiring sign in or registration.
 
         Note
         ----
@@ -1860,7 +1862,9 @@ class Instrument(object):
             Sequence of dates to download date for. Takes precendence over
             start and stop inputs
         **kwargs : dict
-            Dictionary of keywords that may be options for specific instruments
+            Dictionary of keywords that may be options for specific instruments.
+            The keyword arguments 'user' and 'password' are expected for remote
+            databases requiring sign in or registration.
 
         Note
         ----

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1724,16 +1724,12 @@ class Instrument(object):
         files = self.remote_file_list(start=start, stop=stop)
         return [files.index[0], files.index[-1]]
 
-    def download_updated_files(self, user=None, password=None, **kwargs):
+    def download_updated_files(self, **kwargs):
         """Grabs a list of remote files, compares to local, then downloads new
         files.
 
         Parameters
         ----------
-        user : string
-            username, if required by instrument data archive
-        password : string
-            password, if required by instrument data archive
         **kwargs : dict
             Dictionary of keywords that may be options for specific instruments
 
@@ -1775,11 +1771,10 @@ class Instrument(object):
         logger.info(' '.join(('Found {} files that'.format(len(new_dates)),
                               'are new or updated.')))
         # download date for dates in new_dates (also includes new names)
-        self.download(user=user, password=password, date_array=new_dates,
-                      **kwargs)
+        self.download(date_array=new_dates, **kwargs)
 
-    def download(self, start=None, stop=None, freq='D', user=None,
-                 password=None, date_array=None, **kwargs):
+    def download(self, start=None, stop=None, freq='D', date_array=None,
+                 **kwargs):
         """Download data for given Instrument object from start to stop.
 
         Parameters
@@ -1791,10 +1786,6 @@ class Instrument(object):
         freq : string
             Stepsize between dates for season, 'D' for daily, 'M' monthly
             (see pandas)
-        user : string
-            username, if required by instrument data archive
-        password : string
-            password, if required by instrument data archive
         date_array : list-like
             Sequence of dates to download date for. Takes precendence over
             start and stop inputs
@@ -1836,19 +1827,14 @@ class Instrument(object):
             stop = self._filter_datetime_input(stop)
             date_array = utils.time.create_date_range(start, stop, freq=freq)
 
-        if user is None:
-            self._download_rtn(date_array,
-                               tag=self.tag,
-                               inst_id=self.inst_id,
-                               data_path=self.files.data_path,
-                               **kwargs)
-        else:
-            self._download_rtn(date_array,
-                               tag=self.tag,
-                               inst_id=self.inst_id,
-                               data_path=self.files.data_path,
-                               user=user,
-                               password=password, **kwargs)
+        # Add necessary kwargs to the optional kwargs
+        kwargs['tag'] = self.tag
+        kwargs['inst_id'] = self.inst_id
+        kwargs['data_path'] = self.files.data_path
+
+        # Download the data
+        self._download_rtn(date_array, **kwargs)
+
         # get current file date range
         first_date = self.files.start_date
         last_date = self.files.stop_date
@@ -2942,7 +2928,7 @@ def _get_supported_keywords(local_func):
     # account for keywords that exist for the standard functions
     pre_kws = ['fnames', 'inst_id', 'tag', 'date_array', 'data_path',
                'format_str', 'supported_tags', 'fake_daily_files_from_monthly',
-               'two_digit_year_break', 'delimiter', 'start', 'stop']
+               'two_digit_year_break', 'delimiter', 'start', 'stop', 'freq']
 
     # insert 'missing' default for 'fnames'
     n_args = len(args) - len(defaults)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -333,9 +333,9 @@ class Instrument(object):
             self.kwargs[fkey] = {gkey: kwargs[gkey] for gkey in good_kwargs}
 
             # Add in defaults if not already present
-            for dkey in default_keywords.keys():
+            for dkey in default_kwargs.keys():
                 if dkey not in good_kwargs:
-                    self.kwargs[fkey][dkey] = default_keywords[dkey]
+                    self.kwargs[fkey][dkey] = default_kwargs[dkey]
 
             # Determine the number of kwargs in this function
             fkwargs = [gkey for gkey in self.kwargs[fkey].keys()]

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -123,7 +123,7 @@ class Instrument(object):
     custom : pysat.Custom
         interface to instrument nano-kernel
     kwargs : dictionary
-        keyword arguments passed to instrument loading routine
+        keyword arguments passed to the standard Instrument routines
 
     Note
     ----

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1186,8 +1186,9 @@ class Instrument(object):
         output_str += '---------------\n'
         output_str += "Cleaning Level: '{:s}'\n".format(self.clean_level)
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
-        output_str += 'Keyword Arguments Passed to load(): '
-        output_str += "{:s}\n".format(self.kwargs['_load_rtn'].__str__())
+        if '_load_rtn' in self.kwargs.keys():
+            output_str += 'Keyword Arguments Passed to load(): '
+            output_str += "{:s}\n".format(self.kwargs['_load_rtn'].__str__())
         output_str += "{:s}\n".format(self.custom.__str__())
 
         # Print out the orbit settings
@@ -1324,9 +1325,14 @@ class Instrument(object):
         if len(fname) > 0:
             load_fname = [os.path.join(self.files.data_path, f) for f in fname]
             try:
+                if '_load_rtn' in self.kwargs.keys():
+                    load_kwargs = self.kwargs['_load_rtn']
+                else:
+                    load_kwargs = {}
                 data, mdata = self._load_rtn(load_fname, tag=self.tag,
                                              inst_id=self.inst_id,
-                                             **self.kwargs['_load_rtn'])
+                                             **load_kwargs)
+
                 # ensure units and name are named consistently in new Meta
                 # object as specified by user upon Instrument instantiation
                 mdata.accept_default_labels(self)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2930,7 +2930,9 @@ def _get_supported_keywords(local_func):
                'two_digit_year_break', 'delimiter', 'start', 'stop']
 
     # insert 'missing' default for 'fnames'
-    defaults.insert(0, None)
+    n_args = len(args) - len(defaults)
+    for i in range(0, n_args):
+        defaults.insert(0, None)
 
     # account for keywords already set since input was a partial function
     if existing_kws is not None:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1697,10 +1697,10 @@ class Instrument(object):
         """
         # Set the routine kwargs
         kwargs = self.kwargs['_list_remote_files_rtn']
-        kwargs["start"] =  start
+        kwargs["start"] = start
         kwargs["stop"] = stop
 
-        return self._list_remote_files_rtn(self.tag, self.inst_id,  **kwargs)
+        return self._list_remote_files_rtn(self.tag, self.inst_id, **kwargs)
 
     def remote_date_range(self, start=None, stop=None):
         """Returns fist and last date for remote data.  Default behaviour is

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -48,6 +48,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         and '2000' will be added for years < two_digit_year_break.
     delimiter : string
         Delimiter string upon which files will be split (e.g., '.')
+        If not provided, filenames will be parsed presuming a fixed width format.
 
     Returns
     --------

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
                supported_tags=None, fake_daily_files_from_monthly=False,
                two_digit_year_break=None, delimiter=None):
-    """Return a Pandas Series of every file for chosen satellite data.
+    """Return a Pandas Series of every file for chosen Instrument data.
 
     This routine provides a standard interfacefor pysat instrument modules.
 
@@ -51,7 +51,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
     Returns
     --------
-    pysat.Files.from_os : pysat._files.Files
+    out : pysat.Files.from_os : pysat._files.Files
         A class containing the verified available files
 
     Examples

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
                supported_tags=None, fake_daily_files_from_monthly=False,
-               two_digit_year_break=None):
+               two_digit_year_break=None, delimiter=None):
     """Return a Pandas Series of every file for chosen satellite data.
 
     This routine provides a standard interfacefor pysat instrument modules.
@@ -46,6 +46,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         If filenames only store two digits for the year, then
         '1900' will be added for years >= two_digit_year_break
         and '2000' will be added for years < two_digit_year_break.
+    delimiter : string
+        Delimiter string upon which files will be split (e.g., '.')
 
     Returns
     --------
@@ -83,7 +85,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
     # Get the series of files
     out = pysat.Files.from_os(data_path=data_path, format_str=format_str,
-                              two_digit_year_break=two_digit_year_break)
+                              two_digit_year_break=two_digit_year_break,
+                              delimiter=delimiter)
 
     # If the data is monthly, pad the series
     # TODO: take file frequency as an input to allow e.g., weekly files

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -21,7 +21,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     This routine provides a standard interfacefor pysat instrument modules.
 
     Parameters
-    -----------
+    ----------
     tag : string or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
@@ -38,20 +38,21 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         keys are inst_id, each containing a dict keyed by tag
         where the values file format template strings. (default=None)
     fake_daily_files_from_monthly : bool
-        Some CDAWeb instrument data files are stored by month, interfering
-        with pysat's functionality of loading by day. This flag, when true,
-        appends daily dates to monthly files internally. These dates are
-        used by load routine in this module to provide data by day.
-    two_digit_year_break : int
-        If filenames only store two digits for the year, then
-        '1900' will be added for years >= two_digit_year_break
-        and '2000' will be added for years < two_digit_year_break.
-    delimiter : string
-        Delimiter string upon which files will be split (e.g., '.')
-        If not provided, filenames will be parsed presuming a fixed width format.
+        Some instrument data files are stored by month, interfering with daily
+        file loading assumed by pysat. If True, this flag appends daily dates
+        to monthly files internally. These dates are used by load routine in
+        this module to provide data by day. (default=False)
+    two_digit_year_break : int or NoneType
+        If filenames only store two digits for the year, then '1900' will be
+        added for years >= two_digit_year_break and '2000' will be added for
+        years < two_digit_year_break. If None, then four-digit years are
+        assumed. (default=None)
+    delimiter : string or NoneType
+        Delimiter string upon which files will be split (e.g., '.'). If None,
+        filenames will be parsed presuming a fixed width format. (default=None)
 
     Returns
-    --------
+    -------
     out : pysat.Files.from_os : pysat._files.Files
         A class containing the verified available files
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -73,7 +73,8 @@ def init(self):
         # set list files routine to desired date range
         # attach to the instrument object
         fdr = self.kwargs['_load_rtn']['file_date_range']
-        self._list_rtn = functools.partial(list_files, file_date_range=fdr)
+        self._list_files_rtn = functools.partial(list_files,
+                                                 file_date_range=fdr)
         self.files.refresh()
 
     # mess with file dates if kwarg option present

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -69,16 +69,16 @@ def init(self):
     self.references = mm_test.refs
 
     # work on file index if keyword present
-    if self.kwargs['_load_rtn']['file_date_range'] is not None:
+    if self.kwargs['load']['file_date_range'] is not None:
         # set list files routine to desired date range
         # attach to the instrument object
-        fdr = self.kwargs['_load_rtn']['file_date_range']
+        fdr = self.kwargs['load']['file_date_range']
         self._list_files_rtn = functools.partial(list_files,
                                                  file_date_range=fdr)
         self.files.refresh()
 
     # mess with file dates if kwarg option present
-    if self.kwargs['_load_rtn']['mangle_file_dates']:
+    if self.kwargs['load']['mangle_file_dates']:
         self.files.files.index = \
             self.files.files.index + pds.DateOffset(minutes=5)
     return

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -69,15 +69,15 @@ def init(self):
     self.references = mm_test.refs
 
     # work on file index if keyword present
-    if self.kwargs['file_date_range'] is not None:
+    if self.kwargs['_load_rtn']['file_date_range'] is not None:
         # set list files routine to desired date range
         # attach to the instrument object
-        fdr = self.kwargs['file_date_range']
+        fdr = self.kwargs['_load_rtn']['file_date_range']
         self._list_rtn = functools.partial(list_files, file_date_range=fdr)
         self.files.refresh()
 
     # mess with file dates if kwarg option present
-    if self.kwargs['mangle_file_dates']:
+    if self.kwargs['_load_rtn']['mangle_file_dates']:
         self.files.files.index = \
             self.files.files.index + pds.DateOffset(minutes=5)
     return

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -87,14 +87,18 @@ def init(self):
 def default(self):
     """Default customization function.
 
+    Note
+    ----
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue).
 
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
+    """
 
+    pass
+
+
+def clean(self):
+    """Cleaning function
     """
 
     pass

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -41,17 +41,21 @@ def init(self):
     return
 
 
-def default(inst):
+def default(self):
     """Default customization function.
 
+    Note
+    ----
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue).
 
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
+    """
 
+    pass
+
+
+def clean(self):
+    """Cleaning function
     """
 
     pass

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -45,17 +45,21 @@ def init(self):
     return
 
 
-def default(inst):
+def default(self):
     """Default customization function.
 
+    Note
+    ----
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue).
 
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
+    """
 
+    pass
+
+
+def clean(self):
+    """Cleaning function
     """
 
     pass

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -47,18 +47,21 @@ def init(self):
     return
 
 
-def default(inst):
+def default(self):
     """Default customization function.
 
+    Note
+    ----
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue).
 
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
+    """
+
+    pass
 
 
+def clean(self):
+    """Cleaning function
     """
 
     pass

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -42,6 +42,13 @@ def init(self):
     return
 
 
+def clean(self):
+    """Cleaning function
+    """
+
+    pass
+
+
 def load(fnames, tag=None, inst_id=None):
     """ Loads the test files
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -50,6 +50,9 @@ import pysat
 
 logger = logging.getLogger(__name__)
 
+# ----------------------------------------------------------------------------
+# Instrument attributes:
+
 # The platform and name strings associated with this instrument need to be
 # defined at the top level.  These attributes will be copied over to the
 # Instrument object by pysat.  The strings used here should also be used to
@@ -67,13 +70,27 @@ tags = {'': 'description 1',  # this is the default
 # inst_ids = {'a': ['tag1', 'tag2'], 'b': ['tag2', 'tag3']}
 inst_ids = {'': ['', 'tag_string']}
 
+# Set to False to specify using xarray (not using pandas)
+# Set to True if data will be returned via a pandas DataFrame
+pandas_format = False
+
+# The following attributes will be set to these default values upon
+# instantiation if not otherwise specified
+directory_format = None
+file_format = None
+multi_file_day = False  # Set to True if files span less than a day
+orbit_info = None
+
+# ----------------------------------------------------------------------------
+# Instrument testing attributes:
+
 # Define good days to download data for when pysat undergoes testing.
 # format is outer dictionary has inst_id as the key
 # each inst_id has a dictionary of test dates keyed by tag string
-# _test_dates = {'a':{'L0':dt.datetime(2019,1,1),
-#                     'L1':dt.datetime(2019,1,1)},
-#                'b':{'L1':dt.datetime(2019,1,1),
-#                     'L2':dt.datetime(2019,1,1),}}
+# _test_dates = {'a':{'tag1': dt.datetime(2019,1,1),
+#                     'tag2': dt.datetime(2019,1,1)},
+#                'b':{'tag2': dt.datetime(2019,1,1),
+#                     'tag3': dt.datetime(2019,1,1),}}
 _test_dates = {'': {'': dt.datetime(2019, 1, 1),
                     'tag_string': dt.datetime(2019, 1, 2)}}
 
@@ -82,25 +99,24 @@ _test_dates = {'': {'': dt.datetime(2019, 1, 1),
 
 # For instruments without download support, set _test_download to False
 # If not set, defaults to True
-# _test_download = {'': {'': False}}
+_test_download = {'': {'': False, 'tag_string': True}}
 
 # For instruments using FTP for download, set _test_download_travis to False
 # These tests will still download locally but be skipped on Travis CI
 # If not set, defaults to True
-# _test_download_travis = {'': {'': False}}
+_test_download_travis = {'': {'': False, 'tag_string': False}}
 
 # For instruments requiring a user passwrod, set _password_req to True
 # These instruments will not be downloaded as part of tests to preserve password
 # security
 # If not set, defaults to False
-# _password_req = {'': {'': True}}
+_password_req = {'': {'': True, 'tag_string': False}}
 
-# Set to False to specify using xarray (not using pandas)
-# Set to True if data will be returned via a pandas DataFrame
-pandas_format = False
+# ----------------------------------------------------------------------------
+# Instrument methods: routines that are attached to the pysat.Instrument
+# as class methods
 
-
-# Required function
+# Required method
 def init(self):
     """Initializes the Instrument object with instrument specific values.
 
@@ -120,42 +136,45 @@ def init(self):
     return
 
 
-# Required function
-def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
-             **kwargs):
-    """Placeholder for PLATFORM/NAME downloads.
+# Required method
+def clean(self):
+    """Method to return PLATFORM/NAME data cleaned to the specified level
 
-    This routine is invoked by pysat and is not intended for direct use by the
-    end user.
+    Cleaning level is specified in inst.clean_level and pysat
+    will accept user input for several strings. The clean_level is
+    specified at instantiation of the Instrument object, though it may be
+    updated to a more stringent level and re-applied after instantiation.
+    The clean method is applied after default every time data is loaded.
 
-    Parameters
-    ----------
-    date_array : array-like
-        list of datetimes to download data for. The sequence of dates need not
-        be contiguous.
-    tag : string
-        Tag identifier used for particular dataset. This input is provided by
-        pysat. (default='')
-    inst_id : string
-        Satellite ID string identifier used for particular dataset. This input
-        is provided by pysat. (default='')
-    data_path : string
-        Path to directory to download data to. (default=None)
-    user : string (OPTIONAL)
-        User string input used for download. Provided by user and passed via
-        pysat. If an account is required for dowloads this routine here must
-        error if user not supplied. (default=None)
-    password : string (OPTIONAL)
-        Password for data download. (default=None)
-    custom_keywords : placeholder
-        Additional keywords supplied by user when invoking the download
-        routine attached to a pysat.Instrument object are passed to this
-        routine. Use of custom keywords here is discouraged.
+    Note
+    ----
+    'clean' All parameters should be good, suitable for statistical and
+            case studies
+    'dusty' All paramers should generally be good though same may
+            not be great
+    'dirty' There are data areas that have issues, data should be used
+            with caution
+    'none'  No cleaning applied, routine not called in this case.
 
     """
 
     return
 
+
+# Optional method
+def default(self):
+    """Default customization method.
+
+    This routine is automatically applied to the Instrument object
+    on every load by the pysat nanokernel (first in queue). Object
+    modified in place.
+
+    """
+
+    return
+
+# Instrument functions: routines that are attached to the pysat.Instrument
+# as function attributes
 
 # Required function
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
@@ -212,6 +231,43 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
     # we use a pysat provided function to grab list of files from the
     # local file system that match the format defined above
     return pysat.Files.from_os(data_path=data_path, format_str=format_str)
+
+
+# Required function
+def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
+             **kwargs):
+    """Placeholder for PLATFORM/NAME downloads.
+
+    This routine is invoked by pysat and is not intended for direct use by the
+    end user.
+
+    Parameters
+    ----------
+    date_array : array-like
+        list of datetimes to download data for. The sequence of dates need not
+        be contiguous.
+    tag : string
+        Tag identifier used for particular dataset. This input is provided by
+        pysat. (default='')
+    inst_id : string
+        Satellite ID string identifier used for particular dataset. This input
+        is provided by pysat. (default='')
+    data_path : string
+        Path to directory to download data to. (default=None)
+    user : string (OPTIONAL)
+        User string input used for download. Provided by user and passed via
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string (OPTIONAL)
+        Password for data download. (default=None)
+    custom_keywords : placeholder
+        Additional keywords supplied by user when invoking the download
+        routine attached to a pysat.Instrument object are passed to this
+        routine. Use of custom keywords here is discouraged.
+
+    """
+
+    return
 
 
 # Required function
@@ -285,30 +341,7 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
     return
 
 
-# Required function
-def clean(self):
-    """Routine to return PLATFORM/NAME data cleaned to the specified level
-
-    Cleaning level is specified in inst.clean_level and pysat
-    will accept user input for several strings. The clean_level is
-    specified at instantiation of the Instrument object.
-
-    Note
-    ----
-    'clean' All parameters should be good, suitable for statistical and
-            case studies
-    'dusty' All paramers should generally be good though same may
-            not be great
-    'dirty' There are data areas that have issues, data should be used
-            with caution
-    'none'  No cleaning applied, routine not called in this case.
-
-    """
-
-    return
-
-
-# not required but recommended
+# Recommended function
 def list_remote_files(tag, inst_id, user=None, password=None):
     """Return a Pandas Series of every file for chosen remote data.
 
@@ -335,24 +368,6 @@ def list_remote_files(tag, inst_id, user=None, password=None):
     pandas.Series
         A Series formatted for the Files class (pysat._files.Files)
         containing filenames and indexed by date and time
-
-    """
-
-    return
-
-
-# not required
-def default(self):
-    """Default customization function.
-
-    This routine is automatically applied to the Instrument object
-    on every load by the pysat nanokernel (first in queue). Object
-    modified in place.
-
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
 
     """
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -50,11 +50,10 @@ import pysat
 
 logger = logging.getLogger(__name__)
 
-# the platform and name strings associated with this instrument
-# need to be defined at the top level
-# these attributes will be copied over to the Instrument object by pysat
-# the strings used here should also be used to name this file
-# platform_name.py
+# The platform and name strings associated with this instrument need to be
+# defined at the top level.  These attributes will be copied over to the
+# Instrument object by pysat.  The strings used here should also be used to
+# name this file platform_name.py
 platform = ''
 name = ''
 
@@ -63,11 +62,10 @@ tags = {'': 'description 1',  # this is the default
         'tag_string': 'description 2'}
 
 # Let pysat know if there are multiple satellite platforms supported
-# by these routines
-# define a dictionary keyed by satellite ID, each with a list of
-# corresponding tags
-# inst_ids = {'a':['L1', 'L0'], 'b':['L1', 'L2'], 'c':['L1', 'L3']}
-inst_ids = {'': ['']}
+# by these routines.  Define a dictionary keyed by instrument ID, each with a
+# list of corresponding tags.  For example:
+# inst_ids = {'a': ['tag1', 'tag2'], 'b': ['tag2', 'tag3']}
+inst_ids = {'': ['', 'tag_string']}
 
 # Define good days to download data for when pysat undergoes testing.
 # format is outer dictionary has inst_id as the key
@@ -76,7 +74,8 @@ inst_ids = {'': ['']}
 #                     'L1':dt.datetime(2019,1,1)},
 #                'b':{'L1':dt.datetime(2019,1,1),
 #                     'L2':dt.datetime(2019,1,1),}}
-_test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2019, 1, 1),
+                    'tag_string': dt.datetime(2019, 1, 2)}}
 
 # Set Testing flags
 # Dict structure should mirror _test_dates above
@@ -101,26 +100,23 @@ _test_dates = {'': {'': dt.datetime(2019, 1, 1)}}
 pandas_format = False
 
 
+# Required function
 def init(self):
     """Initializes the Instrument object with instrument specific values.
 
     Runs once upon instantiation. Object modified in place.  Use this to set
     the acknowledgements and references.
 
-    Parameters
-    ----------
-    self : pysat.Instrument
-        This object
-
     """
-    # direct feedback to logging info
-    logger.info(" ".join(("Mission acknowledgements and data restrictions will",
-                          "be here when available.")))
-    # acknowledgements
-    self.acknowledgements = ''
-    # references
-    self.references = ''
 
+    # Required attribute: acknowledgements
+    self.acknowledgements = 'This would go in the Acknowledgements section'
+
+    # Required attribute: references
+    self.references = 'These are the instrument references'
+
+    # direct feedback to logging info
+    logger.info(self.acknowledgements)
     return
 
 
@@ -145,11 +141,11 @@ def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
         is provided by pysat. (default='')
     data_path : string
         Path to directory to download data to. (default=None)
-    user : string
+    user : string (OPTIONAL)
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
         error if user not supplied. (default=None)
-    password : string
+    password : string (OPTIONAL)
         Password for data download. (default=None)
     custom_keywords : placeholder
         Additional keywords supplied by user when invoking the download
@@ -289,14 +285,16 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
     return
 
 
-# not required but recommended
-def clean(inst):
+# Required function
+def clean(self):
     """Routine to return PLATFORM/NAME data cleaned to the specified level
 
     Cleaning level is specified in inst.clean_level and pysat
     will accept user input for several strings. The clean_level is
     specified at instantiation of the Instrument object.
 
+    Note
+    ----
     'clean' All parameters should be good, suitable for statistical and
             case studies
     'dusty' All paramers should generally be good though same may
@@ -304,13 +302,6 @@ def clean(inst):
     'dirty' There are data areas that have issues, data should be used
             with caution
     'none'  No cleaning applied, routine not called in this case.
-
-
-    Parameters
-    -----------
-    inst : pysat.Instrument
-        Instrument class object, whose attribute clean_level is used to return
-        the desired level of data selectivity.
 
     """
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -116,6 +116,7 @@ _password_req = {'': {'': True, 'tag_string': False}}
 # Instrument methods: routines that are attached to the pysat.Instrument
 # as class methods
 
+
 # Required method
 def init(self):
     """Initializes the Instrument object with instrument specific values.
@@ -173,8 +174,10 @@ def default(self):
 
     return
 
+# ----------------------------------------------------------------------------
 # Instrument functions: routines that are attached to the pysat.Instrument
 # as function attributes
+
 
 # Required function
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None):

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -234,15 +234,16 @@ def parse_delimited_filenames(files, format_str, delimiter):
     # so apply delimiter breakdown to the string blocks as a guide
     pblock = []
     parsed_block = [snip.split(delimiter) for snip in snips]
-    for _ in parsed_block:
-        if _ != ['', '']:
-            if _[0] == '':
-                _ = _[1:]
-            if _[-1] == '':
-                _ = _[:-1]
-            pblock.extend(_)
+    for block in parsed_block:
+        if block != ['', '']:
+            if block[0] == '':
+                block = block[1:]
+            if block[-1] == '':
+                block = block[:-1]
+            pblock.extend(block)
         pblock.append('')
     parsed_block = pblock[:-1]
+
     # need to parse out dates for datetime index
     for temp in files:
         split_name = temp.split(delimiter)
@@ -264,8 +265,10 @@ def parse_delimited_filenames(files, format_str, delimiter):
             stored[key] = np.array(stored[key])
         if len(stored[key]) == 0:
             stored[key] = None
+
     # include files in output
     stored['files'] = files
+
     # include format string as convenience for later functions
     stored['format_str'] = format_str
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -197,6 +197,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
         and 'revision'
         Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+    delimiter : string
+        Delimiter string upon which files will be split (e.g., '.')
 
     Returns
     -------


### PR DESCRIPTION
# Description

Currently, the Instrument input `*args` is not used and `**kwargs` can only be used to supply optional kwargs for the load routine.  This PR removes unused input arguments and allows optional kwargs to specify information for any of the standard Instrument methods.

Addresses #531 

## Type of change

Please delete options that are not relevant.

- Bug fix and Breaking Change that fixes an issue
- This change requires a documentation update

# How Has This Been Tested?

Tested with https://github.com/pysat/pysatMadrigal/pull/20 and local unit tests.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
