### PR TITLE
Unlimited time dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [2.2.2] - 2020-07-29
+## [2.2.2] - 2020-12-31
 - Documentation
    - Updated guidance on numpy version for installation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.2] - 2020-07-29
+- Documentation
+   - Updated guidance on numpy version for installation
+
 ## [2.2.1] - 2020-07-29
 - Documentation
    - Improved organization of documentation on ReadTheDocs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.2.2] - 2020-12-31
+- New Features
+   - netCDF4 files produced using `to_netcdf4()` now have an unlimited
+     time dimension
 - Documentation
    - Updated guidance on numpy version for installation
 - Bug Fix

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -35,7 +35,7 @@ To use Anaconda's tools for creating a suitable virtual environment, for Python
 
     conda create -n virt_env_name python=2.7
     conda activate virt_env_name
-    conda install numpy -c conda
+    conda install 'numpy<1.19' -c conda
 and for Python 3
 
 .. code:: bash

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2226,7 +2226,7 @@ class Instrument(object):
             # number of items, yeah
             num = len(self.index)
             # write out the datetime index
-            out_data.createDimension(epoch_name, num)
+            out_data.createDimension(epoch_name, None)
             cdfkey = out_data.createVariable(epoch_name, 'i8',
                                              dimensions=(epoch_name),
                                              zlib=zlib,

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2105,7 +2105,7 @@ class Instrument(object):
 
     def to_netcdf4(self, fname=None, base_instrument=None, epoch_name='Epoch',
                    zlib=False, complevel=4, shuffle=True, preserve_meta_case=False,
-                   export_nan=None):
+                   export_nan=None, unlimited_time=True):
         """Stores loaded data into a netCDF4 file.
 
         Parameters
@@ -2141,6 +2141,9 @@ class Instrument(object):
             included will be written to the file. If not listed
             and a value is NaN then that attribute simply won't be included in
             the netCDF4 file.
+        unlimited_time : bool
+            If True, then the main epoch dimension will be set to 'unlimited'
+            within the netCDF4 file. (default=True)
 
         Note
         ----
@@ -2226,7 +2229,10 @@ class Instrument(object):
             # number of items, yeah
             num = len(self.index)
             # write out the datetime index
-            out_data.createDimension(epoch_name, None)
+            if unlimited_time:
+                out_data.createDimension(epoch_name, None)
+            else:
+                out_data.createDimension(epoch_name, num)
             cdfkey = out_data.createVariable(epoch_name, 'i8',
                                              dimensions=(epoch_name),
                                              zlib=zlib,

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -257,13 +257,18 @@ class TestBasicNetCDF4():
     def test_load_netcdf4_empty_filenames(self):
         pysat.utils.load_netcdf4(fnames=None)
 
-    def test_basic_write_and_read_netcdf4_default_format(self):
+    def test_basic_write_and_read_netcdf4_unimited_time(self):
+        """Test reading and writing netcdf4, unlimited time dimension"""
+        self.test_basic_write_and_read_netcdf4_default_format(unlimited=True)
+        return
+
+    def test_basic_write_and_read_netcdf4_default_format(self, unlimited=False):
         # create a bunch of files by year and doy
         prep_dir(self.testInst)
         outfile = os.path.join(self.testInst.files.data_path,
                                'pysat_test_ncdf.nc')
         self.testInst.load(2009, 1)
-        self.testInst.to_netcdf4(outfile)
+        self.testInst.to_netcdf4(outfile, unlimited_time=unlimited)
 
         loaded_inst, meta = \
             pysat.utils.load_netcdf4(outfile,


### PR DESCRIPTION
# Description

Addresses #559 

Time/Epoch dimension for pysat produced netcdf4 files using `to_netCDF4` is now set to unlimited.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit test suite.


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
