### PR TITLE
ENH: cycle keyword for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added variable rename method to Instrument object (#91)
   - Migrated file methods to pysat.utils.files (#336)
   - Added support for loading more than one day/file (#56)
-  - Added support for iterating over a dataset a with a loaded data width and 
+  - Added support for iterating over a dataset a with a loaded data width and
     stepsize larger than a single day/file
   - Added check for inconsistent inputs when loading data via Instrument
   - Added file locking for thread-safe behavior (#304)
   - Allow the Instrument object to be initialized with optional kwargs for any
     of the standard methods (not just load).
+  - Added support for 'cycle' in addition to 'version' and 'revision' for
+    filename conventions.
 - Deprecations
   - Migraged instruments to pysatMadrigal, pysatNASA, pysatSpaceWeather,
     pysatIncubator, pysatModels, pysatCDAAC, and pysatMissions
@@ -59,7 +61,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Improved docstring readability and consistency
   - Added Travis-CI testing for the documentation
   - Added a style guide for developers
-  - Adopted standard for bounds. `stop` is an inclusive bound, `end` is 
+  - Adopted standard for bounds. `stop` is an inclusive bound, `end` is
     exclusive
 - Bug Fix
   - Fixed custom instrument attribute persistence upon load

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -234,7 +234,7 @@ in ``pysat.instruments.methods.general.list_files`` that may find broad use.
 include time information in the filename and utilize a constant field width
 or a consistent delimiter. The location and format of the time information is
 specified using standard python formatting and keywords year, month, day, hour,
-minute, second. Additionally, both version, revision, and cycle keywords
+minute, second. Additionally, version, revision, and cycle keywords
 are supported. When present, the from_os constructor will filter down the
 file list to the latest version/revision/cycle combination.
 

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -234,9 +234,9 @@ in ``pysat.instruments.methods.general.list_files`` that may find broad use.
 include time information in the filename and utilize a constant field width
 or a consistent delimiter. The location and format of the time information is
 specified using standard python formatting and keywords year, month, day, hour,
-minute, second. Additionally, both version and revision keywords
+minute, second. Additionally, both version, revision, and cycle keywords
 are supported. When present, the from_os constructor will filter down the
-file list to the latest version and revision combination.
+file list to the latest version/revision/cycle combination.
 
 A complete list_files routine could be as simple as
 
@@ -250,7 +250,7 @@ A complete list_files routine could be as simple as
            # template string below works for CINDI IVM data that looks like
            # 'cindi-2009310-ivm-v02.hdf'
            # format_str supported keywords: year, month, day,
-           # hour, minute, second, version, and revision
+           # hour, minute, second, version, revision, and cycle
            format_str = 'cindi-{year:4d}{day:03d}-ivm-v{version:02d}.hdf'
        return pysat.Files.from_os(data_path=data_path, format_str=format_str)
 

--- a/docs/tutorial_basics.rst
+++ b/docs/tutorial_basics.rst
@@ -153,8 +153,8 @@ the local system is fully up to date compared to the data source. The command,
 
     dmsp.download_updated_files()
 
-will obtain the full set of files present on the server and compare the
-version and revision numbers for the server files with those on the local
+will obtain the full set of files present on the server and compare the version,
+revision, and cycle numbers for the server files with those on the local
 system.  Any files missing or out of date on the local system are downloaded
 from the server. This command downloads, as needed, the entire dataset.
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -540,7 +540,7 @@ class Files(object):
             Provides the naming pattern of the instrument files and the
             locations of date information so an ordered list may be produced.
             Supports 'year', 'month', 'day', 'hour', 'minute', 'second',
-            'version', and 'revision'
+            'version', 'revision', and 'cycle'
             Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
         two_digit_year_break : int or None
             If filenames only store two digits for the year, then
@@ -618,9 +618,9 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     Note
     ----
         If two files have the same date and time information in the
-        filename then the file with the higher version/revision is used.
+        filename then the file with the higher version/revision/cycle is used.
         Series returned only has one file der datetime. Version is required
-        for this filtering, revision is optional.
+        for this filtering, revision and cycle are optional.
 
     """
 
@@ -649,15 +649,15 @@ def parse_fixed_width_filenames(files, format_str):
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        and 'revision'
-        Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        'revision', and 'cycle'
+        Ex: 'instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
 
     Returns
     -------
     OrderedDict
         Information parsed from filenames
         'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        'revision'
+        'revision', 'cycle'
         'files' - input list of files
 
     """
@@ -687,8 +687,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        and 'revision'
-        Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        'revision', 'cycle'
+        Ex: 'instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
     delimiter : string
         Delimiter string upon which files will be split (e.g., '.')
 
@@ -697,7 +697,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
     OrderedDict
         Information parsed from filenames
         'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        'revision'
+        'revision', 'cycle'
         'files' - input list of files
         'format_str' - formatted string from input
 
@@ -727,7 +727,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        and 'revision'
+        'revision', and 'cycle'
         Ex: 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
     wildcard : bool
         if True, replaces the ? sequence with a * . This option may be well

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2073,8 +2073,8 @@ class Instrument(object):
             if date not in local_files:
                 new_dates.append(date)
 
-        # Now compare filenames between common dates as it may be a new version
-        # or revision.  This will have a problem with filenames that are
+        # Now compare filenames between common dates as it may be a new version,
+        # revision, or cycle.  This will have a problem with filenames that are
         # faking daily data from monthly.
         for date in local_files.index:
             if date in remote_files.index:

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -34,9 +34,9 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     Note
     ----
         If two files have the same date and time information in the
-        filename then the file with the higher version/revision is used.
+        filename then the file with the higher version/revision/cycle is used.
         Series returned only has one file der datetime. Version is required
-        for this filtering, revision is optional.
+        for this filtering, revision and cycle are optional.
 
     """
 
@@ -88,7 +88,7 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
                                       day=stored['day'],
                                       uts=stored['second'])
 
-        # if version and revision are supplied
+        # if version, revision, and cycle are supplied
         # use these parameters to weed out files that have been replaced
         # with updated versions
         # first, check for duplicate index times
@@ -124,15 +124,15 @@ def parse_fixed_width_filenames(files, format_str):
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        and 'revision'
-        Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        'revision', and 'cycle'
+        Ex: 'instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
 
     Returns
     -------
     OrderedDict
         Information parsed from filenames
         'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        'revision'
+        'revision', 'cycle'
         'files' - input list of files
 
     """
@@ -198,8 +198,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        and 'revision'
-        Ex: 'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v01.cdf'
+        'revision', and 'cycle'
+        Ex: 'instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf'
     delimiter : string
         Delimiter string upon which files will be split (e.g., '.')
 
@@ -208,7 +208,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
     OrderedDict
         Information parsed from filenames
         'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        'revision'
+        'revision', 'cycle'
         'files' - input list of files
         'format_str' - formatted string from input
 
@@ -288,8 +288,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
         Supports 'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
-        and 'revision'
-        Ex: 'cnofs_vefi_bfield_1sec_{year:04d}{month:02d}{day:02d}_v05.cdf'
+        'revision', and 'cycle'
+        Ex: 'instrument_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf'
     wildcard : bool
         if True, replaces the ? sequence with a * . This option may be well
         suited when dealing with delimited filenames.

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -129,7 +129,7 @@ def parse_fixed_width_filenames(files, format_str):
 
     Returns
     -------
-    OrderedDict
+    stored : OrderedDict
         Information parsed from filenames
         'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
         'revision', 'cycle'
@@ -205,7 +205,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
     Returns
     -------
-    OrderedDict
+    stored : OrderedDict
         Information parsed from filenames
         'year', 'month', 'day', 'hour', 'minute', 'second', 'version',
         'revision', 'cycle'

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -80,6 +80,8 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
         # version is required to remove duplicate datetimes
         if stored['revision'] is None:
             stored['revision'] = np.zeros(len(files))
+        if stored['cycle'] is None:
+            stored['cycle'] = np.zeros(len(files))
 
         index = create_datetime_index(year=stored['year'],
                                       month=stored['month'],
@@ -96,7 +98,8 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
             # keep the highest version/revision combo
             version = pds.Series(stored['version'], index=index)
             revision = pds.Series(stored['revision'], index=index)
-            revive = version * 100000. + revision
+            cycle = pds.Series(stored['cycle'], index=index)
+            revive = version * 100000. + revision + cycle * 1e-5
             frame = pds.DataFrame({'files': files, 'revive': revive,
                                    'time': index}, index=index)
             frame = frame.sort_values(by=['time', 'revive'],
@@ -136,7 +139,7 @@ def parse_fixed_width_filenames(files, format_str):
 
     # create storage for data to be parsed from filenames
     ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',
-                    'version', 'revision']
+                    'version', 'revision', 'cycle']
     stored = collections.OrderedDict({kk: list() for kk in ordered_keys})
 
     if len(files) == 0:
@@ -213,7 +216,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
     # create storage for data to be parsed from filenames
     ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',
-                    'version', 'revision']
+                    'version', 'revision', 'cycle']
     stored = collections.OrderedDict({kk: list() for kk in ordered_keys})
 
     # exit early if there are no files


### PR DESCRIPTION
# Description

Addresses roadmap, #566 (partial)

Some data products (including those from GOLD) use a cycle keyword in addition to version / revision to track files.  This adds support for this in the pysat files methods.  This is required before pysat/pysatNASA#7 can be merged.

Note this addresses the immediate requirement behind #566 so development can proceed, but the bug documented there should still be addressed, even though it currently does not affect instruments in development.

Unrelated issues with test_files.py documented in #597.  Will be updated in a future pull.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Using the branch at pysat/pysatNASA#7:
```
import datetime as dt
import pysat
import pysatNASA
nmax = pysat.Instrument(inst_module=pysatNASA.instruments.gold_nmax,
                        strict_time_flag=False)
nmax.remote_file_list(start=dt.datetime(2020, 3, 1), stop=dt.datetime(2020, 3, 31))  
```
This should return a daily list of files spanning all 31 days.  The cycle number updates on 3/10/2020.

**Test Configuration**:
* Mac OSX 10.15.7
* python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
