### PR TITLE
BUG: Updated installation instructions for numpy version restriction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.2] - 2020-07-29
+## [2.2.2] - 2020-12-31
 - Documentation
    - Updated guidance on numpy version for installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.2] - 2020-07-29
+- Documentation
+   - Updated guidance on numpy version for installation
+
 ## [2.2.1] - 2020-07-29
 - Documentation
    - Improved organization of documentation on ReadTheDocs

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ To use Anaconda's tools for creating a suitable virtual environment, for Python
 
     conda create -n virt_env_name python=2.7
     conda activate virt_env_name
-    conda install numpy -c conda
+    conda install 'numpy<1.19' -c conda
 and for Python 3
 
 .. code:: bash

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -42,7 +42,7 @@ and for Python 3
 
     conda create -n virt_env_name python=3
     conda activate virt_env_name
-    conda install numpy -c conda
+    conda install 'numpy<1.19' -c conda
 
 **pysat**
 


### PR DESCRIPTION
# Description

Addresses #592 

Updates documentation to include numpy version restriction. There is a version restriction on numpy with setup.py, however, numpy must be installed before setup.py can be run.

## Type of change

Please delete options that are not relevant.

- Bug fix in Documentation (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Ran a new installation on my local system using a fresh conda install using python 3.8


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
