### PR TITLE
BUG: Format Madrigal Metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.2] - 2020-10-19
+- Bug Fix
+   - Updated madrigal methods to simplify compound data types and enable
+     creation of netCDF4 files using `self.to_netcdf4()`.
+
 ## [2.2.1] - 2020-07-29
 - Documentation
    - Improved organization of documentation on ReadTheDocs

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -133,6 +133,10 @@ def init(self):
     """
 
     logger.info(mad_meth.cedar_rules())
+    self.acknowledgements = "".join(("See 'self.Experiment_Notes' for ",
+                                     "instrument specific acknowledgements\n",
+                                     mad_meth.cedar_rules()))
+    self.references = "See 'self.Experiment_Notes' for references"
     return
 
 

--- a/pysat/instruments/methods/madrigal.py
+++ b/pysat/instruments/methods/madrigal.py
@@ -88,9 +88,11 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
     file_meta = filed['Metadata']['Data Parameters']
     # load up what is offered into pysat.Meta
     meta = pysat.Meta()
-    meta.info = {'acknowledgements': "See 'meta.Experiment_Notes' for " +
-                 "instrument specific acknowledgements\n" + cedar_rules(),
-                 'references': "See 'meta.Experiment_Notes' for references"}
+    meta.acknowledgements = "".join(("See 'meta.Experiment_Notes' for ",
+                                     "instrument specific acknowledgements\n",
+                                     cedar_rules()))
+    meta.references = "See 'meta.Experiment_Notes' for references"
+
     labels = []
     for item in file_meta:
         # handle difference in string output between python 2 and 3
@@ -113,6 +115,16 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
     for key in filed['Metadata']:
         if key != 'Data Parameters':
             setattr(meta, key.replace(' ', '_'), filed['Metadata'][key][:])
+
+    # update formatting of madrigal added information
+    # netcdf4 doesn't recommend compound data types
+    mad_vars = [('Experiment_Parameters', ': '),
+                ('Independent_Spatial_Parameters', ': '),
+                ('Experiment_Notes', '')]
+    for mad_var in mad_vars:
+        temp = [mad_var[1].join(snip) for snip in getattr(meta, mad_var[0])]
+        setattr(meta, mad_var[0], temp)
+
     # data into frame, with labels from metadata
     data = pds.DataFrame.from_records(file_data, columns=labels)
     # lowercase variable names

--- a/pysat/instruments/methods/madrigal.py
+++ b/pysat/instruments/methods/madrigal.py
@@ -116,8 +116,8 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
         if key != 'Data Parameters':
             setattr(meta, key.replace(' ', '_'), filed['Metadata'][key][:])
 
-    # update formatting of madrigal added information
-    # netcdf4 doesn't recommend compound data types
+    # Update formatting of madrigal experiment information since
+    # netcdf4 doesn't recommend compound data types.
     mad_vars = [('Experiment_Parameters', ': '),
                 ('Independent_Spatial_Parameters', ': '),
                 ('Experiment_Notes', '')]

--- a/pysat/instruments/methods/madrigal.py
+++ b/pysat/instruments/methods/madrigal.py
@@ -88,10 +88,6 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
     file_meta = filed['Metadata']['Data Parameters']
     # load up what is offered into pysat.Meta
     meta = pysat.Meta()
-    meta.acknowledgements = "".join(("See 'meta.Experiment_Notes' for ",
-                                     "instrument specific acknowledgements\n",
-                                     cedar_rules()))
-    meta.references = "See 'meta.Experiment_Notes' for references"
 
     labels = []
     for item in file_meta:
@@ -121,9 +117,16 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
     mad_vars = [('Experiment_Parameters', ': '),
                 ('Independent_Spatial_Parameters', ': '),
                 ('Experiment_Notes', '')]
-    for mad_var in mad_vars:
-        temp = [mad_var[1].join(snip) for snip in getattr(meta, mad_var[0])]
-        setattr(meta, mad_var[0], temp)
+    if sys.version_info.major < 3:
+        for mad_var in mad_vars:
+            temp = [mad_var[1].join(snip) for snip in getattr(meta, mad_var[0])]
+            setattr(meta, mad_var[0], temp)
+    else:
+        for mad_var in mad_vars:
+            snips = [[snip.decode('UTF-8') for snip in items] for items in
+                     getattr(meta, mad_var[0])]
+            snips = [mad_var[1].join(snip) for snip in snips]
+            setattr(meta, mad_var[0], snips)
 
     # data into frame, with labels from metadata
     data = pds.DataFrame.from_records(file_data, columns=labels)


### PR DESCRIPTION
# Description

Addresses #567

Madrigal metadata about an experiment gets loaded as a combined data type, like  dtype=('Notes', 'S80'), which netCDF4 doesn't appreciate. Updated the code to simplify compound data types into a string only. 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

I followed the directions in #567 and was able to produce a file.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
