### PR TITLE
Add timezone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed additional file date range for monthly data with gaps
   - Corrected iteration over Instrument within list comprehension
   - Removed unused input arguments
+  - Corrects Instrument today, yesterday, and tomorrow methods by implementing
+    aware datetimes
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -293,10 +293,10 @@ class Files(object):
         # if not, do nothing
         stored_files = self._load()
         if len(stored_files) != len(self.files):
-            # # of items is different, things are new
+            # Number of items are different, things are new
             new_flag = True
         elif len(stored_files) == len(self.files):
-            # # of items equal, check specifically for equality
+            # Number of items are equal, check specifically for equality
             if stored_files.eq(self.files).all():
                 new_flag = False
             else:
@@ -304,7 +304,6 @@ class Files(object):
                 new_flag = True
 
         if new_flag:
-
             if self.write_to_disk:
                 stored_files.to_csv(os.path.join(self.home_path,
                                                  'previous_' + name),
@@ -380,15 +379,18 @@ class Files(object):
         if not info.empty:
             if self.ignore_empty_files:
                 self._filter_empty_files()
-            logger.info('Found {ll:d} files locally.'.format(ll=len(info)))
+            logger.info('Found {:d} local files'.format(len(info)))
         else:
-            estr = "Unable to find any files that match the supplied template."
-            estr += " If you have the necessary files please check pysat "
-            estr += "settings and file locations (e.g. pysat.pysat_dir)."
+            estr = "".join(["Unable to find any files that match the supplied ",
+                            "template. If you have the necessary files please ",
+                            "check pysat settings and file locations (e.g. ",
+                            "pysat.pysat_dir)."])
             logger.warning(estr)
-        # attach to object
+
+        # Attach the information to the object
         self._attach_files(info)
-        # store - to disk, if enabled
+
+        # Store refreshed data to disk, if enabled
         self._store()
 
     def get_new(self):

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -341,8 +341,17 @@ class Files(object):
 
         if os.path.isfile(fname) and (os.path.getsize(fname) > 0):
             if self.write_to_disk:
-                return pds.read_csv(fname, index_col=0, parse_dates=True,
-                                    squeeze=True, header=None)
+                fseries = pds.read_csv(fname, index_col=0, parse_dates=True,
+                                       squeeze=True, header=None)
+                if fseries.index.tz is None:
+                    warnings.warn(' '.join(["{:s} uses old time".format(fname),
+                                            "formatting, recommend updating",
+                                            "file information by initializing",
+                                            "pysat Instrument with",
+                                            "update_file=True"]),
+                                  DeprecationWarning, stacklevel=2)
+                    fseries.index = fseries.index.tz_localize(dt.timezone.utc)
+                return fseries
             else:
                 # grab files from memory
                 if prev_version:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1662,9 +1662,8 @@ class Instrument(object):
                 ustops = [stop - self._iter_width + pds.DateOffset(days=1)
                           for stop in self._iter_stop]
                 ufreq = self._iter_step
-                self._iter_list = utils.time.create_date_range(self._iter_start,
-                                                               ustops,
-                                                               freq=ufreq)
+                self._iter_list = utils.time.create_date_range(
+                    self._iter_start, ustops, freq=ufreq)
             else:
                 # instrument has no files
                 self._iter_list = []
@@ -1782,12 +1781,11 @@ class Instrument(object):
                 # account for width of load. Don't extend past bound.
                 ustops = [stop - width + pds.DateOffset(days=1)
                           for stop in stops]
-                self._iter_list = utils.time.create_date_range(starts,
-                                                               ustops,
-                                                               freq=freq)
+                self._iter_list = utils.time.create_date_range(
+                    starts, ustops, freq=freq).tolist()
+
                 # go back to time index
                 self._iter_list = pds.DatetimeIndex(self._iter_list)
-
             else:
                 raise ValueError(' '.join(('Input is not a known type, string',
                                            'or datetime')))
@@ -2443,7 +2441,7 @@ class Instrument(object):
             _check_load_arguments_none(fname, stop_fname, date, end_date,
                                        raise_error=True)
             # convert yr/doy to a date
-            date = utils.set_timezone_to_utc(dt.datetime.strptime(
+            date = utils.time.set_timezone_to_utc(dt.datetime.strptime(
                 "{:.0f} {:.0f}".format(yr, doy), "%Y %j"), True)
             self._set_load_parameters(date=date, fid=None)
 
@@ -2452,7 +2450,7 @@ class Instrument(object):
                     estr = ''.join(('Day of year (end_doy) is only valid ',
                                     'between and including 1-366.'))
                     raise ValueError(estr)
-                end_date = utils.set_timezone_to_utc(dt.datetime.strptime(
+                end_date = utils.time.set_timezone_to_utc(dt.datetime.strptime(
                     "{:.0f} {:.0f}".format(end_yr, end_doy), "%Y %j"), True)
                 self.load_step = end_date - date
             elif (end_yr is not None) or (end_doy is not None):
@@ -2471,7 +2469,7 @@ class Instrument(object):
                                        end_doy, raise_error=True)
 
             # Make sure the timezone is specified
-            date = utils.set_timezone_to_utc(date, date_is_utc)
+            date = utils.time.set_timezone_to_utc(date, date_is_utc)
 
             # ensure date portion from user is only year, month, day
             self._set_load_parameters(date=date, fid=None)
@@ -2480,7 +2478,7 @@ class Instrument(object):
             # increment
             if end_date is not None:
                 # support loading a range of dates
-                end_date = utils.set_timezone_to_utc(end_date, date_is_utc)
+                end_date = utils.time.set_timezone_to_utc(end_date, date_is_utc)
                 self.load_step = end_date - date
             else:
                 # defaults to single day load

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1095,9 +1095,11 @@ class Instrument(object):
             return date
         else:
             if hasattr(date, '__iter__'):
-                return [dt.datetime(da.year, da.month, da.day) for da in date]
+                return [dt.datetime(da.year, da.month, da.day,
+                                    tzinfo=dt.timezone.utc) for da in date]
             else:
-                return dt.datetime(date.year, date.month, date.day)
+                return dt.datetime(date.year, date.month, date.day,
+                                   tzinfo=dt.timezone.utc)
 
     def _load_data(self, date=None, fid=None, inc=None):
         """
@@ -1596,8 +1598,8 @@ class Instrument(object):
             import pysat
 
             inst = pysat.Instrument(platform=platform, name=name, tag=tag)
-            start = dt.datetime(2009,1,1)
-            stop = dt.datetime(2009,1,31)
+            start = dt.datetime(2009, 1, 1)
+            stop = dt.datetime(2009, 1, 31)
             # Defaults to stepping by a single day and a data loading window
             # of one day/file.
             inst.bounds = (start, stop)
@@ -1606,8 +1608,8 @@ class Instrument(object):
             inst.bounds = ('filename1', 'filename2')
 
             # Create a more complicated season, multiple start and stop dates.
-            start2 = dt.datetetime(2010,1,1)
-            stop2 = dt.datetime(2010,2,14)
+            start2 = dt.datetetime(2010, 1, 1)
+            stop2 = dt.datetime(2010, 2, 14)
             inst.bounds = ([start, start2], [stop, stop2])
 
             # Iterate via a non-standard step size of two days.
@@ -1894,11 +1896,13 @@ class Instrument(object):
         Returns
         -------
         datetime
-            Today's date
+            Today's date in UTC
 
         """
+        ttime = utils.time.set_timezone_to_utc(dt.datetime.utcnow(),
+                                               naive_is_utc=True)
 
-        return self._filter_datetime_input(dt.datetime.today())
+        return self._filter_datetime_input(ttime)
 
     def tomorrow(self):
         """Returns tomorrow's date (UTC), with no hour, minute, second, etc.
@@ -1910,7 +1914,7 @@ class Instrument(object):
 
         """
 
-        return self.today() + pds.DateOffset(days=1)
+        return self.today() + dt.timedelta(days=1)
 
     def yesterday(self):
         """Returns yesterday's date (UTC), with no hour, minute, second, etc.
@@ -1922,7 +1926,7 @@ class Instrument(object):
 
         """
 
-        return self.today() - pds.DateOffset(days=1)
+        return self.today() - dt.timedelta(days=1)
 
     def next(self, verifyPad=False):
         """Manually iterate through the data loaded in Instrument object.
@@ -2530,7 +2534,7 @@ class Instrument(object):
         # check for constiency between loading range and data padding, if any
         if self.pad is not None:
             if self._load_by_date:
-                tdate = dt.datetime(2009, 1, 1)
+                tdate = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
                 if tdate + self.load_step < tdate + loop_pad:
                     estr = ''.join(('Data padding window must be shorter than ',
                                     'data loading window. Load a greater ',
@@ -2701,7 +2705,8 @@ class Instrument(object):
                 temp = first_time
             else:
                 temp = self.index[0]
-            self.date = dt.datetime(temp.year, temp.month, temp.day)
+            self.date = dt.datetime(temp.year, temp.month, temp.day,
+                                    tzinfo=dt.timezone.utc)
             self.yr, self.doy = utils.time.getyrdoy(self.date)
 
         # ensure data is unique and monotonic

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -47,8 +47,8 @@ class Orbits(object):
         info = {'index':'longitude', 'kind':'longitude'}
         vefi = pysat.Instrument(platform='cnofs', name='vefi', tag='dc_b',
                                 clean_level=None, orbit_info=info)
-        start = dt.datetime(2009,1,1)
-        stop = dt.datetime(2009,1,10)
+        start = dt.datetime(2009, 1, 1)
+        stop = dt.datetime(2009, 1, 10)
         vefi.load(date=start)
         vefi.bounds(start, stop)
 
@@ -199,7 +199,7 @@ class Orbits(object):
             # need to check step (frequency string) against width (DateOffset)
             step = pds.tseries.frequencies.to_offset(self.sat._iter_step)
             step = pds.DateOffset(seconds=step.delta.total_seconds())
-            root = dt.datetime(2001, 1, 1)
+            root = dt.datetime(2001, 1, 1, tzinfo=dt.timezone.utc)
             if root + step < root + self.sat._iter_width:
                 raise ValueError(estr)
 

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -216,7 +216,7 @@ def generate_times(fnames, num, freq='1S'):
         yr = int(parts[0])
         month = int(parts[1])
         day = int(parts[2][0:2])
-        date = dt.datetime(yr, month, day)
+        date = dt.datetime(yr, month, day, tzinfo=dt.timezone.utc)
         dates.append(date)
 
         # Create one day of data at desired frequency

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -220,14 +220,16 @@ def generate_times(fnames, num, freq='1S'):
         dates.append(date)
 
         # Create one day of data at desired frequency
-        end_date = date + pds.DateOffset(seconds=86399)
+        end_date = date + dt.timedelta(seconds=86399)
         index = pds.date_range(start=date, end=end_date, freq=freq)
         index = index[0:num]
         indices.extend(index)
         uts.extend(index.hour * 3600 + index.minute * 60 + index.second
                    + 86400. * loop)
+
     # combine index times together
     index = pds.DatetimeIndex(indices)
+
     # make UTS an array
     uts = np.array(uts)
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -35,9 +35,11 @@ tags = {'': 'Regular testing data set',
 # a numeric string can be used in inst_id to change the number of points per day
 inst_ids = {'': ['', 'ascend', 'descend', 'plus10', 'fives', 'mlt_offset',
                  'no_download']}
-_test_dates = {'': {'': dt.datetime(2009, 1, 1),
-                    'no_download': dt.datetime(2009, 1, 1),
-                    'non_strict': dt.datetime(2009, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                    'no_download': dt.datetime(2009, 1, 1,
+                                               tzinfo=dt.timezone.utc),
+                    'non_strict': dt.datetime(2009, 1, 1,
+                                              tzinfo=dt.timezone.utc)}}
 _test_download = {'': {'no_download': False}}
 
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -20,7 +20,7 @@ platform = 'pysat'
 name = 'testing2d'
 tags = {'': 'Regular testing data set'}
 inst_ids = {'': ['']}
-_test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)}}
 
 
 def init(self):
@@ -112,7 +112,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     # figure out how far in time from the root start
     # use that info to create a signal that is continuous from that start
     # going to presume there are 5820 seconds per orbit (97 minute period)
-    time_delta = dates[0] - dt.datetime(2009, 1, 1)
+    time_delta = dates[0] - dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
     # mlt runs 0-24 each orbit.
     data['mlt'] = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
                                              period=iperiod['lt'],

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -22,7 +22,7 @@ name = 'testing2d_xarray'
 pandas_format = False
 tags = {'': 'Regular testing data set'}
 inst_ids = {'': ['']}
-_test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)}}
 
 epoch_name = u'time'
 
@@ -123,7 +123,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     # figure out how far in time from the root start
     # use that info to create a signal that is continuous from that start
     # going to presume there are 5820 seconds per orbit (97 minute period)
-    time_delta = dates[0] - dt.datetime(2009, 1, 1)
+    time_delta = dates[0] - dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
 
     # mlt runs 0-24 each orbit.
     mlt = mm_test.generate_fake_data(time_delta.total_seconds(), uts,

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -130,8 +130,9 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         # non unique
         index[6:9] = [index[6]] * 3
 
-    data = xarray.Dataset({'uts': ((epoch_name), index)},
-                          coords={epoch_name: index})
+    data = xarray.Dataset({'uts': ((epoch_name), index.tolist())},
+                          coords={epoch_name: index.tolist()})
+    
     # need to create simple orbits here. Have start of first orbit
     # at 2009,1, 0 UT. 14.84 orbits per day
     time_delta = dates[0] - root_date

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -23,7 +23,7 @@ name = 'testing_xarray'
 tags = {'': 'Regular testing data set'}
 # dictionary of satellite IDs, list of corresponding tags
 inst_ids = {'': ['']}
-_test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)}}
 pandas_format = False
 
 epoch_name = u'time'
@@ -117,11 +117,11 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
                                                freq='1S')
 
     if sim_multi_file_right:
-        root_date = dt.datetime(2009, 1, 1, 12)
+        root_date = dt.datetime(2009, 1, 1, 12, tzinfo=dt.timezone.utc)
     elif sim_multi_file_left:
-        root_date = dt.datetime(2008, 12, 31, 12)
+        root_date = dt.datetime(2008, 12, 31, 12, tzinfo=dt.timezone.utc)
     else:
-        root_date = dt.datetime(2009, 1, 1)
+        root_date = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
 
     if malformed_index:
         index = index.tolist()
@@ -167,7 +167,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     data['altitude'] = ((epoch_name), altitude)
 
     # fake orbit number
-    fake_delta = dates[0] - dt.datetime(2008, 1, 1)
+    fake_delta = dates[0] - dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
     orbit_num = mm_test.generate_fake_data(fake_delta.total_seconds(),
                                            uts, period=iperiod['lt'],
                                            cyclic=False)

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -21,7 +21,7 @@ name = 'testmodel'
 tags = {'': 'Regular testing data set'}
 inst_ids = {'': ['']}
 pandas_format = False
-_test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)}}
 
 
 def init(self):

--- a/pysat/instruments/templates/netcdf_pandas.py
+++ b/pysat/instruments/templates/netcdf_pandas.py
@@ -35,7 +35,7 @@ name = 'pandas'
 tags = {'': 'netCDF4'}
 # dictionary of satellite IDs, list of corresponding tags
 inst_ids = {'': ['']}
-_test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
+_test_dates = {'': {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)}}
 
 
 def init(self):

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -87,12 +87,13 @@ orbit_info = None
 # Define good days to download data for when pysat undergoes testing.
 # format is outer dictionary has inst_id as the key
 # each inst_id has a dictionary of test dates keyed by tag string
-# _test_dates = {'a':{'tag1': dt.datetime(2019,1,1),
-#                     'tag2': dt.datetime(2019,1,1)},
-#                'b':{'tag2': dt.datetime(2019,1,1),
-#                     'tag3': dt.datetime(2019,1,1),}}
-_test_dates = {'': {'': dt.datetime(2019, 1, 1),
-                    'tag_string': dt.datetime(2019, 1, 2)}}
+# _test_dates = {'a':{'tag1': dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc),
+#                     'tag2': dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc)},
+#                'b':{'tag2': dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc),
+#                     'tag3': dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc)}}
+_test_dates = {'': {'': dt.datetime(2019, 1, 1, tzinfo=dt.timezone.utc),
+                    'tag_string': dt.datetime(2019, 1, 2,
+                                              tzinfo=dt.timezone.utc)}}
 
 # Set Testing flags
 # Dict structure should mirror _test_dates above

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -189,8 +189,8 @@ class TestBasics():
 
     def test_year_doy_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 12, 31, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='1D')
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
@@ -200,15 +200,16 @@ class TestBasics():
                                                         'pysat_testing_file')))
         # check overall length
         assert len(files) == (365 + 366)
-        # check specific dates
+
+        # check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
         assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_doy_files_no_gap_in_name_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 12, 31, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='1D',
                      root_fname=''.join(('pysat_testing_junk_{year:04d}',
                                          '{day:03d}_stuff.pysat_testing_',
@@ -221,15 +222,16 @@ class TestBasics():
                                                         'file')))
         # check overall length
         assert len(files) == (365 + 366)
-        # check specific dates
+
+        # Check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
         assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 12, 31, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='1D', use_doy=False,
                      root_fname=''.join(('pysat_testing_junk_{year:04d}_gold_',
                                          '{day:03d}_stuff_{month:02d}.pysat_',
@@ -243,15 +245,16 @@ class TestBasics():
                                                         'testing_file')))
         # check overall length
         assert len(files) == (365 + 366)
-        # check specific dates
+
+        # check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
         assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_hour_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 12, 31, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='6h',
                      use_doy=False,
                      root_fname=''.join(('pysat_testing_junk_{year:04d}_gold_',
@@ -267,7 +270,8 @@ class TestBasics():
                                                         'testing_file')))
         # check overall length
         assert len(files) == (365 + 366) * 4 - 3
-        # check specific dates
+
+        # check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
         assert pds.to_datetime(files.index[1460]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
@@ -277,8 +281,8 @@ class TestBasics():
                               'stuff_{month:02d}_{hour:02d}{minute:02d}.',
                               'pysat_testing_file'))
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2008, 1, 4)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 4, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='30min',
                      use_doy=False,
                      root_fname=root_fname)
@@ -287,7 +291,8 @@ class TestBasics():
                                     format_str=root_fname)
         # check overall length
         assert len(files) == 145
-        # check specific dates
+
+        # check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
         assert pds.to_datetime(files.index[1]) == dt.datetime(2008, 1, 1, 0, 30)
         assert pds.to_datetime(files.index[10]) == dt.datetime(2008, 1, 1, 5, 0)
@@ -298,8 +303,8 @@ class TestBasics():
                               'stuff_{month:02d}_{hour:02d}_{minute:02d}_',
                               '{second:02d}.pysat_testing_file'))
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2008, 1, 3)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 3, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='30s',
                      use_doy=False, root_fname=root_fname)
         # use from_os function to get pandas Series of files and dates
@@ -307,16 +312,19 @@ class TestBasics():
                                     format_str=root_fname)
         # check overall length
         assert len(files) == 5761
-        # check specific dates
+
+        # Check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        assert (pds.to_datetime(files.index[1])
-                == dt.datetime(2008, 1, 1, 0, 0, 30))
+        assert pds.to_datetime(
+            files.index[1]) == dt.datetime(2008, 1, 1, 0, 0, 30)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 3)
 
     def test_year_month_files_direct_call_to_from_os(self):
+        """test creation of file list with month/year using from_os
+        """
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
+        start = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 12, 31, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='1MS',
                      root_fname=''.join(('pysat_testing_junk_{year:04d}_gold_',
                                          'stuff_{month:02d}.pysat_testing_',
@@ -329,7 +337,8 @@ class TestBasics():
                                                         'pysat_testing_file')))
         # check overall length
         assert len(files) == 24
-        # check specific dates
+
+        # Check specific dates, which are naive
         assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
         assert pds.to_datetime(files.index[11]) == dt.datetime(2008, 12, 1)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 1)
@@ -350,8 +359,8 @@ class TestBasics():
                               'stuff_{month:02d}_{hour:02d}_{minute:02d}_'
                               '{second:02d}.pysat_testing_file'))
         # create a bunch of files by year and doy
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False, root_fname=root_fname)
         # create the same range of dates
@@ -360,7 +369,7 @@ class TestBasics():
         inst = pysat.Instrument(platform='pysat', name='testing',
                                 update_files=True)
         reload(pysat.instruments.pysat_testing)
-        assert (np.all(inst.files.files.index == dates))
+        assert np.all(inst.files.files.index == dates)
 
 
 class TestBasicsNoFileListStorage(TestBasics):
@@ -396,8 +405,8 @@ class TestInstrumentWithFiles():
                                    '{day:03d}_stuff_{month:02d}_{hour:02d}_',
                                    '{minute:02d}_{second:02d}.pysat_testing_',
                                    'file'))
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False, root_fname=self.root_fname)
 
@@ -423,13 +432,13 @@ class TestInstrumentWithFiles():
 
     def test_refresh(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 10)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname)
-        start = dt.datetime(2007, 12, 31)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
@@ -441,8 +450,8 @@ class TestInstrumentWithFiles():
         assert len(self.testInst.files.files) == 0
 
         # create new files with content and make sure they are captured
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname,
@@ -463,8 +472,8 @@ class TestInstrumentWithFiles():
         assert len(self.testInst.files.files) == 0
 
         # create new files with content and make sure they are captured
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname,
@@ -474,16 +483,16 @@ class TestInstrumentWithFiles():
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_refresh_on_unchanged_files(self):
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_get_new_files_after_refresh(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
@@ -496,8 +505,8 @@ class TestInstrumentWithFiles():
 
     def test_get_new_files_after_multiple_refreshes(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
@@ -511,8 +520,8 @@ class TestInstrumentWithFiles():
 
     def test_get_new_files_after_adding_files(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
@@ -523,8 +532,8 @@ class TestInstrumentWithFiles():
 
     def test_get_new_files_after_adding_files_and_adding_file(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
@@ -532,8 +541,8 @@ class TestInstrumentWithFiles():
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         new_files = self.testInst.files.get_new()
 
-        start = dt.datetime(2008, 1, 15)
-        stop = dt.datetime(2008, 1, 18)
+        start = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 18, tzinfo=dt.timezone.utc)
 
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
@@ -545,8 +554,8 @@ class TestInstrumentWithFiles():
 
     def test_get_new_files_after_deleting_files_and_adding_files(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
 
         # remove files, same number as will be added
@@ -569,8 +578,8 @@ class TestInstrumentWithFiles():
 
     def test_files_non_standard_pysat_directory(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
 
         self.testInst = \
@@ -602,8 +611,8 @@ class TestInstrumentWithFiles():
 
     def test_files_non_standard_file_format_template(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
 
         # clear out old files, create new ones
@@ -662,9 +671,9 @@ def create_versioned_files(inst, start=None, stop=None, freq='1D',
                            use_doy=True, root_fname=None, timeout=None):
     # create a bunch of files
     if start is None:
-        start = dt.datetime(2009, 1, 1)
+        start = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
     if stop is None:
-        stop = dt.datetime(2013, 12, 31)
+        stop = dt.datetime(2013, 12, 31, tzinfo=dt.timezone.utc)
     dates = pysat.utils.time.create_date_range(start, stop, freq=freq)
 
     versions = np.array([1, 2])
@@ -750,8 +759,8 @@ class TestInstrumentWithVersionedFiles():
                                    '{second:02d}_stuff_{version:02d}_',
                                    '{revision:03d}_{cycle:02d}',
                                    '.pysat_testing_file'))
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False, root_fname=self.root_fname)
 
@@ -778,13 +787,13 @@ class TestInstrumentWithVersionedFiles():
     def test_refresh(self):
         # create new files and make sure that new files are captured
         # files slready exist from 2007, 12, 31 through to 10th
-        start = dt.datetime(2008, 1, 10)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False,
                                root_fname=self.root_fname)
         # create list of dates for all files that should be there
-        start = dt.datetime(2007, 12, 31)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         # update instrument file list
         self.testInst.files.refresh()
@@ -792,16 +801,16 @@ class TestInstrumentWithVersionedFiles():
 
     def test_refresh_on_unchanged_files(self):
 
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
+        start = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 10, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_get_new_files_after_refresh(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False,
@@ -814,8 +823,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_get_new_files_after_multiple_refreshes(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False,
@@ -830,8 +839,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_get_new_files_after_adding_files(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False,
@@ -842,8 +851,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_get_new_files_after_adding_files_and_adding_file(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
 
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False,
@@ -851,8 +860,8 @@ class TestInstrumentWithVersionedFiles():
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         new_files = self.testInst.files.get_new()
 
-        start = dt.datetime(2008, 1, 15)
-        stop = dt.datetime(2008, 1, 18)
+        start = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 18, tzinfo=dt.timezone.utc)
 
         create_versioned_files(self.testInst, start, stop, freq='100min',
                                use_doy=False,
@@ -864,8 +873,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_get_new_files_after_deleting_files_and_adding_files(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 12, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         # remove files, same number as will be added
         to_be_removed = len(dates)
@@ -892,8 +901,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_files_non_standard_pysat_directory(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         pysat.instruments.pysat_testing.list_files = list_versioned_files
         self.testInst = \
@@ -924,8 +933,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_files_non_standard_file_format_template(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
 
         file_format = ''.join(('pysat_testing_unique_{version:02d}_',
@@ -949,8 +958,8 @@ class TestInstrumentWithVersionedFiles():
 
     def test_files_when_duplicates_forced(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
+        start = dt.datetime(2008, 1, 11, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 1, 15, tzinfo=dt.timezone.utc)
         dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
 
         file_format = ''.join(('pysat_testing_unique_{version:02d}_',
@@ -968,6 +977,8 @@ class TestInstrumentWithVersionedFiles():
                              clean_level='clean', file_format=file_format,
                              update_files=True,
                              temporary_file_list=self.temporary_file_list)
+
+        print("TEST", dates, self.testInst.files.files.index)
         assert (np.all(self.testInst.files.files.index == dates))
 
 
@@ -987,8 +998,8 @@ def create_instrument(j):
                          update_files=True,
                          temporary_file_list=False)
 
-    start = dt.datetime(2007, 12, 30)
-    stop = dt.datetime(2007, 12, 31)
+    start = dt.datetime(2007, 12, 30, tzinfo=dt.timezone.utc)
+    stop = dt.datetime(2007, 12, 31, tzinfo=dt.timezone.utc)
     create_versioned_files(testInst, start, stop,
                            freq='1D', use_doy=False,
                            root_fname=root_fname,
@@ -1034,8 +1045,8 @@ class TestFilesRaceCondition():
                                    '{second:02d}_stuff_{version:02d}_',
                                    '{revision:03d}_{cycle:02d}',
                                    '.pysat_testing_file'))
-        start = dt.datetime(2007, 12, 30)
-        stop = dt.datetime(2008, 12, 31)
+        start = dt.datetime(2007, 12, 30, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2008, 12, 31, tzinfo=dt.timezone.utc)
         create_versioned_files(self.testInst, start, stop, freq='1D',
                                use_doy=False, root_fname=self.root_fname)
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -76,8 +76,7 @@ class TestBasics():
             # iterate via for loop option
             for inst in self.testInst:
                 dates.append(inst.date)
-                time_range.append((inst.index[0],
-                                   inst.index[-1]))
+                time_range.append((inst.index[0], inst.index[-1]))
         else:
             # .next/.prev iterations
             if reverse:
@@ -104,9 +103,11 @@ class TestBasics():
         out = []
         for start, stop in zip(starts, stops):
             tdate = stop - width + pds.DateOffset(days=1)
-            out.extend(pds.date_range(start, tdate, freq=step).tolist())
+            out.extend([tt.to_pydatetime() for tt in
+                        pds.date_range(start, tdate, freq=step)])
         if reverse:
             out = out[::-1]
+
         assert np.all(dates == out)
 
         output = {}
@@ -196,28 +197,27 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("input", [{'yr': 2009, 'doy': 1,
-                                        'date': dt.datetime(
-                                            2009, 1, 1,
-                                            tzinfo=dt.timezone.utc)},
-                                       {'yr': 2009, 'doy': 1,
-                                        'end_date': dt.datetime(
-                                            2009, 1, 1,
-                                            tzinfo=dt.timezone.utc)},
-                                       {'yr': 2009, 'doy': 1,
-                                        'fname': 'dummy_str.nofile'},
-                                       {'yr': 2009, 'doy': 1,
-                                        'stop_fname': 'dummy_str.nofile'},
-                                       {'date': dt.datetime(
-                                           2009, 1, 1, tzinfo=dt.timezone.utc),
-                                        'fname': 'dummy_str.nofile'},
-                                       {'date': dt.datetime(
-                                           2009, 1, 1, tzinfo=dt.timezone.utc),
-                                        'stop_fname': 'dummy_str.nofile'},
-                                       {'date': dt.datetime(
-                                           2009, 1, 1, tzinfo=dt.timezone.utc),
-                                        'fname': 'dummy_str.nofile',
-                                        'end_yr': 2009, 'end_doy': 1}])
+    @pytest.mark.parametrize("input",
+                             [{'yr': 2009, 'doy': 1,
+                               'date': dt.datetime(2009, 1, 1,
+                                                   tzinfo=dt.timezone.utc)},
+                              {'yr': 2009, 'doy': 1,
+                               'end_date': dt.datetime(2009, 1, 1,
+                                                       tzinfo=dt.timezone.utc)},
+                              {'yr': 2009, 'doy': 1,
+                               'fname': 'dummy_str.nofile'},
+                              {'yr': 2009, 'doy': 1,
+                               'stop_fname': 'dummy_str.nofile'},
+                              {'date': dt.datetime(2009, 1, 1,
+                                                   tzinfo=dt.timezone.utc),
+                               'fname': 'dummy_str.nofile'},
+                              {'date': dt.datetime(2009, 1, 1,
+                                                   tzinfo=dt.timezone.utc),
+                               'stop_fname': 'dummy_str.nofile'},
+                              {'date': dt.datetime(2009, 1, 1,
+                                                   tzinfo=dt.timezone.utc),
+                               'fname': 'dummy_str.nofile',
+                               'end_yr': 2009, 'end_doy': 1}])
     def test_basic_instrument_load_mixed_inputs(self, input):
         """Ensure mixed load inputs raise ValueError"""
         with pytest.raises(ValueError) as err:
@@ -542,7 +542,7 @@ class TestBasics():
         with caplog.at_level(logging.INFO, logger='pysat'):
             self.testInst.download_updated_files()
         # Perform a local search
-        assert "files locally" in caplog.text
+        assert "local files" in caplog.text
         # New files are found
         assert "that are new or updated" in caplog.text
         # download new files
@@ -1166,19 +1166,25 @@ class TestBasics():
         """
         self.testInst.bounds = (self.testInst.files.files.index[0],
                                 self.testInst.files.files.index[9])
+
         # ensure no data to begin
         assert self.testInst.empty
+
         # perform comprehension and ensure there are as many as there should be
         insts = [inst for inst in self.testInst]
         assert len(insts) == 10
+
         # get list of dates
         dates = pds.Series([inst.date for inst in insts])
         assert dates.is_monotonic_increasing
+
         # dates are unique
         assert np.all(np.unique(dates) == dates.values)
+
         # iteration instruments are not the same as original
         for inst in insts:
             assert not (inst is self.testInst)
+
         # check there is data after iteration
         assert not self.testInst.empty
 
@@ -1322,27 +1328,19 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 3,
-                                                     tzinfo=dt.timezone.utc),
-                                         '2D', pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 4,
-                                                     tzinfo=dt.timezone.utc),
-                                         '2D', pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 5,
-                                                     tzinfo=dt.timezone.utc),
-                                         '3D', pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 17,
-                                                     tzinfo=dt.timezone.utc),
-                                         '5D', pds.DateOffset(days=1))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [(dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=3)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                               '3D', pds.DateOffset(days=1)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 17, tzinfo=dt.timezone.utc),
+                               '5D', pds.DateOffset(days=1))])
     def test_iterate_bounds_with_frequency_and_width(self, values):
         """Iterate via date with mixed step/width, excludes stop date"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -1351,36 +1349,25 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 4,
-                                                     tzinfo=dt.timezone.utc), '2D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 4,
-                                                     tzinfo=dt.timezone.utc), '3D',
-                                         pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 4,
-                                                     tzinfo=dt.timezone.utc), '1D',
-                                         pds.DateOffset(days=4)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 5,
-                                                     tzinfo=dt.timezone.utc), '4D',
-                                         pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 5,
-                                                     tzinfo=dt.timezone.utc), '2D',
-                                         pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 5,
-                                                     tzinfo=dt.timezone.utc), '3D',
-                                         pds.DateOffset(days=2))])
+    @pytest.mark.parametrize("values",
+                             [(dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               '3D', pds.DateOffset(days=1)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               '1D', pds.DateOffset(days=4)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                               '4D', pds.DateOffset(days=1)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=3)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                               '3D', pds.DateOffset(days=2))])
     def test_iterate_bounds_with_frequency_and_width_incl(self, values):
         """Iterate via date with mixed step/width, includes stop date"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -1389,27 +1376,19 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc), '2D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 9,
-                                                     tzinfo=dt.timezone.utc), '4D',
-                                         pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 11,
-                                                     tzinfo=dt.timezone.utc), '1D',
-                                         pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 11,
-                                                     tzinfo=dt.timezone.utc), '1D',
-                                         pds.DateOffset(days=11)),
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [(dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 10, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 9, tzinfo=dt.timezone.utc),
+                               '4D', pds.DateOffset(days=1)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               '1D', pds.DateOffset(days=3)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               '1D', pds.DateOffset(days=11))])
     def test_next_date_with_frequency_and_width_incl(self, values):
         """Test .next() via date step/width>1, includes stop date"""
         out = self.support_iter_evaluations(values)
@@ -1418,31 +1397,22 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 11,
-                                                     tzinfo=dt.timezone.utc), '2D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 12,
-                                                     tzinfo=dt.timezone.utc), '2D',
-                                         pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 13,
-                                                     tzinfo=dt.timezone.utc), '3D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 3,
-                                                     tzinfo=dt.timezone.utc), '4D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                         dt.datetime(2009, 1, 12,
-                                                     tzinfo=dt.timezone.utc), '2D',
-                                         pds.DateOffset(days=1))])
+    @pytest.mark.parametrize("values",
+                             [(dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=3)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 13, tzinfo=dt.timezone.utc),
+                               '3D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                               '4D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=1))])
     def test_next_date_with_frequency_and_width(self, values):
         """Test .next() via date step/width>1, excludes stop date"""
         out = self.support_iter_evaluations(values)
@@ -1451,37 +1421,28 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc)),
-                                         (dt.datetime(2009, 1, 4,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 13,
-                                                     tzinfo=dt.timezone.utc)),
-                                         '2D',
-                                         pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc)),
-                                         (dt.datetime(2009, 1, 7,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 16,
-                                                     tzinfo=dt.timezone.utc)),
-                                         '3D',
-                                         pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc)),
-                                         (dt.datetime(2009, 1, 6,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 15,
-                                                     tzinfo=dt.timezone.utc)),
-                                         '2D',
-                                         pds.DateOffset(days=4))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 13,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=2)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 7, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 16,
+                                            tzinfo=dt.timezone.utc)),
+                               '3D', pds.DateOffset(days=1)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 6, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=4))])
     def test_next_date_season_frequency_and_width_incl(self, values):
         """Test .next() via date season step/width>1, includes stop date"""
         out = self.support_iter_evaluations(values)
@@ -1490,37 +1451,28 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc)),
-                                         (dt.datetime(2009, 1, 3,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 12,
-                                                     tzinfo=dt.timezone.utc)),
-                                         '2D',
-                                         pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc)),
-                                         (dt.datetime(2009, 1, 6,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 15,
-                                                     tzinfo=dt.timezone.utc)),
-                                         '3D',
-                                         pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 10,
-                                                     tzinfo=dt.timezone.utc)),
-                                         (dt.datetime(2009, 1, 7,
-                                                     tzinfo=dt.timezone.utc),
-                                          dt.datetime(2009, 1, 16,
-                                                     tzinfo=dt.timezone.utc)),
-                                         '2D',
-                                         pds.DateOffset(days=4))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 12,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=2)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 6, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)),
+                               '3D', pds.DateOffset(days=1)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 7, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 16,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=4))])
     def test_next_date_season_frequency_and_width(self, values):
         """Test .next() via date season step/width>1, excludes stop date"""
         out = self.support_iter_evaluations(values)
@@ -1529,19 +1481,19 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 10), '2D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 9), '4D',
-                                         pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 11), '1D',
-                                         pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 11), '1D',
-                                         pds.DateOffset(days=11)),
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [(dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 10, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 9, tzinfo=dt.timezone.utc),
+                               '4D', pds.DateOffset(days=1)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               '1D', pds.DateOffset(days=3)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               '1D', pds.DateOffset(days=11))])
     def test_prev_date_with_frequency_and_width_incl(self, values):
         """Test .prev() via date step/width>1, includes stop date"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -1550,21 +1502,22 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 11), '2D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 12), '2D',
-                                         pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 13), '3D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 3), '4D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 12), '2D',
-                                         pds.DateOffset(days=1))])
+    @pytest.mark.parametrize("values",
+                             [(dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=3)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 13, tzinfo=dt.timezone.utc),
+                               '3D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                               '4D', pds.DateOffset(days=2)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                               '2D', pds.DateOffset(days=1))])
     def test_prev_date_with_frequency_and_width(self, values):
         """Test .prev() via date step/width>1, excludes stop date"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -1573,25 +1526,28 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 13)),
-                                         '2D',
-                                         pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 7),
-                                          dt.datetime(2009, 1, 16)),
-                                         '3D',
-                                         pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 6),
-                                          dt.datetime(2009, 1, 15)),
-                                         '2D',
-                                         pds.DateOffset(days=4))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 13,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=2)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 7, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 16,
+                                            tzinfo=dt.timezone.utc)),
+                               '3D', pds.DateOffset(days=1)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 6, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=4))])
     def test_prev_date_season_frequency_and_width_incl(self, values):
         """Test .prev() via date season step/width>1, includes stop date"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -1600,58 +1556,63 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 3),
-                                          dt.datetime(2009, 1, 12)),
-                                         '2D',
-                                         pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 6),
-                                          dt.datetime(2009, 1, 15)),
-                                         '3D',
-                                         pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 7),
-                                          dt.datetime(2009, 1, 16)),
-                                         '2D',
-                                         pds.DateOffset(days=4))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 12,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=2)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 6, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)),
+                               '3D', pds.DateOffset(days=1)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 7, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 16,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=4))])
     def test_prev_date_season_frequency_and_width(self, values):
         """Test .prev() via date season step/width>1, excludes stop date"""
         out = self.support_iter_evaluations(values, reverse=True)
+
         # verify range of loaded data
         self.verify_exclusive_iteration(out, forward=False)
 
         return
 
     def test_set_bounds_too_few(self):
-        start = dt.datetime(2009, 1, 1)
+        start = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         with pytest.raises(ValueError):
             self.testInst.bounds = [start]
 
     def test_set_bounds_mixed(self):
-        start = dt.datetime(2009, 1, 1)
+        start = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         with pytest.raises(ValueError):
             self.testInst.bounds = [start, '2009-01-01.nofile']
 
     def test_set_bounds_wrong_type(self):
         """Test Exception when setting bounds with inconsistent types"""
-        start = dt.datetime(2009, 1, 1)
+        start = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         with pytest.raises(ValueError):
             self.testInst.bounds = [start, 1]
 
     def test_set_bounds_mixed_iterable(self):
-        start = [dt.datetime(2009, 1, 1)] * 2
+        start = [dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)] * 2
         with pytest.raises(ValueError):
             self.testInst.bounds = [start, '2009-01-01.nofile']
 
     def test_set_bounds_mixed_iterabless(self):
-        start = [dt.datetime(2009, 1, 1)] * 2
+        start = [dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)] * 2
         with pytest.raises(ValueError):
-            self.testInst.bounds = [start, [dt.datetime(2009, 1, 1),
+            self.testInst.bounds = [start, [dt.datetime(2009, 1, 1,
+                                                        tzinfo=dt.timezone.utc),
                                             '2009-01-01.nofile']]
 
     def test_set_bounds_string_default_start(self):
@@ -1664,8 +1625,8 @@ class TestBasics():
 
     def test_set_bounds_too_many(self):
         """Ensure error if too many inputs to inst.bounds"""
-        start = dt.datetime(2009, 1, 1)
-        stop = dt.datetime(2009, 1, 1)
+        start = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         width = pds.DateOffset(days=1)
         with pytest.raises(ValueError) as err:
             self.testInst.bounds = [start, stop, '1D', width, False]
@@ -1674,16 +1635,16 @@ class TestBasics():
 
     def test_set_bounds_by_date(self):
         """Test setting bounds with datetimes over simple range"""
-        start = dt.datetime(2009, 1, 1)
-        stop = dt.datetime(2009, 1, 15)
+        start = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop)
         assert np.all(self.testInst._iter_list
                       == pds.date_range(start, stop).tolist())
 
     def test_set_bounds_by_date_wrong_order(self):
         """Test error if bounds assignment has stop date before start"""
-        start = dt.datetime(2009, 1, 15)
-        stop = dt.datetime(2009, 1, 1)
+        start = dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         with pytest.raises(Exception) as err:
             self.testInst.bounds = (start, stop)
         estr = 'Bounds must be set in increasing'
@@ -1704,19 +1665,21 @@ class TestBasics():
         assert np.all(self.testInst._iter_list == full_list)
 
     def test_set_bounds_by_date_extra_time(self):
-        start = dt.datetime(2009, 1, 1, 1, 10)
-        stop = dt.datetime(2009, 1, 15, 1, 10)
+        start = dt.datetime(2009, 1, 1, 1, 10, tzinfo=dt.timezone.utc)
+        stop = dt.datetime(2009, 1, 15, 1, 10, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop)
         start = self.testInst._filter_datetime_input(start)
         stop = self.testInst._filter_datetime_input(stop)
         assert np.all(self.testInst._iter_list
                       == pds.date_range(start, stop).tolist())
 
-    @pytest.mark.parametrize("start,stop", [(dt.datetime(2008, 1, 1),
-                                             dt.datetime(2010, 12, 31)),
-                                            (dt.datetime(2009, 1, 1),
-                                             dt.datetime(2009, 1, 15))
-                                            ])
+    @pytest.mark.parametrize("start,stop",
+                             [(dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2010, 12, 31,
+                                           tzinfo=dt.timezone.utc)),
+                              (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               dt.datetime(2009, 1, 15,
+                                           tzinfo=dt.timezone.utc))])
     def test_iterate_over_bounds_set_by_date(self, start, stop):
         """Test iterating over bounds via single date range"""
         self.testInst.bounds = (start, stop)
@@ -1737,8 +1700,10 @@ class TestBasics():
         assert np.all(dates == out)
 
     def test_set_bounds_by_date_season(self):
-        start = [dt.datetime(2009, 1, 1), dt.datetime(2009, 2, 1)]
-        stop = [dt.datetime(2009, 1, 15), dt.datetime(2009, 2, 15)]
+        start = [dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                 dt.datetime(2009, 2, 1, tzinfo=dt.timezone.utc)]
+        stop = [dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc),
+                dt.datetime(2009, 2, 15, tzinfo=dt.timezone.utc)]
         self.testInst.bounds = (start, stop)
         out = pds.date_range(start[0], stop[0]).tolist()
         out.extend(pds.date_range(start[1], stop[1]).tolist())
@@ -1746,18 +1711,20 @@ class TestBasics():
 
     def test_set_bounds_by_date_season_wrong_order(self):
         """Test error if bounds season assignment has stop date before start"""
-        start = [dt.datetime(2009, 1, 1), dt.datetime(2009, 2, 1)]
-        stop = [dt.datetime(2009, 1, 12), dt.datetime(2009, 1, 15)]
+        start = [dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                 dt.datetime(2009, 2, 1, tzinfo=dt.timezone.utc)]
+        stop = [dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc)]
         with pytest.raises(Exception) as err:
             self.testInst.bounds = (start, stop)
         estr = 'Bounds must be set in increasing'
         assert str(err).find(estr) >= 0
 
     def test_set_bounds_by_date_season_extra_time(self):
-        start = [dt.datetime(2009, 1, 1, 1, 10),
-                 dt.datetime(2009, 2, 1, 1, 10)]
-        stop = [dt.datetime(2009, 1, 15, 1, 10),
-                dt.datetime(2009, 2, 15, 1, 10)]
+        start = [dt.datetime(2009, 1, 1, 1, 10, tzinfo=dt.timezone.utc),
+                 dt.datetime(2009, 2, 1, 1, 10, tzinfo=dt.timezone.utc)]
+        stop = [dt.datetime(2009, 1, 15, 1, 10, tzinfo=dt.timezone.utc),
+                dt.datetime(2009, 2, 15, 1, 10, tzinfo=dt.timezone.utc)]
         self.testInst.bounds = (start, stop)
         start = self.testInst._filter_datetime_input(start)
         stop = self.testInst._filter_datetime_input(stop)
@@ -1766,8 +1733,10 @@ class TestBasics():
         assert np.all(self.testInst._iter_list == out)
 
     def test_iterate_over_bounds_set_by_date_season(self):
-        start = [dt.datetime(2009, 1, 1), dt.datetime(2009, 2, 1)]
-        stop = [dt.datetime(2009, 1, 15), dt.datetime(2009, 2, 15)]
+        start = [dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                 dt.datetime(2009, 2, 1, tzinfo=dt.timezone.utc)]
+        stop = [dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc),
+                dt.datetime(2009, 2, 15, tzinfo=dt.timezone.utc)]
         self.testInst.bounds = (start, stop)
         dates = []
         for inst in self.testInst:
@@ -1776,25 +1745,28 @@ class TestBasics():
         out.extend(pds.date_range(start[1], stop[1]).tolist())
         assert np.all(dates == out)
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 3),
-                                          dt.datetime(2009, 1, 12)),
-                                         '2D',
-                                         pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 6),
-                                          dt.datetime(2009, 1, 15)),
-                                         '3D',
-                                         pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 7),
-                                          dt.datetime(2009, 1, 16)),
-                                         '2D',
-                                         pds.DateOffset(days=4))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 12,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=2)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 6, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)),
+                               '3D', pds.DateOffset(days=1)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 7, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 16,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=4))])
     def test_iterate_over_bounds_set_by_date_season_step_width(self, values):
         """Iterate over season, step/width > 1, excludes stop bounds"""
 
@@ -1804,25 +1776,28 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 13)),
-                                         '2D',
-                                         pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 7),
-                                          dt.datetime(2009, 1, 16)),
-                                         '3D',
-                                         pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 6),
-                                          dt.datetime(2009, 1, 15)),
-                                         '2D',
-                                         pds.DateOffset(days=4))
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 13,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=2)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 7, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 16,
+                                            tzinfo=dt.timezone.utc)),
+                               '3D', pds.DateOffset(days=1)),
+                              ((dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 10,
+                                            tzinfo=dt.timezone.utc)),
+                               (dt.datetime(2009, 1, 6, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)),
+                               '2D', pds.DateOffset(days=4))])
     def test_iterate_bounds_set_by_date_season_step_width_incl(self, values):
         """Iterate over season, step/width > 1, includes stop bounds"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -1832,10 +1807,10 @@ class TestBasics():
         return
 
     def test_iterate_over_bounds_set_by_date_season_extra_time(self):
-        start = [dt.datetime(2009, 1, 1, 1, 10),
-                 dt.datetime(2009, 2, 1, 1, 10)]
-        stop = [dt.datetime(2009, 1, 15, 1, 10),
-                dt.datetime(2009, 2, 15, 1, 10)]
+        start = [dt.datetime(2009, 1, 1, 1, 10, tzinfo=dt.timezone.utc),
+                 dt.datetime(2009, 2, 1, 1, 10, tzinfo=dt.timezone.utc)]
+        stop = [dt.datetime(2009, 1, 15, 1, 10, tzinfo=dt.timezone.utc),
+                dt.datetime(2009, 2, 15, 1, 10, tzinfo=dt.timezone.utc)]
         self.testInst.bounds = (start, stop)
         # filter
         start = self.testInst._filter_datetime_input(start)
@@ -1859,8 +1834,8 @@ class TestBasics():
     def test_iterate_over_bounds_set_by_fname(self):
         start = '2009-01-01.nofile'
         stop = '2009-01-15.nofile'
-        start_d = dt.datetime(2009, 1, 1)
-        stop_d = dt.datetime(2009, 1, 15)
+        start_d = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
+        stop_d = dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop)
         dates = []
         for inst in self.testInst:
@@ -1881,8 +1856,8 @@ class TestBasics():
     def test_iterate_over_bounds_set_by_fname_via_next(self):
         start = '2009-01-01.nofile'
         stop = '2009-01-15.nofile'
-        start_d = dt.datetime(2009, 1, 1)
-        stop_d = dt.datetime(2009, 1, 15)
+        start_d = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
+        stop_d = dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop)
         dates = []
         loop_next = True
@@ -1898,8 +1873,8 @@ class TestBasics():
     def test_iterate_over_bounds_set_by_fname_via_prev(self):
         start = '2009-01-01.nofile'
         stop = '2009-01-15.nofile'
-        start_d = dt.datetime(2009, 1, 1)
-        stop_d = dt.datetime(2009, 1, 15)
+        start_d = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
+        stop_d = dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop)
         dates = []
         loop = True
@@ -1936,8 +1911,10 @@ class TestBasics():
         """Test set bounds using multiple filenames"""
         start = ['2009-01-01.nofile', '2009-02-01.nofile']
         stop = ['2009-01-15.nofile', '2009-02-15.nofile']
-        start_d = [dt.datetime(2009, 1, 1), dt.datetime(2009, 2, 1)]
-        stop_d = [dt.datetime(2009, 1, 15), dt.datetime(2009, 2, 15)]
+        start_d = [dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                   dt.datetime(2009, 2, 1, tzinfo=dt.timezone.utc)]
+        stop_d = [dt.datetime(2009, 1, 15, tzinfo=dt.timezone.utc),
+                  dt.datetime(2009, 2, 15, tzinfo=dt.timezone.utc)]
         self.testInst.bounds = (start, stop)
         dates = []
         for inst in self.testInst:
@@ -1949,24 +1926,24 @@ class TestBasics():
     def test_set_bounds_fname_with_frequency(self):
         """Test set bounds using filenames and non-default step"""
         start = '2009-01-01.nofile'
-        start_date = dt.datetime(2009, 1, 1)
+        start_date = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         stop = '2009-01-03.nofile'
-        stop_date = dt.datetime(2009, 1, 3)
+        stop_date = dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop, 2)
         out = pds.date_range(start_date, stop_date, freq='2D').tolist()
-        # convert filenames in list to a date
-        date_list = []
-        for item in self.testInst._iter_list:
+
+        # Evaluate each filename date
+        for i, item in enumerate(self.testInst._iter_list):
             snip = item.split('.')[0]
-            date_list.append(dt.datetime.strptime(snip, '%Y-%m-%d'))
-        assert np.all(date_list == out)
+            ref_snip = out[i].strftime('%Y-%m-%d')
+            assert snip == ref_snip
 
     def test_iterate_bounds_fname_with_frequency(self):
         """Test iterate over bounds using filenames and non-default step"""
         start = '2009-01-01.nofile'
-        start_date = dt.datetime(2009, 1, 1)
+        start_date = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         stop = '2009-01-03.nofile'
-        stop_date = dt.datetime(2009, 1, 3)
+        stop_date = dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop, 2)
 
         dates = []
@@ -1978,34 +1955,35 @@ class TestBasics():
     def test_set_bounds_fname_with_frequency_and_width(self):
         """Set fname bounds with step/width>1"""
         start = '2009-01-01.nofile'
-        start_date = dt.datetime(2009, 1, 1)
+        start_date = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         stop = '2009-01-03.nofile'
-        stop_date = dt.datetime(2009, 1, 3)
+        stop_date = dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc)
         self.testInst.bounds = (start, stop, 2, 2)
         out = pds.date_range(start_date, stop_date - pds.DateOffset(days=1),
                              freq='2D').tolist()
         # convert filenames in list to a date
         date_list = []
-        for item in self.testInst._iter_list:
+        for i, item in enumerate(self.testInst._iter_list):
             snip = item.split('.')[0]
-            date_list.append(dt.datetime.strptime(snip, '%Y-%m-%d'))
-        assert np.all(date_list == out)
+            ref_snip = out[i].strftime('%Y-%m-%d')
+            assert snip == ref_snip
 
-    @pytest.mark.parametrize("values", [('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-03.nofile',
-                                         dt.datetime(2009, 1, 3),
-                                         2, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         2, 3),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-05.nofile',
-                                         dt.datetime(2009, 1, 5),
-                                         3, 1)])
+    @pytest.mark.parametrize("values",
+                             [('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-03.nofile',
+                               dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                               2, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-04.nofile',
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               2, 3),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-05.nofile',
+                               dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                               3, 1)])
     def test_iterate_bounds_fname_with_frequency_and_width(self, values):
         """File iteration in bounds with step/width>1, excludes stop bounds"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -2014,26 +1992,27 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         2, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         3, 1),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         1, 4),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-05.nofile',
-                                         dt.datetime(2009, 1, 5),
-                                         2, 3)])
+    @pytest.mark.parametrize("values",
+                             [('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-04.nofile',
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               2, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-04.nofile',
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               3, 1),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-04.nofile',
+                               dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                               1, 4),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-05.nofile',
+                               dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                               2, 3)])
     def test_iterate_bounds_fname_with_frequency_and_width_incl(self, values):
         """File iteration in bounds with step/width>1, includes stop bounds"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -2042,30 +2021,31 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-03.nofile',
-                                          '2009-01-13.nofile'),
-                                         (dt.datetime(2009, 1, 3),
-                                          dt.datetime(2009, 1, 13)), 2, 2),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 2, 3),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-05.nofile',
-                                          '2009-01-15.nofile'),
-                                         (dt.datetime(2009, 1, 5),
-                                          dt.datetime(2009, 1, 15)), 3, 1)])
+    @pytest.mark.parametrize("values",
+                             [(('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-03.nofile', '2009-01-13.nofile'),
+                               (dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 13,
+                                            tzinfo=dt.timezone.utc)), 2, 2),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 2, 3),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-05.nofile', '2009-01-15.nofile'),
+                               (dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)), 3, 1)])
     def test_iterate_fname_season_with_frequency_and_width(self, values):
         """File season iteration with step/width>1, excludes stop bounds"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -2074,38 +2054,39 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 2, 2),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 3, 1),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 1, 4),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-05.nofile',
-                                          '2009-01-15.nofile'),
-                                         (dt.datetime(2009, 1, 5),
-                                          dt.datetime(2009, 1, 15)), 2, 3)])
+    @pytest.mark.parametrize("values",
+                             [(('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 2, 2),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 3, 1),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 1, 4),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-05.nofile', '2009-01-15.nofile'),
+                               (dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)), 2, 3)])
     def test_iterate_fname_season_with_frequency_and_width_incl(self, values):
         """File iteration in bounds with step/width>1, includes stop bounds"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -2114,26 +2095,32 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11), 2, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-12.nofile',
-                                         dt.datetime(2009, 1, 12), 2, 3),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-13.nofile',
-                                         dt.datetime(2009, 1, 13), 3, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-03.nofile',
-                                         dt.datetime(2009, 1, 3), 4, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-12.nofile',
-                                         dt.datetime(2009, 1, 12), 2, 1)])
+    @pytest.mark.parametrize("values",
+                             [('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 11,
+                                           tzinfo=dt.timezone.utc), 2, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-12.nofile',
+                               dt.datetime(2009, 1, 12,
+                                           tzinfo=dt.timezone.utc), 2, 3),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-13.nofile',
+                               dt.datetime(2009, 1, 13,
+                                           tzinfo=dt.timezone.utc), 3, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-03.nofile',
+                               dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                               4, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-12.nofile',
+                               dt.datetime(2009, 1, 12,
+                                           tzinfo=dt.timezone.utc), 2, 1)])
     def test_next_fname_with_frequency_and_width(self, values):
         """Test .next() via fname step/width>1, excludes stop file"""
         out = self.support_iter_evaluations(values)
@@ -2142,27 +2129,27 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 10),
-                                         2, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-09.nofile',
-                                         dt.datetime(2009, 1, 9),
-                                         4, 1),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         1, 3),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         1, 11),
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 10, tzinfo=dt.timezone.utc),
+                               2, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-09.nofile',
+                               dt.datetime(2009, 1, 9, tzinfo=dt.timezone.utc),
+                               4, 1),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               1, 3),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               1, 11)])
     def test_next_fname_with_frequency_and_width_incl(self, values):
         """Test .next() via fname step/width>1, includes stop file"""
         out = self.support_iter_evaluations(values)
@@ -2171,30 +2158,31 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-03.nofile',
-                                          '2009-01-13.nofile'),
-                                         (dt.datetime(2009, 1, 3),
-                                          dt.datetime(2009, 1, 13)), 2, 2),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 2, 3),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-05.nofile',
-                                          '2009-01-15.nofile'),
-                                         (dt.datetime(2009, 1, 5),
-                                          dt.datetime(2009, 1, 15)), 3, 1)])
+    @pytest.mark.parametrize("values",
+                             [(('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-03.nofile', '2009-01-13.nofile'),
+                               (dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 13,
+                                            tzinfo=dt.timezone.utc)), 2, 2),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 2, 3),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-05.nofile', '2009-01-15.nofile'),
+                               (dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)), 3, 1)])
     def test_next_fname_season_with_frequency_and_width(self, values):
         """File next season with step/width>1, excludes stop bounds"""
         out = self.support_iter_evaluations(values)
@@ -2203,38 +2191,39 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 2, 2),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 3, 1),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 1, 4),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-05.nofile',
-                                          '2009-01-15.nofile'),
-                                         (dt.datetime(2009, 1, 5),
-                                          dt.datetime(2009, 1, 15)), 2, 3)])
+    @pytest.mark.parametrize("values",
+                             [(('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 2, 2),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 3, 1),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 1, 4),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-05.nofile', '2009-01-15.nofile'),
+                               (dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)), 2, 3)])
     def test_next_fname_season_with_frequency_and_width_incl(self, values):
         """File next season with step/width>1, includes stop bounds"""
         out = self.support_iter_evaluations(values)
@@ -2243,31 +2232,32 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         2, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-12.nofile',
-                                         dt.datetime(2009, 1, 12),
-                                         2, 3),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-13.nofile',
-                                         dt.datetime(2009, 1, 13),
-                                         3, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-03.nofile',
-                                         dt.datetime(2009, 1, 3),
-                                         4, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-12.nofile',
-                                         dt.datetime(2009, 1, 12),
-                                         2, 1)])
+    @pytest.mark.parametrize("values",
+                             [('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               2, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-12.nofile',
+                               dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                               2, 3),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-13.nofile',
+                               dt.datetime(2009, 1, 13, tzinfo=dt.timezone.utc),
+                               3, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-03.nofile',
+                               dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                               4, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-12.nofile',
+                               dt.datetime(2009, 1, 12, tzinfo=dt.timezone.utc),
+                               2, 1)])
     def test_prev_fname_with_frequency_and_width(self, values):
         """Test prev() fname step/width>1, excludes stop bound"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -2276,27 +2266,27 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 10),
-                                         2, 2),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-09.nofile',
-                                         dt.datetime(2009, 1, 9),
-                                         4, 1),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         1, 3),
-                                        ('2009-01-01.nofile',
-                                         dt.datetime(2009, 1, 1),
-                                         '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         1, 11),
-                                        ])
+    @pytest.mark.parametrize("values",
+                             [('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 10, tzinfo=dt.timezone.utc),
+                               2, 2),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-09.nofile',
+                               dt.datetime(2009, 1, 9, tzinfo=dt.timezone.utc),
+                               4, 1),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               1, 3),
+                              ('2009-01-01.nofile',
+                               dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                               '2009-01-11.nofile',
+                               dt.datetime(2009, 1, 11, tzinfo=dt.timezone.utc),
+                               1, 11)])
     def test_prev_fname_with_frequency_and_width_incl(self, values):
         """Test prev() fname step/width>1, includes bounds stop date"""
 
@@ -2306,30 +2296,31 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-03.nofile',
-                                          '2009-01-13.nofile'),
-                                         (dt.datetime(2009, 1, 3),
-                                          dt.datetime(2009, 1, 13)), 2, 2),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 2, 3),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-05.nofile',
-                                          '2009-01-15.nofile'),
-                                         (dt.datetime(2009, 1, 5),
-                                          dt.datetime(2009, 1, 15)), 3, 1)])
+    @pytest.mark.parametrize("values",
+                             [(('2009-01-01.nofile',  '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-03.nofile', '2009-01-13.nofile'),
+                               (dt.datetime(2009, 1, 3, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 13,
+                                            tzinfo=dt.timezone.utc)), 2, 2),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 2, 3),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-05.nofile', '2009-01-15.nofile'),
+                               (dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)), 3, 1)])
     def test_prev_fname_season_with_frequency_and_width(self, values):
         """File prev season with step/width>1, excludes stop bounds"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -2338,38 +2329,39 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 2, 2),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 3, 1),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-04.nofile',
-                                          '2009-01-14.nofile'),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 14)), 1, 4),
-                                        (('2009-01-01.nofile',
-                                          '2009-01-11.nofile'),
-                                         (dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 11)),
-                                         ('2009-01-05.nofile',
-                                          '2009-01-15.nofile'),
-                                         (dt.datetime(2009, 1, 5),
-                                          dt.datetime(2009, 1, 15)), 2, 3)])
+    @pytest.mark.parametrize("values",
+                             [(('2009-01-01.nofile',  '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 2, 2),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 3, 1),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-04.nofile', '2009-01-14.nofile'),
+                               (dt.datetime(2009, 1, 4, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 14,
+                                            tzinfo=dt.timezone.utc)), 1, 4),
+                              (('2009-01-01.nofile', '2009-01-11.nofile'),
+                               (dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 11,
+                                            tzinfo=dt.timezone.utc)),
+                               ('2009-01-05.nofile', '2009-01-15.nofile'),
+                               (dt.datetime(2009, 1, 5, tzinfo=dt.timezone.utc),
+                                dt.datetime(2009, 1, 15,
+                                            tzinfo=dt.timezone.utc)), 2, 3)])
     def test_prev_fname_season_with_frequency_and_width_incl(self, values):
         """File prev season with step/width>1, includes stop bounds"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -2417,7 +2409,7 @@ class TestBasicsXarray(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 1
         self.out = None
 
@@ -2439,7 +2431,7 @@ class TestBasics2D(TestBasics):
                                          num_samples=50,
                                          clean_level='clean',
                                          update_files=True)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 1
         self.out = None
 
@@ -2464,7 +2456,7 @@ class TestBasicsShiftedFileDates(TestBasics):
                                          update_files=True,
                                          mangle_file_dates=True,
                                          strict_time_flag=True)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 1
         self.out = None
 
@@ -2488,7 +2480,7 @@ class TestMalformedIndex():
                                          malformed_index=True,
                                          update_files=True,
                                          strict_time_flag=True)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 1
 
     def teardown(self):
@@ -2524,7 +2516,7 @@ class TestMalformedIndexXarray(TestMalformedIndex):
                                          malformed_index=True,
                                          update_files=True,
                                          strict_time_flag=True)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 1
 
     def teardown(self):
@@ -2740,7 +2732,7 @@ class TestDataPadding():
                                          clean_level='clean',
                                          pad={'minutes': 5},
                                          update_files=True)
-        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_time = dt.datetime(2009, 1, 2, tzinfo=dt.timezone.utc)
         self.ref_doy = 2
 
     def teardown(self):
@@ -2914,7 +2906,7 @@ class TestDataPaddingXarray(TestDataPadding):
                                          clean_level='clean',
                                          pad={'minutes': 5},
                                          update_files=True)
-        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_time = dt.datetime(2009, 1, 2, tzinfo=dt.timezone.utc)
         self.ref_doy = 2
 
     def teardown(self):
@@ -2932,7 +2924,7 @@ class TestMultiFileRightDataPaddingBasics(TestDataPadding):
                                          sim_multi_file_right=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
-        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_time = dt.datetime(2009, 1, 2, tzinfo=dt.timezone.utc)
         self.ref_doy = 2
 
     def teardown(self):
@@ -2951,7 +2943,7 @@ class TestMultiFileRightDataPaddingBasicsXarray(TestDataPadding):
                                          sim_multi_file_right=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
-        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_time = dt.datetime(2009, 1, 2, tzinfo=dt.timezone.utc)
         self.ref_doy = 2
 
     def teardown(self):
@@ -2970,7 +2962,7 @@ class TestMultiFileLeftDataPaddingBasics(TestDataPadding):
                                          sim_multi_file_left=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
-        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_time = dt.datetime(2009, 1, 2, tzinfo=dt.timezone.utc)
         self.ref_doy = 2
 
     def teardown(self):
@@ -2989,7 +2981,7 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
                                          sim_multi_file_left=True,
                                          pad={'minutes': 5},
                                          multi_file_day=True)
-        self.ref_time = dt.datetime(2009, 1, 2)
+        self.ref_time = dt.datetime(2009, 1, 2, tzinfo=dt.timezone.utc)
         self.ref_doy = 2
 
     def teardown(self):
@@ -3026,7 +3018,7 @@ class TestInstListGeneration():
             assert 'broken_inst' not in dict['inst_module'].__name__
 
     def test_for_missing_test_date(self):
-        """Check that instruments without _test_dates are still added to the list
+        """Check that instruments without _test_dates are still included
         """
         del self.test_library.pysat_testing._test_dates
         # If an instrument does not have the _test_dates attribute, it should

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -30,7 +30,7 @@ class TestBasics():
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 1
         self.out = None
 
@@ -129,7 +129,8 @@ class TestBasics():
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_basic_instrument_load_two_days(self):
@@ -139,7 +140,8 @@ class TestBasics():
                            self.ref_time.year, self.ref_doy + 2)
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
         self.out = self.testInst.index[-1]
         assert (self.out >= self.ref_time + pds.DateOffset(days=1))
@@ -195,18 +197,25 @@ class TestBasics():
         return
 
     @pytest.mark.parametrize("input", [{'yr': 2009, 'doy': 1,
-                                        'date': dt.datetime(2009, 1, 1)},
+                                        'date': dt.datetime(
+                                            2009, 1, 1,
+                                            tzinfo=dt.timezone.utc)},
                                        {'yr': 2009, 'doy': 1,
-                                        'end_date': dt.datetime(2009, 1, 1)},
+                                        'end_date': dt.datetime(
+                                            2009, 1, 1,
+                                            tzinfo=dt.timezone.utc)},
                                        {'yr': 2009, 'doy': 1,
                                         'fname': 'dummy_str.nofile'},
                                        {'yr': 2009, 'doy': 1,
                                         'stop_fname': 'dummy_str.nofile'},
-                                       {'date': dt.datetime(2009, 1, 1),
+                                       {'date': dt.datetime(
+                                           2009, 1, 1, tzinfo=dt.timezone.utc),
                                         'fname': 'dummy_str.nofile'},
-                                       {'date': dt.datetime(2009, 1, 1),
+                                       {'date': dt.datetime(
+                                           2009, 1, 1, tzinfo=dt.timezone.utc),
                                         'stop_fname': 'dummy_str.nofile'},
-                                       {'date': dt.datetime(2009, 1, 1),
+                                       {'date': dt.datetime(
+                                           2009, 1, 1, tzinfo=dt.timezone.utc),
                                         'fname': 'dummy_str.nofile',
                                         'end_yr': 2009, 'end_doy': 1}])
     def test_basic_instrument_load_mixed_inputs(self, input):
@@ -261,7 +270,8 @@ class TestBasics():
         self.testInst.load(date=self.ref_time)
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_basic_instrument_load_by_dates(self):
@@ -270,7 +280,8 @@ class TestBasics():
         self.testInst.load(date=self.ref_time, end_date=end_date)
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
         self.out = self.testInst.index[-1]
         assert (self.out >= self.ref_time + pds.DateOffset(days=1))
@@ -279,10 +290,12 @@ class TestBasics():
     def test_basic_instrument_load_by_date_with_extra_time(self):
         """Ensure .load(date=date) only uses year, month, day portion of date"""
         # put in a date that has more than year, month, day
-        self.testInst.load(date=dt.datetime(2009, 1, 1, 1, 1, 1))
+        self.testInst.load(date=dt.datetime(2009, 1, 1, 1, 1, 1,
+                                            tzinfo=dt.timezone.utc))
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_basic_instrument_load_data(self):
@@ -293,32 +306,35 @@ class TestBasics():
 
     def test_basic_instrument_load_leap_year(self):
         """Test if the correct day is being loaded (Leap-Year)."""
-        self.ref_time = dt.datetime(2008, 12, 31)
+        self.ref_time = dt.datetime(2008, 12, 31, tzinfo=dt.timezone.utc)
         self.ref_doy = 366
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_next_load_default(self):
         """Test if first day is loaded by default when first invoking .next.
         """
-        self.ref_time = dt.datetime(2008, 1, 1)
+        self.ref_time = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
         self.testInst.next()
         self.out = self.testInst.index[0]
         assert self.out == self.ref_time
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_prev_load_default(self):
         """Test if last day is loaded by default when first invoking .prev.
         """
-        self.ref_time = dt.datetime(2010, 12, 31)
+        self.ref_time = dt.datetime(2010, 12, 31, tzinfo=dt.timezone.utc)
         self.testInst.prev()
         self.out = self.testInst.index[0]
         assert self.out == self.ref_time
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_next_load_bad_start_file(self):
@@ -368,7 +384,7 @@ class TestBasics():
     def test_prev_load_bad_start_date(self):
         """Test Error if trying to iterate when on a date not in iteration list
         """
-        self.ref_time = dt.datetime(2008, 1, 2)
+        self.ref_time = dt.datetime(2008, 1, 2, tzinfo=dt.timezone.utc)
         self.testInst.load(date=self.ref_time)
         # set new bounds that doesn't include this date
         self.testInst.bounds = (self.ref_time + pds.DateOffset(days=1),
@@ -405,32 +421,35 @@ class TestBasics():
 
     def test_next_fname_load_default(self):
         """Test next day is being loaded (checking object date)."""
-        self.ref_time = dt.datetime(2008, 1, 2)
+        self.ref_time = dt.datetime(2008, 1, 2, tzinfo=dt.timezone.utc)
         self.testInst.load(fname=self.testInst.files[0])
         self.testInst.next()
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_prev_fname_load_default(self):
         """Test prev day is loaded when invoking .prev."""
-        self.ref_time = dt.datetime(2008, 1, 3)
+        self.ref_time = dt.datetime(2008, 1, 3, tzinfo=dt.timezone.utc)
         self.testInst.load(fname=self.testInst.files[3])
         self.testInst.prev()
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_basic_fname_instrument_load(self):
         """Test loading by filename from attached .files.
         """
-        self.ref_time = dt.datetime(2008, 1, 1)
+        self.ref_time = dt.datetime(2008, 1, 1, tzinfo=dt.timezone.utc)
         self.testInst.load(fname=self.testInst.files[0])
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_filename_load(self):
@@ -467,7 +486,8 @@ class TestBasics():
         self.testInst.next()
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time + dt.timedelta(days=1))
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_prev_filename_load_default(self):
@@ -476,7 +496,8 @@ class TestBasics():
         self.testInst.prev()
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time - dt.timedelta(days=1))
-        self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
+        self.out = dt.datetime(self.out.year, self.out.month, self.out.day,
+                               tzinfo=dt.timezone.utc)
         assert (self.out == self.testInst.date)
 
     def test_list_files(self):
@@ -553,23 +574,23 @@ class TestBasics():
     #
     # -------------------------------------------------------------------------
     def test_today_yesterday_and_tomorrow(self):
-        self.ref_time = dt.datetime.now()
+        self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
-                               self.ref_time.day)
+                               self.ref_time.day, tzinfo=dt.timezone.utc)
         assert self.out == self.testInst.today()
         assert self.out - pds.DateOffset(days=1) == self.testInst.yesterday()
         assert self.out + pds.DateOffset(days=1) == self.testInst.tomorrow()
 
     def test_filter_datetime(self):
-        self.ref_time = dt.datetime.now()
+        self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
-                               self.ref_time.day)
+                               self.ref_time.day, tzinfo=dt.timezone.utc)
         assert self.out == self.testInst._filter_datetime_input(self.ref_time)
 
     def test_filtered_date_attribute(self):
-        self.ref_time = dt.datetime.now()
+        self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
-                               self.ref_time.day)
+                               self.ref_time.day, tzinfo=dt.timezone.utc)
         self.testInst.date = self.ref_time
         assert self.out == self.testInst.date
 
@@ -785,7 +806,7 @@ class TestBasics():
         import pysat.instruments.pysat_testing as test
         self.out = pysat.Instrument(inst_module=test, tag='',
                                     clean_level='clean')
-        self.ref_time = dt.datetime(2009, 2, 1)
+        self.ref_time = dt.datetime(2009, 2, 1, tzinfo=dt.timezone.utc)
         self.ref_doy = 32
         self.out.load(self.ref_time.year, self.ref_doy)
         assert self.out.date == self.ref_time
@@ -858,7 +879,7 @@ class TestBasics():
 
     def test_data_access_by_datetime_and_name(self):
         self.testInst.load(self.ref_time.year, self.ref_doy)
-        self.out = dt.datetime(2009, 1, 1, 0, 0, 0)
+        self.out = dt.datetime(2009, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
         assert np.all(self.testInst[self.out, 'uts']
                       == self.testInst.data['uts'].values[0])
 
@@ -867,7 +888,7 @@ class TestBasics():
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
         offset = pds.DateOffset(seconds=(10 * time_step))
-        start = dt.datetime(2009, 1, 1, 0, 0, 0)
+        start = dt.datetime(2009, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
         stop = start + offset
         assert np.all(self.testInst[start:stop, 'uts']
                       == self.testInst.data['uts'].values[0:11])
@@ -967,7 +988,8 @@ class TestBasics():
     def test_setting_partial_data_by_datetime_and_name(self):
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
-        self.testInst[dt.datetime(2009, 1, 1, 0, 0, 0), 'doubleMLT'] = 0
+        self.testInst[dt.datetime(2009, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc),
+                      'doubleMLT'] = 0
         assert np.all(self.testInst[0, 'doubleMLT']
                       == 2. * self.testInst[0, 'mlt'])
         assert np.all(self.testInst[0, 'doubleMLT'] == 0)
@@ -978,7 +1000,7 @@ class TestBasics():
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
         offset = pds.DateOffset(seconds=(10 * time_step))
-        start = dt.datetime(2009, 1, 1, 0, 0, 0)
+        start = dt.datetime(2009, 1, 1, 0, 0, 0, tzinfo=dt.timezone.utc)
         stop = start + offset
         self.testInst[start:stop, 'doubleMLT'] = 0
         assert np.all(self.testInst[11:, 'doubleMLT']
@@ -1300,18 +1322,26 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 3), '2D',
-                                         pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 4), '2D',
-                                         pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 5), '3D',
-                                         pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 17), '5D',
-                                         pds.DateOffset(days=1))
+    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 3,
+                                                     tzinfo=dt.timezone.utc),
+                                         '2D', pds.DateOffset(days=2)),
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 4,
+                                                     tzinfo=dt.timezone.utc),
+                                         '2D', pds.DateOffset(days=3)),
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 5,
+                                                     tzinfo=dt.timezone.utc),
+                                         '3D', pds.DateOffset(days=1)),
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 17,
+                                                     tzinfo=dt.timezone.utc),
+                                         '5D', pds.DateOffset(days=1))
                                         ])
     def test_iterate_bounds_with_frequency_and_width(self, values):
         """Iterate via date with mixed step/width, excludes stop date"""
@@ -1321,23 +1351,35 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 4), '2D',
+    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 4,
+                                                     tzinfo=dt.timezone.utc), '2D',
                                          pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 4), '3D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 4,
+                                                     tzinfo=dt.timezone.utc), '3D',
                                          pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 4), '1D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 4,
+                                                     tzinfo=dt.timezone.utc), '1D',
                                          pds.DateOffset(days=4)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 5), '4D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 5,
+                                                     tzinfo=dt.timezone.utc), '4D',
                                          pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 5), '2D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 5,
+                                                     tzinfo=dt.timezone.utc), '2D',
                                          pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 5), '3D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 5,
+                                                     tzinfo=dt.timezone.utc), '3D',
                                          pds.DateOffset(days=2))])
     def test_iterate_bounds_with_frequency_and_width_incl(self, values):
         """Iterate via date with mixed step/width, includes stop date"""
@@ -1347,17 +1389,25 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 10), '2D',
+    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc), '2D',
                                          pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 9), '4D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 9,
+                                                     tzinfo=dt.timezone.utc), '4D',
                                          pds.DateOffset(days=1)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 11), '1D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 11,
+                                                     tzinfo=dt.timezone.utc), '1D',
                                          pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 11), '1D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 11,
+                                                     tzinfo=dt.timezone.utc), '1D',
                                          pds.DateOffset(days=11)),
                                         ])
     def test_next_date_with_frequency_and_width_incl(self, values):
@@ -1368,20 +1418,30 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 11), '2D',
+    @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 11,
+                                                     tzinfo=dt.timezone.utc), '2D',
                                          pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 12), '2D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 12,
+                                                     tzinfo=dt.timezone.utc), '2D',
                                          pds.DateOffset(days=3)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 13), '3D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 13,
+                                                     tzinfo=dt.timezone.utc), '3D',
                                          pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 3), '4D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 3,
+                                                     tzinfo=dt.timezone.utc), '4D',
                                          pds.DateOffset(days=2)),
-                                        (dt.datetime(2009, 1, 1),
-                                         dt.datetime(2009, 1, 12), '2D',
+                                        (dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                         dt.datetime(2009, 1, 12,
+                                                     tzinfo=dt.timezone.utc), '2D',
                                          pds.DateOffset(days=1))])
     def test_next_date_with_frequency_and_width(self, values):
         """Test .next() via date step/width>1, excludes stop date"""
@@ -1391,22 +1451,34 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 4),
-                                          dt.datetime(2009, 1, 13)),
+    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc)),
+                                         (dt.datetime(2009, 1, 4,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 13,
+                                                     tzinfo=dt.timezone.utc)),
                                          '2D',
                                          pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 7),
-                                          dt.datetime(2009, 1, 16)),
+                                        ((dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc)),
+                                         (dt.datetime(2009, 1, 7,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 16,
+                                                     tzinfo=dt.timezone.utc)),
                                          '3D',
                                          pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 6),
-                                          dt.datetime(2009, 1, 15)),
+                                        ((dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc)),
+                                         (dt.datetime(2009, 1, 6,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 15,
+                                                     tzinfo=dt.timezone.utc)),
                                          '2D',
                                          pds.DateOffset(days=4))
                                         ])
@@ -1418,22 +1490,34 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 3),
-                                          dt.datetime(2009, 1, 12)),
+    @pytest.mark.parametrize("values", [((dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc)),
+                                         (dt.datetime(2009, 1, 3,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 12,
+                                                     tzinfo=dt.timezone.utc)),
                                          '2D',
                                          pds.DateOffset(days=2)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 6),
-                                          dt.datetime(2009, 1, 15)),
+                                        ((dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc)),
+                                         (dt.datetime(2009, 1, 6,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 15,
+                                                     tzinfo=dt.timezone.utc)),
                                          '3D',
                                          pds.DateOffset(days=1)),
-                                        ((dt.datetime(2009, 1, 1),
-                                          dt.datetime(2009, 1, 10)),
-                                         (dt.datetime(2009, 1, 7),
-                                          dt.datetime(2009, 1, 16)),
+                                        ((dt.datetime(2009, 1, 1,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 10,
+                                                     tzinfo=dt.timezone.utc)),
+                                         (dt.datetime(2009, 1, 7,
+                                                     tzinfo=dt.timezone.utc),
+                                          dt.datetime(2009, 1, 16,
+                                                     tzinfo=dt.timezone.utc)),
                                          '2D',
                                          pds.DateOffset(days=4))
                                         ])

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -558,7 +558,7 @@ def generate_instrument_list(inst_loc):
                 # other tests.  This will be caught later by
                 # InstTestClass.test_instrument_test_dates
                 info = {}
-                info[''] = {'': dt.datetime(2009, 1, 1)}
+                info[''] = {'': dt.datetime(2009, 1, 1, tzinfo=dt.timezone.utc)}
                 module._test_dates = info
             for inst_id in info.keys():
                 for tag in info[inst_id].keys():

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -35,7 +35,7 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     ----
         If two files have the same date and time information in the
         filename then the file with the higher version/revision/cycle is used.
-        Series returned only has one file der datetime. Version is required
+        Series returned only has one file per datetime. Version is required
         for this filtering, revision and cycle are optional.
 
     """

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -262,7 +262,7 @@ def set_timezone_to_utc(in_time, naive_is_utc=False):
     # this is true.  If tzinfo is not None, it will have a utcoffset method.
     if in_time.tzinfo is None or in_time.utcoffset() is None:
         if naive_is_utc:
-            out_time = in_time.astimezone(tz=dt.timezone.utc)
+            out_time = in_time.replace(tzinfo=dt.timezone.utc)
         else:
             raise TypeError('datetime input is naive and may not be in UTC')
     else:


### PR DESCRIPTION
# Description

Implements aware timestamps throughout the core code, will address #514 

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

This has been tested by running the new unit tests in `test_utils_time`.  Stated running through old unit tests and `test_instrument` fails.  Not sure if this is due to the current way file information is saved?

I see the benefits of using aware datetime objects, especially with the SpaceWeather instruments, but most people I know don't use them.  Do we want to require this as input?  How lax/strict should we be?


```______________________________________ ERROR at setup of TestBasics.test_basic_instrument_load _______________________________________

self = <pysat.tests.test_instrument.TestBasics object at 0x10a567fd0>

    def setup(self):
        reload(pysat.instruments.pysat_testing)
        """Runs before every method to create a clean testing setup."""
        self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                         num_samples=10,
                                         clean_level='clean',
>                                        update_files=True)

pysat/tests/test_instrument.py:32: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
pysat/_instrument.py:377: in __init__
    ignore_empty_files=ignore_empty_files)
pysat/_files.py:179: in __init__
    self.refresh()
pysat/_files.py:394: in refresh
    self._store()
pysat/_files.py:300: in _store
    if stored_files.eq(self.files).all():
../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/ops.py:1870: in flex_wrapper
    return self._binop(other, op, level=level, fill_value=fill_value)
../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/series.py:2452: in _binop
    copy=False)
../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/series.py:3664: in align
    broadcast_axis=broadcast_axis)
../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/generic.py:8428: in align
    fill_axis=fill_axis)
../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/generic.py:8497: in _align_series
    return_indexers=True)
../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/indexes/datetimes.py:781: in join
    this, other = self._maybe_utc_convert(other)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = DatetimeIndex(['2008-01-01', '2008-01-02', '2008-01-03', '2008-01-04',
               '2008-01-05', '2008-01-06', '200...-29',
               '2010-12-30', '2010-12-31'],
              dtype='datetime64[ns]', name=0, length=1096, freq=None)
other = DatetimeIndex(['2008-01-01 00:00:00+00:00', '2008-01-02 00:00:00+00:00',
               '2008-01-03 00:00:00+00:00', '...-12-30 00:00:00+00:00', '2010-12-31 00:00:00+00:00'],
              dtype='datetime64[ns, UTC]', length=1096, freq='D')

    def _maybe_utc_convert(self, other):
        this = self
        if isinstance(other, DatetimeIndex):
            if self.tz is not None:
                if other.tz is None:
                    raise TypeError('Cannot join tz-naive with tz-aware '
                                    'DatetimeIndex')
            elif other.tz is not None:
>               raise TypeError('Cannot join tz-naive with tz-aware '
                                'DatetimeIndex')
E               TypeError: Cannot join tz-naive with tz-aware DatetimeIndex

../../../Library/Python/3.7/lib/python/site-packages/pandas-0.24.2-py3.7-macosx-10.14-x86_64.egg/pandas/core/indexes/datetimes.py:793: TypeError
====================================================== short test summary info =======================================================
ERROR pysat/tests/test_instrument.py::TestBasics::test_basic_instrument_load - TypeError: Cannot join tz-naive with tz-aware Dateti...
========================================================== 1 error in 2.09s ==========================================================
```

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
