### PR TITLE
DOC: broken links in sphinx build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jobs:
   include:
     - name: 'docs'
       python: '3.6'
-      script: 
+      script:
         - sphinx-build -E -b html docs dist/docs
         - sphinx-build -b linkcheck docs dist/docs
     - name: '3.6 with flake8'
@@ -15,9 +15,6 @@ jobs:
       script: pytest --cov=pysat/
     - python: '3.8'
       script: pytest --cov=pysat/
-  allow_failures:
-    - name: 'docs'
-      python: '3.6'
 
 services: xvfb
 cache: pip

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -88,11 +88,6 @@ Registry
 .. automodule:: pysat.utils.registry
    :members:
 
-Statistics
-^^^^^^^^^^
-.. automodule:: pysat.utils.stats
-   :members:
-
 Time
 ^^^^^^^^^^^
 .. automodule:: pysat.utils.time

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -5,8 +5,7 @@ When referring to this software package, please cite the original paper by
 Stoneback et al [2018] `<https://doi.org/10.1029/2018JA025297>`_ as well as the
 package `<https://doi.org/10.5281/zenodo.1199703>`_. Note that this doi will
 always point to the latest version of the code.  A list of dois for all
-versions can be found at the
-`Zenodo page <https://zenodo.org/record/1199703)>`_.
+versions can be found at the Zenodo page above.
 
 Example for citation in BibTex for a generalized version:
 

--- a/docs/dependency.rst
+++ b/docs/dependency.rst
@@ -34,7 +34,7 @@ could look something like:
 
 The instruments folder includes a file for each instrument object.  The
 requirements for structuring each of the instruments is discussed in
-:ref:`new_inst`.  The __init__ file in this folder should import the instruments
+:ref:`rst_new_inst`.  The __init__ file in this folder should import the instruments
 and construct a list of instruments to aid in the testing.
 
 .. code:: python

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -1,5 +1,5 @@
+.. _rst_new_inst:
 
-=======================
 Adding a New Instrument
 =======================
 

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -274,6 +274,7 @@ files which may take time to identify. The list of files associated
 with an Instrument may be updated by adding `update_files=True`.
 
 .. code:: python
+
    inst = pysat.Instrument(platform=platform, name=name, update_files=True)
 
 The output provided by the list_files function that has been pulled into pysat

--- a/docs/tutorial_basics.rst
+++ b/docs/tutorial_basics.rst
@@ -255,7 +255,7 @@ loading all data at once.
 In addition, convenience access to the data is also available at
 the instrument level.
 
-.. _DataFrame: http://pandas.pydata.org/pandas-docs/stable/dsintro.html#dataframe
+.. _DataFrame: https://pandas.pydata.org/pandas-docs/stable/user_guide/dsintro.html
 
 .. _DataSet: http://xarray.pydata.org/en/v0.11.3/generated/xarray.Dataset.html
 

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -1,6 +1,6 @@
 """
 pysat.utils.coords - coordinate transformations for pysat
-=========================================
+=========================================================
 
 pysat.utils.coords contains a number of coordinate-transformation
 functions used throughout the pysat package.

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -1,6 +1,6 @@
 """
 pysat.utils.registry - user module registry operations in pysat
-=========================================
+===============================================================
 
 Instantiating a pysat.Instrument object for a particular data set
 requires a module for each instrument with routines that download,

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -1,6 +1,6 @@
 """
 pysat.utils.time - date and time operations in pysat
-=========================================
+====================================================
 
 pysat.utils.time contains a number of functions used throughout
 the pysat package, including interactions with datetime objects,


### PR DESCRIPTION
# Description

- Updates broken links in docs
- Removed the "allow failures" for doc testing in Travis CI.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested locally via
```
sphinx-build -E -b html docs dist/docs
sphinx-build -b linkcheck docs dist/docs
```
**Test Configuration**:
* Mac OS X 10.15.7
* Python 3.8.2
* Sphinx 3.2.1

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes [part of previous changelog comment]
