### PR TITLE
MAINT: update requirements for readthedocs

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,5 +2,6 @@ ipython
 netCDF4
 numpydoc
 pandas
+portalocker
 pytest
 xarray


### PR DESCRIPTION
# Description

Read the docs is failing to build on develop since #525 was merged.  `portalocker` needs to be added to the requirements in the docs too.
```
ModuleNotFoundError: No module named 'portalocker'
```

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing through compilation on readthedocs

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes -- part of #525 
