### PR TITLE
TST: update test_files.py structure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-09-17
+## [3.0.0] - 2020-12-03
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -86,6 +86,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Simplified internal logic in Instrument class
   - Updated Instrument.concat_func to behave as described in the docstring
   - Moved setup metadata to setup.cfg
+  - Improve instrument tests for files
 
 ## [2.2.2] - 2020-12-31
  - New Features

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -15,7 +15,6 @@ import tempfile
 
 import pysat
 import pysat.instruments.pysat_testing
-from pysat.utils import files as futils
 from pysat.utils import NetworkLock
 
 
@@ -154,38 +153,6 @@ class TestBasics():
         assert self.out.find('Number of files') > 0
         # Test no files
         assert self.out.find('Date Range') > 0
-
-    def test_parse_delimited_filename(self):
-        """Check ability to parse delimited files"""
-        # Note: Can be removed if future instrument that uses delimited
-        # filenames is added to routine travis end-to-end testing
-        fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',
-                         '_{minute:2d}_{second:2d}_{version:2s}_r02.cdf'))
-        year = np.ones(6) * 2009
-        month = np.ones(6) * 12
-        day = np.array([12, 15, 17, 19, 22, 24])
-        hour = np.array([8, 10, 6, 18, 3, 23])
-        minute = np.array([8, 10, 6, 18, 3, 59])
-        second = np.array([58, 11, 26, 2, 18, 59])
-        version = np.array(['v1', 'v2', 'r1', 'r3', 'v5', 'a6'])
-        file_list = []
-        for i in range(6):
-            file_list.append(fname.format(year=year[i].astype(int),
-                                          month=month[i].astype(int),
-                                          day=day[i], hour=hour[i],
-                                          minute=minute[i], second=second[i],
-                                          version=version[i]))
-
-        file_dict = futils.parse_delimited_filenames(file_list, fname, '_')
-        assert np.all(file_dict['year'] == year)
-        assert np.all(file_dict['month'] == month)
-        assert np.all(file_dict['day'] == day)
-        assert np.all(file_dict['hour'] == hour)
-        assert np.all(file_dict['minute'] == minute)
-        assert np.all(file_dict['day'] == day)
-        assert np.all(file_dict['version'] == version)
-        assert (file_dict['revision'] is None)
-        assert (file_dict['cycle'] is None)
 
     def test_year_doy_files_direct_call_to_from_os(self):
         # create a bunch of files by year and doy

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -170,6 +170,9 @@ class TestBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         self.out = ''
+        # Use a two-year as default.  Some tests will use custom ranges.
+        self.start = dt.datetime(2008, 1, 1)
+        self.stop = dt.datetime(2009, 12, 31)
 
         # store current pysat directory
         self.data_path = pysat.data_dir
@@ -189,7 +192,7 @@ class TestBasics():
         """Runs after every method to clean up previous testing."""
         pysat.utils.set_data_dir(self.data_path, store=False)
         self.tempdir.cleanup()
-        del self.testInst, self.out, self.tempdir
+        del self.testInst, self.out, self.tempdir, self.start, self.stop
 
     def test_basic_repr(self):
         """The repr output will match the str output"""
@@ -209,12 +212,10 @@ class TestBasics():
     def test_year_doy_files_directly_call_from_os(self):
         """Check that Files.from_os generates file list"""
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
-        create_files(self.testInst, start, stop, freq='1D',
-                     version=self.version)
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_',
                               '{day:03d}_stuff.pysat_testing_file'))
+        create_files(self.testInst, self.start, self.stop, freq='1D',
+                     root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
                                     format_str=root_fname)
@@ -228,11 +229,9 @@ class TestBasics():
     def test_year_doy_files_no_gap_in_name_directly_call_from_os(self):
         """Files.from_os generates file list for date w/o delimiter"""
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
         root_fname = ''.join(('pysat_testing_junk_{year:04d}{day:03d}_stuff.',
                               'pysat_testing_file'))
-        create_files(self.testInst, start, stop, freq='1D',
+        create_files(self.testInst, self.start, self.stop, freq='1D',
                      root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
@@ -247,11 +246,9 @@ class TestBasics():
     def test_year_month_day_files_directly_call_from_os(self):
         """Files.from_os generates file list for date w/ month"""
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}',
                               '_stuff_{month:02d}.pysat_testing_file'))
-        create_files(self.testInst, start, stop, freq='1D',
+        create_files(self.testInst, self.start, self.stop, freq='1D',
                      use_doy=False, root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
@@ -266,12 +263,10 @@ class TestBasics():
     def test_year_month_day_hour_files_directly_call_from_os(self):
         """Files.from_os generates file list for date w hours"""
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}',
                               '_stuff_{month:02d}_{hour:02d}.pysat_testing',
                               '_file'))
-        create_files(self.testInst, start, stop, freq='6h',
+        create_files(self.testInst, self.start, self.stop, freq='6h',
                      use_doy=False, root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
@@ -328,11 +323,9 @@ class TestBasics():
     def test_year_month_files_direct_call_to_from_os(self):
         """Files.from_os generates file list for monthly files"""
         # create a bunch of files by year and doy
-        start = dt.datetime(2008, 1, 1)
-        stop = dt.datetime(2009, 12, 31)
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_stuff',
                               '_{month:02d}.pysat_testing_file'))
-        create_files(self.testInst, start, stop, freq='1MS',
+        create_files(self.testInst, self.start, self.stop, freq='1MS',
                      root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
@@ -413,9 +406,13 @@ class TestInstWithFiles():
                                    '{day:03d}_stuff_{month:02d}_{hour:02d}_',
                                    '{minute:02d}_{second:02d}.pysat_testing_',
                                    'file'))
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        create_files(self.testInst, start, stop, freq='100min',
+        # Default file range.  Some tests will use custom ranges.
+        self.start = dt.datetime(2007, 12, 31)
+        self.stop = dt.datetime(2008, 1, 10)
+        self.start2 = dt.datetime(2008, 1, 11)
+        self.stop2 = dt.datetime(2008, 1, 12)
+
+        create_files(self.testInst, self.start, self.stop, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
 
@@ -439,7 +436,7 @@ class TestInstWithFiles():
                          temporary_file_list=self.temporary_file_list)
         pysat.utils.set_data_dir(self.data_path, store=False)
         self.tempdir.cleanup()
-        del self.tempdir
+        del self.tempdir, self.start, self.stop, self.start2, self.stop2
 
     def test_refresh(self):
         """Check that refresh updates the files"""
@@ -463,21 +460,19 @@ class TestInstWithFiles():
         assert len(self.testInst.files.files) == 0
 
         # create new files with content and make sure they are captured
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start, self.stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname,
                      content='test', version=self.version)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start, self.stop,
+                                                   freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_refresh_on_unchanged_files(self):
         """Make sure new refresh does not duplicate files"""
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start, self.stop,
+                                                   freq='100min')
         assert (np.all(self.testInst.files.files.index == dates))
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
@@ -494,38 +489,33 @@ class TestInstWithFiles():
         assert len(self.testInst.files.files) == 0
 
         # create new files with content and make sure they are captured
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start, self.stop, freq='100min',
                      use_doy=False, root_fname=self.root_fname, content='test',
                      version=self.version)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start, self.stop,
+                                                   freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_get_new_files_after_adding_files(self):
         """Check that get_new locates new files"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start2, self.stop2, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start2, self.stop2,
+                                                   freq='100min')
         new_files = self.testInst.files.get_new()
         assert (np.all(new_files.index == dates))
 
     def test_get_new_files_after_refresh(self):
         """Check that get_new locates new files after refresh"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start2, self.stop2, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start2, self.stop2,
+                                                   freq='100min')
         self.testInst.files.refresh()
         new_files = self.testInst.files.get_new()
 
@@ -534,13 +524,11 @@ class TestInstWithFiles():
     def test_get_new_files_after_multiple_refreshes(self):
         """Check that get_new locates new files after multiple refreshes"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start2, self.stop2, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start2, self.stop2,
+                                                   freq='100min')
         self.testInst.files.refresh()
         self.testInst.files.refresh()
         self.testInst.files.refresh()
@@ -550,13 +538,11 @@ class TestInstWithFiles():
     def test_get_new_files_after_adding_files_and_adding_file(self):
         """Check that get_new works after multiple rounds of added files"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start2, self.stop2, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start2, self.stop2,
+                                                   freq='100min')
         new_files = self.testInst.files.get_new()
 
         start = dt.datetime(2008, 1, 15)
@@ -573,9 +559,8 @@ class TestInstWithFiles():
     def test_get_new_files_after_deleting_files_and_adding_files(self):
         """Check that get_new works after deleting and adding files"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start2, self.stop2,
+                                                   freq='100min')
 
         # remove files, same number as will be added
         to_be_removed = len(dates)
@@ -588,7 +573,7 @@ class TestInstWithFiles():
                     to_be_removed -= 1
                     os.unlink(file_path)
         # add new files
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start2, self.stop2, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
         # get new files
@@ -611,6 +596,8 @@ class TestInstWithFilesNonStandard():
         self.tempdir = tempfile.TemporaryDirectory()
         pysat.utils.set_data_dir(self.tempdir.name, store=False)
 
+        self.start = dt.datetime(2008, 1, 11)
+        self.stop = dt.datetime(2008, 1, 15)
         self.root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_',
                                    '{day:03d}_stuff_{month:02d}_{hour:02d}_',
                                    '{minute:02d}_{second:02d}.pysat_testing_',
@@ -637,13 +624,13 @@ class TestInstWithFilesNonStandard():
                          update_files=True,
                          temporary_file_list=self.temporary_file_list)
         pysat.utils.set_data_dir(self.data_path, store=False)
+        del self.start, self.stop
 
     def test_files_non_standard_pysat_directory(self):
         """Check that files work with a weird directory structure"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        dates = pysat.utils.time.create_date_range(self.start, self.stop,
+                                                   freq='100min')
 
         nonstandard_dir = 'pysat_testing_{tag}_{inst_id}'
 
@@ -656,7 +643,7 @@ class TestInstWithFilesNonStandard():
                              temporary_file_list=self.temporary_file_list)
         # add new files
         create_dir(self.testInst)
-        create_files(self.testInst, start, stop, freq='100min',
+        create_files(self.testInst, self.start, self.stop, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
 
@@ -671,9 +658,8 @@ class TestInstWithFilesNonStandard():
     def test_files_non_standard_file_format_template(self):
         """Check that files work if format has a weird heirarchy"""
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
+        dates = pysat.utils.time.create_date_range(self.start, self.stop,
+                                                   freq='1D')
         if self.version:
             root_fname = ''.join(('pysat_testing_unique_{version:02d}_',
                                   '{revision:03d}_{cycle:02d}_{year:04d}',
@@ -691,7 +677,7 @@ class TestInstWithFilesNonStandard():
 
         # add new files
         create_dir(self.testInst)
-        create_files(self.testInst, start, stop, freq='1D',
+        create_files(self.testInst, self.start, self.stop, freq='1D',
                      use_doy=False, root_fname=root_fname, version=self.version)
         # refresh file list
         self.testInst.files.refresh()
@@ -747,9 +733,8 @@ class TestInstWithVersionedFilesNonStandard(TestInstWithFilesNonStandard):
 
     def test_files_when_duplicates_forced(self):
         # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
+        dates = pysat.utils.time.create_date_range(self.start, self.stop,
+                                                   freq='1D')
 
         file_format = ''.join(('pysat_testing_unique_{version:02d}_',
                                '{revision:03d}_{cycle:02d}_{year:04d}',
@@ -763,7 +748,7 @@ class TestInstWithVersionedFilesNonStandard(TestInstWithFilesNonStandard):
 
         # add new files
         create_dir(self.testInst)
-        create_files(self.testInst, start, stop, freq='1D',
+        create_files(self.testInst, self.start, self.stop, freq='1D',
                      use_doy=False, root_fname=file_format,
                      version=self.version)
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -709,8 +709,14 @@ class TestInstWithFilesNonStandard():
                                  temporary_file_list=self.temporary_file_list)
 
 
-class TestInstWithFilesNoFileListStorage(TestInstWithFiles,
-                                         TestInstWithFilesNonStandard):
+class TestInstWithFilesNoFileListStorage(TestInstWithFiles):
+    """Repeat all file tests with a temporary file list"""
+
+    temporary_file_list = True
+    version = False
+
+
+class TestInstWithFilesNoFileListStorageNonStd(TestInstWithFilesNonStandard):
     """Repeat all file tests with a temporary file list"""
 
     temporary_file_list = True

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -2,7 +2,7 @@
 tests the pysat meta object and code
 """
 import datetime as dt
-import glob
+import functools
 from importlib import reload
 import numpy as np
 import os
@@ -19,6 +19,7 @@ from pysat.utils import NetworkLock
 
 
 def create_dir(inst=None, temporary_file_list=False):
+    """Create a temporary datset directory for a test instrument"""
     if inst is None:
         # create instrument
         inst = pysat.Instrument(platform='pysat', name='testing',
@@ -28,24 +29,46 @@ def create_dir(inst=None, temporary_file_list=False):
     try:
         os.makedirs(inst.files.data_path)
     except OSError:
+        # File already exists
         pass
     return
 
 
-def remove_files(inst=None):
-    # remove any files like pysat_testing_junk_
-    temp_dir = inst.files.data_path
-    for the_file in os.listdir(temp_dir):
-        if ((the_file[0:13] == 'pysat_testing')
-                and (the_file[-19:] == '.pysat_testing_file')):
-            file_path = os.path.join(temp_dir, the_file)
-            if os.path.isfile(file_path):
-                os.unlink(file_path)
-
-
-# create year doy file set
 def create_files(inst, start, stop, freq=None, use_doy=True, root_fname=None,
-                 content=None, timeout=None):
+                 version=False, content=None, timeout=None):
+    """Create year doy file set
+
+    Parameters
+    ----------
+    inst : pysat.Instrument
+        A test instrument, used to generate file path
+    start : dt.datetime
+        The date for the first file to create
+    stop : dt.datetime
+        The date for the last file to create
+    freq : str
+        Frequency of file output.  Ex: '1D', '100min'
+        (default=None)
+    use_doy : bool
+        If True, use Day of Year (doy)
+        If False, use month / day
+        (default=True)
+    root_fname : str
+        The format of the file name to create.  Uses standard pysat variables.
+        Ex: 'pysat_testing_junk_{year:04d}_{day:03d}.txt'
+        (default=None)
+    version : bool
+        If True, iterate over version / revision / cycle
+        If False, ignore version / revision / cycle
+        (default=False)
+    content : str
+        Custom text to write to temporary files
+        (default=None)
+    timeout : float
+        Time is seconds to lock the files being created.  If None, no timeout is
+        used.  (default=None)
+
+    """
 
     if freq is None:
         freq = '1D'
@@ -54,6 +77,15 @@ def create_files(inst, start, stop, freq=None, use_doy=True, root_fname=None,
     if root_fname is None:
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
                               'stuff.pysat_testing_file'))
+    if version:
+        versions = np.array([1, 2])
+        revisions = np.array([0, 1])
+        cycles = np.array([0, 1])
+    else:
+        versions = [None]
+        revisions = [None]
+        cycles = [None]
+
     # create empty file
     for date in dates:
         yr, doy = pysat.utils.time.getyrdoy(date)
@@ -61,24 +93,42 @@ def create_files(inst, start, stop, freq=None, use_doy=True, root_fname=None,
             doy = doy
         else:
             doy = date.day
+        for version in versions:
+            for revision in revisions:
+                for cycle in cycles:
 
-        fname = os.path.join(inst.files.data_path, root_fname.format(year=yr,
-                             day=doy, month=date.month, hour=date.hour,
-                             minute=date.minute, second=date.second))
-        with NetworkLock(fname, 'w') as fout:
-            if content is not None:
-                fout.write(content)
-            if timeout is not None:
-                time.sleep(timeout)
+                    fname = os.path.join(inst.files.data_path,
+                                         root_fname.format(year=yr,
+                                                           day=doy,
+                                                           month=date.month,
+                                                           hour=date.hour,
+                                                           minute=date.minute,
+                                                           second=date.second,
+                                                           version=version,
+                                                           revision=revision,
+                                                           cycle=cycle))
+                    with NetworkLock(fname, 'w') as fout:
+                        if content is not None:
+                            fout.write(content)
+                        if timeout is not None:
+                            time.sleep(timeout)
 
 
-def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
-    """Return a Pandas Series of every file for chosen satellite data"""
+def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
+               version=False):
+    """Return a Pandas Series of every file for chosen instrument data"""
 
     if format_str is None:
-        format_str = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
-                              'stuff_{month:02d}_{hour:02d}_{minute:02d}_',
-                              '{second:02d}.pysat_testing_file'))
+        if version:
+            format_str = ''.join(('pysat_testing_junk_{year:04d}_{month:02d}_',
+                                  '{day:03d}{hour:02d}{minute:02d}{second:02d}',
+                                  '_stuff_{version:02d}_{revision:03d}_',
+                                  '{cycle:02d}.pysat_testing_file'))
+        else:
+            format_str = ''.join(('pysat_testing_junk_{year:04d}_gold_',
+                                  '{day:03d}_stuff_{month:02d}_{hour:02d}_',
+                                  '{minute:02d}_{second:02d}.',
+                                  'pysat_testing_file'))
 
     if tag is not None:
         if tag == '':
@@ -107,13 +157,15 @@ class TestNoDataDir():
         reload(pysat._files)
 
     def test_no_data_dir(self):
-        with pytest.raises(Exception):
-            _ = pysat.Instrument()
+        """Instrument should error if no data directory is specified."""
+        with pytest.raises(RuntimeError):
+            pysat.Instrument()
 
 
 class TestBasics():
 
     temporary_file_list = False
+    version = False
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
@@ -123,21 +175,22 @@ class TestBasics():
         self.data_path = pysat.data_dir
 
         # create temporary directory
-        dir_name = tempfile.mkdtemp()
-        pysat.utils.set_data_dir(dir_name, store=False)
+        self.tempdir = tempfile.TemporaryDirectory()
+        pysat.utils.set_data_dir(self.tempdir.name, store=False)
 
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              clean_level='clean',
                              temporary_file_list=self.temporary_file_list)
-        # create testing directory
+        # create instrument directories in tempdir
         create_dir(self.testInst)
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        remove_files(self.testInst)
+        # remove_files(self.testInst)
         pysat.utils.set_data_dir(self.data_path, store=False)
-        del self.testInst, self.out
+        self.tempdir.cleanup()
+        del self.testInst, self.out, self.tempdir
 
     def test_basic_repr(self):
         """The repr output will match the str output"""
@@ -154,17 +207,18 @@ class TestBasics():
         # Test no files
         assert self.out.find('Date Range') > 0
 
-    def test_year_doy_files_direct_call_to_from_os(self):
+    def test_year_doy_files_direct_call_from_os(self):
+        """Check that Files.from_os generates file list"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2009, 12, 31)
-        create_files(self.testInst, start, stop, freq='1D')
+        create_files(self.testInst, start, stop, freq='1D',
+                     version=self.version)
+        root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_',
+                              '{day:03d}_stuff.pysat_testing_file'))
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
-                                    format_str=''.join(('pysat_testing_junk_',
-                                                        '{year:04d}_gold_',
-                                                        '{day:03d}_stuff.',
-                                                        'pysat_testing_file')))
+                                    format_str=root_fname)
         # check overall length
         assert len(files) == (365 + 366)
         # check specific dates
@@ -173,19 +227,17 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_doy_files_no_gap_in_name_direct_call_to_from_os(self):
+        """Files.from_os generates file list for date w/o delimiter"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2009, 12, 31)
+        root_fname = ''.join(('pysat_testing_junk_{year:04d}{day:03d}_stuff.',
+                              'pysat_testing_file'))
         create_files(self.testInst, start, stop, freq='1D',
-                     root_fname=''.join(('pysat_testing_junk_{year:04d}',
-                                         '{day:03d}_stuff.pysat_testing_',
-                                         'file')))
+                     root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
-                                    format_str=''.join(('pysat_testing_junk_',
-                                                        '{year:04d}{day:03d}_',
-                                                        'stuff.pysat_testing_',
-                                                        'file')))
+                                    format_str=root_fname)
         # check overall length
         assert len(files) == (365 + 366)
         # check specific dates
@@ -194,20 +246,17 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_files_direct_call_to_from_os(self):
+        """Files.from_os generates file list for date w/ month"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2009, 12, 31)
-        create_files(self.testInst, start, stop, freq='1D', use_doy=False,
-                     root_fname=''.join(('pysat_testing_junk_{year:04d}_gold_',
-                                         '{day:03d}_stuff_{month:02d}.pysat_',
-                                         'testing_file')))
+        root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}',
+                              '_stuff_{month:02d}.pysat_testing_file'))
+        create_files(self.testInst, start, stop, freq='1D',
+                     use_doy=False, root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
-                                    format_str=''.join(('pysat_testing_junk_',
-                                                        '{year:04d}_gold_',
-                                                        '{day:03d}_stuff_',
-                                                        '{month:02d}.pysat_',
-                                                        'testing_file')))
+                                    format_str=root_fname)
         # check overall length
         assert len(files) == (365 + 366)
         # check specific dates
@@ -216,22 +265,18 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_hour_files_direct_call_to_from_os(self):
+        """Files.from_os generates file list for date w hours"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2009, 12, 31)
+        root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}',
+                              '_stuff_{month:02d}_{hour:02d}.pysat_testing',
+                              '_file'))
         create_files(self.testInst, start, stop, freq='6h',
-                     use_doy=False,
-                     root_fname=''.join(('pysat_testing_junk_{year:04d}_gold_',
-                                         '{day:03d}_stuff_{month:02d}_',
-                                         '{hour:02d}.pysat_testing_file')))
+                     use_doy=False, root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
-                                    format_str=''.join(('pysat_testing_junk_',
-                                                        '{year:04d}_gold_',
-                                                        '{day:03d}_stuff_',
-                                                        '{month:02d}_',
-                                                        '{hour:02d}.pysat_',
-                                                        'testing_file')))
+                                    format_str=root_fname)
         # check overall length
         assert len(files) == (365 + 366) * 4 - 3
         # check specific dates
@@ -240,6 +285,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
     def test_year_month_day_hour_minute_files_direct_call_to_from_os(self):
+        """Files.from_os generates file list for date w/ hours and minutes"""
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
                               'stuff_{month:02d}_{hour:02d}{minute:02d}.',
                               'pysat_testing_file'))
@@ -247,8 +293,7 @@ class TestBasics():
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2008, 1, 4)
         create_files(self.testInst, start, stop, freq='30min',
-                     use_doy=False,
-                     root_fname=root_fname)
+                     use_doy=False, root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
                                     format_str=root_fname)
@@ -261,6 +306,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 4)
 
     def test_year_month_day_hour_minute_second_files_direct_call_from_os(self):
+        """Files.from_os generates file list for date w/ hour/min/sec"""
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
                               'stuff_{month:02d}_{hour:02d}_{minute:02d}_',
                               '{second:02d}.pysat_testing_file'))
@@ -268,7 +314,7 @@ class TestBasics():
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2008, 1, 3)
         create_files(self.testInst, start, stop, freq='30s',
-                     use_doy=False, root_fname=root_fname)
+                     use_doy=False, root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
                                     format_str=root_fname)
@@ -281,19 +327,17 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 3)
 
     def test_year_month_files_direct_call_to_from_os(self):
+        """Files.from_os generates file list for monthly files"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
         stop = dt.datetime(2009, 12, 31)
+        root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_stuff',
+                              '_{month:02d}.pysat_testing_file'))
         create_files(self.testInst, start, stop, freq='1MS',
-                     root_fname=''.join(('pysat_testing_junk_{year:04d}_gold_',
-                                         'stuff_{month:02d}.pysat_testing_',
-                                         'file')))
+                     root_fname=root_fname, version=self.version)
         # use from_os function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
-                                    format_str=''.join(('pysat_testing_junk_',
-                                                        '{year:04d}_gold_',
-                                                        'stuff_{month:02d}.',
-                                                        'pysat_testing_file')))
+                                    format_str=root_fname)
         # check overall length
         assert len(files) == 24
         # check specific dates
@@ -302,15 +346,17 @@ class TestBasics():
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 1)
 
     def test_instrument_has_no_files(self):
-        import pysat.instruments.pysat_testing
+        """Instrument generates empty file list if no files"""
 
-        pysat.instruments.pysat_testing.list_files = list_files
+        pysat.instruments.pysat_testing.list_files = \
+            functools.partial(list_files, version=self.version)
         inst = pysat.Instrument(platform='pysat', name='testing',
                                 update_files=True)
         reload(pysat.instruments.pysat_testing)
         assert(inst.files.files.empty)
 
     def test_instrument_has_files(self):
+        """Instrument generates file list if there are files"""
         import pysat.instruments.pysat_testing
 
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_'
@@ -323,7 +369,8 @@ class TestBasics():
                      use_doy=False, root_fname=root_fname)
         # create the same range of dates
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        pysat.instruments.pysat_testing.list_files = list_files
+        pysat.instruments.pysat_testing.list_files = \
+            functools.partial(list_files, version=self.version)
         inst = pysat.Instrument(platform='pysat', name='testing',
                                 update_files=True)
         reload(pysat.instruments.pysat_testing)
@@ -331,28 +378,32 @@ class TestBasics():
 
 
 class TestBasicsNoFileListStorage(TestBasics):
+    """Repeat basic tests with temporary file list"""
 
     temporary_file_list = True
 
 
-class TestInstrumentWithFiles():
+class TestInstWithFiles():
+    """Test basic file operations within an instrument"""
 
     temporary_file_list = False
+    version = False
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         # store current pysat directory
         self.data_path = pysat.data_dir
         # create temporary directory
-        dir_name = tempfile.mkdtemp()
-        pysat.utils.set_data_dir(dir_name, store=False)
+        self.tempdir = tempfile.TemporaryDirectory()
+        pysat.utils.set_data_dir(self.tempdir.name, store=False)
         # create testing directory
         create_dir(temporary_file_list=self.temporary_file_list)
 
         # create a test instrument, make sure it is getting files from
         # filesystem
         reload(pysat.instruments.pysat_testing)
-        pysat.instruments.pysat_testing.list_files = list_files
+        pysat.instruments.pysat_testing.list_files = \
+            functools.partial(list_files, version=self.version)
         # create a bunch of files by year and doy
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
@@ -366,17 +417,18 @@ class TestInstrumentWithFiles():
         start = dt.datetime(2007, 12, 31)
         stop = dt.datetime(2008, 1, 10)
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False, root_fname=self.root_fname)
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
 
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              clean_level='clean',
                              update_files=True,
+                             file_format=self.root_fname,
                              temporary_file_list=self.temporary_file_list)
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        remove_files(self.testInst)
         del self.testInst
         reload(pysat.instruments.pysat_testing)
         reload(pysat.instruments)
@@ -387,21 +439,25 @@ class TestInstrumentWithFiles():
                          update_files=True,
                          temporary_file_list=self.temporary_file_list)
         pysat.utils.set_data_dir(self.data_path, store=False)
+        self.tempdir.cleanup()
+        del self.tempdir
 
     def test_refresh(self):
+        """Check that refresh updates the files"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 10)
         stop = dt.datetime(2008, 1, 12)
 
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False,
-                     root_fname=self.root_fname)
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
         start = dt.datetime(2007, 12, 31)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
     def test_refresh_on_ignore_empty_files(self):
+        """Check that refresh can ignore empty files"""
         # setup created empty files - make sure such files can be ignored
         self.testInst.files.ignore_empty_files = True
         self.testInst.files.refresh()
@@ -413,7 +469,7 @@ class TestInstrumentWithFiles():
         create_files(self.testInst, start, stop, freq='100min',
                      use_doy=False,
                      root_fname=self.root_fname,
-                     content='test')
+                     content='test', version=self.version)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
@@ -422,9 +478,9 @@ class TestInstrumentWithFiles():
         """Make sure new instruments can ignore empty files"""
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             update_files=True,
+                             clean_level='clean', update_files=True,
                              temporary_file_list=self.temporary_file_list,
+                             file_format=self.root_fname,
                              ignore_empty_files=True)
 
         assert len(self.testInst.files.files) == 0
@@ -433,28 +489,34 @@ class TestInstrumentWithFiles():
         start = dt.datetime(2007, 12, 31)
         stop = dt.datetime(2008, 1, 10)
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False,
-                     root_fname=self.root_fname,
-                     content='test')
+                     use_doy=False, root_fname=self.root_fname, content='test',
+                     version=self.version)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
-    def test_refresh_on_unchanged_files(self):
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        self.testInst.files.refresh()
-        assert (np.all(self.testInst.files.files.index == dates))
-
-    def test_get_new_files_after_refresh(self):
+    def test_get_new_files_after_adding_files(self):
+        """Check that get_new locates new files"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 11)
         stop = dt.datetime(2008, 1, 12)
 
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False,
-                     root_fname=self.root_fname)
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
+        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        new_files = self.testInst.files.get_new()
+        assert (np.all(new_files.index == dates))
+
+    def test_get_new_files_after_refresh(self):
+        """Check that get_new locates new files after refresh"""
+        # create new files and make sure that new files are captured
+        start = dt.datetime(2008, 1, 11)
+        stop = dt.datetime(2008, 1, 12)
+
+        create_files(self.testInst, start, stop, freq='100min',
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         new_files = self.testInst.files.get_new()
@@ -462,33 +524,23 @@ class TestInstrumentWithFiles():
         assert (np.all(new_files.index == dates))
 
     def test_get_new_files_after_multiple_refreshes(self):
+        """Check that get_new locates new files after multiple refreshes"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 11)
         stop = dt.datetime(2008, 1, 12)
 
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False,
-                     root_fname=self.root_fname)
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         self.testInst.files.refresh()
         self.testInst.files.refresh()
         self.testInst.files.refresh()
-        new_files = self.testInst.files.get_new()
-        assert (np.all(new_files.index == dates))
-
-    def test_get_new_files_after_adding_files(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False,
-                     root_fname=self.root_fname)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
         new_files = self.testInst.files.get_new()
         assert (np.all(new_files.index == dates))
 
     def test_get_new_files_after_adding_files_and_adding_file(self):
+        """Check that get_new works after multiple rounds of added files"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 11)
         stop = dt.datetime(2008, 1, 12)
@@ -503,14 +555,15 @@ class TestInstrumentWithFiles():
         stop = dt.datetime(2008, 1, 18)
 
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False,
-                     root_fname=self.root_fname)
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
         dates2 = pysat.utils.time.create_date_range(start, stop, freq='100min')
         new_files2 = self.testInst.files.get_new()
         assert np.all(new_files.index == dates)
         assert np.all(new_files2.index == dates2)
 
     def test_get_new_files_after_deleting_files_and_adding_files(self):
+        """Check that get_new works after deleting and adding files"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 11)
         stop = dt.datetime(2008, 1, 12)
@@ -528,210 +581,45 @@ class TestInstrumentWithFiles():
                     os.unlink(file_path)
         # add new files
         create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False, root_fname=self.root_fname)
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
         # get new files
         new_files = self.testInst.files.get_new()
 
         assert (np.all(new_files.index == dates))
 
-    def test_files_non_standard_pysat_directory(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
 
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             inst_id='hello',
-                             directory_format='pysat_testing_{tag}_{inst_id}',
-                             update_files=True,
-                             temporary_file_list=self.temporary_file_list)
-        # add new files
-        create_dir(self.testInst)
-        remove_files(self.testInst)
-        create_files(self.testInst, start, stop, freq='100min',
-                     use_doy=False, root_fname=self.root_fname)
-
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             inst_id='hello',
-                             directory_format=''.join(('pysat_testing_',
-                                                       '{tag}_{inst_id}')),
-                             update_files=True,
-                             temporary_file_list=self.temporary_file_list)
-
-        # get new files
-        new_files = self.testInst.files.get_new()
-        assert np.all(self.testInst.files.files.index == dates)
-        assert np.all(new_files.index == dates)
-
-    def test_files_non_standard_file_format_template(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 15)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
-
-        # clear out old files, create new ones
-        remove_files(self.testInst)
-        create_files(self.testInst, start, stop, freq='1D',
-                     use_doy=False,
-                     root_fname=''.join(('pysat_testing_unique_junk_',
-                                         '{year:04d}_gold_{day:03d}_stuff',
-                                         '.pysat_testing_file')))
-
-        pysat.instruments.pysat_testing.list_files = list_files
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             file_format=''.join(('pysat_testing_unique_',
-                                                  'junk_{year:04d}_gold_',
-                                                  '{day:03d}_stuff',
-                                                  '.pysat_testing_file')),
-                             update_files=True,
-                             temporary_file_list=self.temporary_file_list)
-
-        assert (np.all(self.testInst.files.files.index == dates))
-
-    def test_files_non_standard_file_format_template_misformatted(self):
-
-        pysat.instruments.pysat_testing.list_files = list_files
-        with pytest.raises(ValueError):
-            self.testInst = \
-                pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                                 clean_level='clean',
-                                 file_format=''.join(('pysat_testing_unique_',
-                                                      'junk_stuff.',
-                                                      'pysat_testing_file')),
-                                 update_files=True,
-                                 temporary_file_list=self.temporary_file_list)
-
-    def test_files_non_standard_file_format_template_misformatted_2(self):
-
-        pysat.instruments.pysat_testing.list_files = list_files
-        with pytest.raises(ValueError):
-            self.testInst = \
-                pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                                 clean_level='clean',
-                                 file_format=15,
-                                 update_files=True,
-                                 temporary_file_list=self.temporary_file_list)
-
-
-class TestInstrumentWithFilesNoFileListStorage(TestInstrumentWithFiles):
-
-    temporary_file_list = True
-
-
-# create year doy file set with multiple versions
-def create_versioned_files(inst, start=None, stop=None, freq='1D',
-                           use_doy=True, root_fname=None, timeout=None):
-    # create a bunch of files
-    if start is None:
-        start = dt.datetime(2009, 1, 1)
-    if stop is None:
-        stop = dt.datetime(2013, 12, 31)
-    dates = pysat.utils.time.create_date_range(start, stop, freq=freq)
-
-    versions = np.array([1, 2])
-    revisions = np.array([0, 1])
-    cycles = np.array([0, 1])
-
-    if root_fname is None:
-        root_fname = ''.join(('pysat_testing_junk_{year:04d}_{month:02d}_',
-                              '{day:03d}{hour:02d}{minute:02d}{second:02d}_',
-                              'stuff_{version:02d}_{revision:03d}_{cycle:02d}',
-                              '.pysat_testing_file'))
-    # create empty file
-    for date in dates:
-        for version in versions:
-            for revision in revisions:
-                for cycle in cycles:
-                    yr, doy = pysat.utils.time.getyrdoy(date)
-                    if use_doy:
-                        doy = doy
-                    else:
-                        doy = date.day
-
-                    fname = os.path.join(inst.files.data_path,
-                                         root_fname.format(year=yr,
-                                                           day=doy,
-                                                           month=date.month,
-                                                           hour=date.hour,
-                                                           minute=date.minute,
-                                                           second=date.second,
-                                                           version=version,
-                                                           revision=revision,
-                                                           cycle=cycle))
-                    with NetworkLock(fname, 'w'):
-                        if timeout is not None:
-                            time.sleep(timeout)
-
-
-def list_versioned_files(tag=None, inst_id=None, data_path=None,
-                         format_str=None):
-    """Return a Pandas Series of every file for chosen satellite data"""
-
-    if format_str is None:
-        format_str = ''.join(('pysat_testing_junk_{year:04d}_{month:02d}_',
-                              '{day:03d}{hour:02d}{minute:02d}{second:02d}_',
-                              'stuff_{version:02d}_{revision:03d}_{cycle:02d}',
-                              '.pysat_testing_file'))
-    if tag is not None:
-        if tag == '':
-            return pysat.Files.from_os(data_path=data_path,
-                                       format_str=format_str)
-        else:
-            raise ValueError('Unrecognized tag name')
-    else:
-        raise ValueError('A tag name must be passed ')
-
-
-class TestInstrumentWithVersionedFiles():
+class TestInstWithFilesNonStandard():
+    """Specialized tests for instruments with non-standard setups"""
 
     temporary_file_list = False
+    version = False
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
         # store current pysat directory
         self.data_path = pysat.data_dir
         # create temporary directory
-        dir_name = tempfile.gettempdir()
-        pysat.utils.set_data_dir(dir_name, store=False)
-        # create testing directory
-        create_dir(temporary_file_list=self.temporary_file_list)
+        self.tempdir = tempfile.TemporaryDirectory()
+        pysat.utils.set_data_dir(self.tempdir.name, store=False)
 
-        # create a test instrument, make sure it is getting files from
-        # filesystem
+        self.root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_',
+                                   '{day:03d}_stuff_{month:02d}_{hour:02d}_',
+                                   '{minute:02d}_{second:02d}.pysat_testing_',
+                                   'file'))
         reload(pysat.instruments.pysat_testing)
-        pysat.instruments.pysat_testing.list_files = list_versioned_files
-        # create a bunch of files by year and doy
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             temporary_file_list=self.temporary_file_list)
 
-        self.root_fname = ''.join(('pysat_testing_junk_{year:04d}_{month:02d}',
-                                   '_{day:03d}{hour:02d}{minute:02d}',
-                                   '{second:02d}_stuff_{version:02d}_',
-                                   '{revision:03d}_{cycle:02d}',
-                                   '.pysat_testing_file'))
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False, root_fname=self.root_fname)
-
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             update_files=True,
-                             temporary_file_list=self.temporary_file_list)
+        # Use custom list_files routine
+        pysat.instruments.pysat_testing.list_files = \
+            functools.partial(list_files, version=self.version)
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        remove_files(self.testInst)
-        del self.testInst
+        self.tempdir.cleanup()
+        del self.tempdir
+        if hasattr(self, 'testInst'):
+            # The two tests for error do not generate testInst
+            del self.testInst
         reload(pysat.instruments.pysat_testing)
         reload(pysat.instruments)
         # make sure everything about instrument state is restored
@@ -742,147 +630,30 @@ class TestInstrumentWithVersionedFiles():
                          temporary_file_list=self.temporary_file_list)
         pysat.utils.set_data_dir(self.data_path, store=False)
 
-    def test_refresh(self):
-        # create new files and make sure that new files are captured
-        # files slready exist from 2007, 12, 31 through to 10th
-        start = dt.datetime(2008, 1, 10)
-        stop = dt.datetime(2008, 1, 12)
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False,
-                               root_fname=self.root_fname)
-        # create list of dates for all files that should be there
-        start = dt.datetime(2007, 12, 31)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        # update instrument file list
-        self.testInst.files.refresh()
-        assert (np.all(self.testInst.files.files.index == dates))
-
-    def test_refresh_on_unchanged_files(self):
-
-        start = dt.datetime(2007, 12, 31)
-        stop = dt.datetime(2008, 1, 10)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        self.testInst.files.refresh()
-        assert (np.all(self.testInst.files.files.index == dates))
-
-    def test_get_new_files_after_refresh(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False,
-                               root_fname=self.root_fname)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        self.testInst.files.refresh()
-        new_files = self.testInst.files.get_new()
-
-        assert (np.all(new_files.index == dates))
-
-    def test_get_new_files_after_multiple_refreshes(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False,
-                               root_fname=self.root_fname)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        self.testInst.files.refresh()
-        self.testInst.files.refresh()
-        self.testInst.files.refresh()
-        new_files = self.testInst.files.get_new()
-
-        assert (np.all(new_files.index == dates))
-
-    def test_get_new_files_after_adding_files(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False,
-                               root_fname=self.root_fname)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        new_files = self.testInst.files.get_new()
-        assert (np.all(new_files.index == dates))
-
-    def test_get_new_files_after_adding_files_and_adding_file(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False,
-                               root_fname=self.root_fname)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        new_files = self.testInst.files.get_new()
-
-        start = dt.datetime(2008, 1, 15)
-        stop = dt.datetime(2008, 1, 18)
-
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False,
-                               root_fname=self.root_fname)
-        dates2 = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        new_files2 = self.testInst.files.get_new()
-        assert np.all(new_files.index == dates)
-        assert np.all(new_files2.index == dates2)
-
-    def test_get_new_files_after_deleting_files_and_adding_files(self):
-        # create new files and make sure that new files are captured
-        start = dt.datetime(2008, 1, 11)
-        stop = dt.datetime(2008, 1, 12)
-        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        # remove files, same number as will be added
-        to_be_removed = len(dates)
-        for the_file in os.listdir(self.testInst.files.data_path):
-            if (the_file[0:13] == 'pysat_testing') & \
-                    (the_file[-19:] == '.pysat_testing_file'):
-                file_path = os.path.join(self.testInst.files.data_path,
-                                         the_file)
-                if os.path.isfile(file_path) & (to_be_removed > 0):
-                    to_be_removed -= 1
-                    # Remove all versions of the file
-                    # otherwise, previous versions will look like new files
-                    pattern = '_'.join(file_path.split('_')[0:7]) + \
-                        '*.pysat_testing_file'
-                    map(os.unlink, glob.glob(pattern))
-                    # os.unlink(file_path)
-        # add new files
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False, root_fname=self.root_fname)
-        # get new files
-        new_files = self.testInst.files.get_new()
-
-        assert (np.all(new_files.index == dates))
-
     def test_files_non_standard_pysat_directory(self):
+        """Check that files work with a weird directory structure"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 11)
         stop = dt.datetime(2008, 1, 15)
         dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
-        pysat.instruments.pysat_testing.list_files = list_versioned_files
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             inst_id='hello',
-                             directory_format='pysat_testing_{tag}_{inst_id}',
-                             update_files=True,
-                             temporary_file_list=self.temporary_file_list)
-        # add new files
-        create_dir(self.testInst)
-        remove_files(self.testInst)
-        create_versioned_files(self.testInst, start, stop, freq='100min',
-                               use_doy=False, root_fname=self.root_fname)
+
+        nonstandard_dir = 'pysat_testing_{tag}_{inst_id}'
 
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              clean_level='clean',
                              inst_id='hello',
-                             directory_format='pysat_testing_{tag}_{inst_id}',
-                             update_files=True,
+                             directory_format=nonstandard_dir,
+                             update_files=True, file_format=self.root_fname,
                              temporary_file_list=self.temporary_file_list)
+        # add new files
+        create_dir(self.testInst)
+        create_files(self.testInst, start, stop, freq='100min',
+                     use_doy=False, root_fname=self.root_fname,
+                     version=self.version)
+
+        # refresh file list
+        self.testInst.files.refresh()
 
         # get new files
         new_files = self.testInst.files.get_new()
@@ -890,29 +661,81 @@ class TestInstrumentWithVersionedFiles():
         assert np.all(new_files.index == dates)
 
     def test_files_non_standard_file_format_template(self):
+        """Check that files work if format has a weird heirarchy"""
         # create new files and make sure that new files are captured
         start = dt.datetime(2008, 1, 11)
         stop = dt.datetime(2008, 1, 15)
         dates = pysat.utils.time.create_date_range(start, stop, freq='1D')
+        if self.version:
+            root_fname = ''.join(('pysat_testing_unique_{version:02d}_',
+                                  '{revision:03d}_{cycle:02d}_{year:04d}',
+                                  '_g_{day:03d}_st.pysat_testing_file'))
+        else:
+            root_fname = ''.join(('pysat_testing_unique_junk_{year:04d}_gold',
+                                  '_{day:03d}_stuff.pysat_testing_file'))
 
-        file_format = ''.join(('pysat_testing_unique_{version:02d}_',
-                               '{revision:03d}_{cycle:02d}_{year:04d}',
-                               '_g_{day:03d}_st.pysat_testing_file'))
-
-        # clear out old files, create new ones
-        remove_files(self.testInst)
-        create_versioned_files(self.testInst, start, stop, freq='1D',
-                               use_doy=False,
-                               root_fname=file_format)
-
-        pysat.instruments.pysat_testing.list_files = list_versioned_files
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              clean_level='clean',
-                             file_format=file_format,
+                             file_format=root_fname,
                              update_files=True,
                              temporary_file_list=self.temporary_file_list)
+
+        # add new files
+        create_dir(self.testInst)
+        create_files(self.testInst, start, stop, freq='1D',
+                     use_doy=False, root_fname=root_fname, version=self.version)
+        # refresh file list
+        self.testInst.files.refresh()
+
         assert (np.all(self.testInst.files.files.index == dates))
+
+    def test_files_non_standard_file_format_template_no_variables(self):
+        """Instrument should error if format template has no variables"""
+
+        with pytest.raises(ValueError):
+            self.testInst = \
+                pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
+                                 clean_level='clean',
+                                 file_format=''.join(('pysat_testing_unique_',
+                                                      'junk_stuff.',
+                                                      'pysat_testing_file')),
+                                 update_files=True,
+                                 temporary_file_list=self.temporary_file_list)
+
+    def test_files_non_standard_file_format_template_wrong_type(self):
+        """Instrument should error if format template is not a string"""
+
+        with pytest.raises(ValueError):
+            self.testInst = \
+                pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
+                                 clean_level='clean',
+                                 file_format=15,
+                                 update_files=True,
+                                 temporary_file_list=self.temporary_file_list)
+
+
+class TestInstWithFilesNoFileListStorage(TestInstWithFiles,
+                                         TestInstWithFilesNonStandard):
+    """Repeat all file tests with a temporary file list"""
+
+    temporary_file_list = True
+    version = False
+
+
+class TestInstWithVersionedFiles(TestInstWithFiles):
+    """Repeat all file tests with versioned files"""
+
+    temporary_file_list = False
+    version = True
+
+
+class TestInstWithVersionedFilesNonStandard(TestInstWithFilesNonStandard):
+    """Repeat all non-standard file tests with versioned files.
+    Includes additional tests for versioned strings"""
+
+    temporary_file_list = False
+    version = True
 
     def test_files_when_duplicates_forced(self):
         # create new files and make sure that new files are captured
@@ -923,13 +746,21 @@ class TestInstrumentWithVersionedFiles():
         file_format = ''.join(('pysat_testing_unique_{version:02d}_',
                                '{revision:03d}_{cycle:02d}_{year:04d}',
                                '_g_{day:03d}_st.pysat_testing_file'))
+        self.testInst = \
+            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
+                             clean_level='clean',
+                             file_format=file_format,
+                             update_files=True,
+                             temporary_file_list=self.temporary_file_list)
 
-        # clear out old files, create new ones
-        remove_files(self.testInst)
-        create_versioned_files(self.testInst, start, stop, freq='1D',
-                               use_doy=False, root_fname=file_format)
+        # add new files
+        create_dir(self.testInst)
+        create_files(self.testInst, start, stop, freq='1D',
+                     use_doy=False, root_fname=file_format,
+                     version=self.version)
 
-        pysat.instruments.pysat_testing.list_files = list_files
+        pysat.instruments.pysat_testing.list_files = \
+            functools.partial(list_files, version=self.version)
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              clean_level='clean', file_format=file_format,
@@ -956,10 +787,8 @@ def create_instrument(j):
 
     start = dt.datetime(2007, 12, 30)
     stop = dt.datetime(2007, 12, 31)
-    create_versioned_files(testInst, start, stop,
-                           freq='1D', use_doy=False,
-                           root_fname=root_fname,
-                           timeout=0.5)
+    create_files(testInst, start, stop, freq='1D', use_doy=False,
+                 root_fname=root_fname, timeout=0.5, version=True)
 
     testInst = \
         pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
@@ -981,15 +810,16 @@ class TestFilesRaceCondition():
         # store current pysat directory
         self.data_path = pysat.data_dir
         # create temporary directory
-        dir_name = tempfile.gettempdir()
-        pysat.utils.set_data_dir(dir_name, store=False)
+        self.tempdir = tempfile.TemporaryDirectory()
+        pysat.utils.set_data_dir(self.tempdir.name, store=False)
         # create testing directory
         create_dir(temporary_file_list=self.temporary_file_list)
 
         # create a test instrument, make sure it is getting files from
         # filesystem
         reload(pysat.instruments.pysat_testing)
-        pysat.instruments.pysat_testing.list_files = list_versioned_files
+        pysat.instruments.pysat_testing.list_files = \
+            functools.partial(list_files, version=True)
         # create a bunch of files by year and doy
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
@@ -1003,8 +833,8 @@ class TestFilesRaceCondition():
                                    '.pysat_testing_file'))
         start = dt.datetime(2007, 12, 30)
         stop = dt.datetime(2008, 12, 31)
-        create_versioned_files(self.testInst, start, stop, freq='1D',
-                               use_doy=False, root_fname=self.root_fname)
+        create_files(self.testInst, start, stop, freq='1D',
+                     use_doy=False, root_fname=self.root_fname, version=True)
 
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
@@ -1017,8 +847,8 @@ class TestFilesRaceCondition():
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        remove_files(self.testInst)
-        del self.testInst
+        self.tempdir.cleanup()
+        del self.testInst, self.tempdir
         reload(pysat.instruments.pysat_testing)
         reload(pysat.instruments)
         # make sure everything about instrument state is restored

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -474,6 +474,15 @@ class TestInstWithFiles():
         self.testInst.files.refresh()
         assert (np.all(self.testInst.files.files.index == dates))
 
+    def test_refresh_on_unchanged_files(self):
+        """Make sure new refresh does not duplicate files"""
+        start = dt.datetime(2007, 12, 31)
+        stop = dt.datetime(2008, 1, 10)
+        dates = pysat.utils.time.create_date_range(start, stop, freq='100min')
+        assert (np.all(self.testInst.files.files.index == dates))
+        self.testInst.files.refresh()
+        assert (np.all(self.testInst.files.files.index == dates))
+
     def test_instrument_with_ignore_empty_files(self):
         """Make sure new instruments can ignore empty files"""
         self.testInst = \

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -187,7 +187,6 @@ class TestBasics():
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        # remove_files(self.testInst)
         pysat.utils.set_data_dir(self.data_path, store=False)
         self.tempdir.cleanup()
         del self.testInst, self.out, self.tempdir

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -207,7 +207,7 @@ class TestBasics():
         # Test no files
         assert self.out.find('Date Range') > 0
 
-    def test_year_doy_files_direct_call_from_os(self):
+    def test_year_doy_files_directly_call_from_os(self):
         """Check that Files.from_os generates file list"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
@@ -226,7 +226,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
-    def test_year_doy_files_no_gap_in_name_direct_call_to_from_os(self):
+    def test_year_doy_files_no_gap_in_name_directly_call_from_os(self):
         """Files.from_os generates file list for date w/o delimiter"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
@@ -245,7 +245,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
-    def test_year_month_day_files_direct_call_to_from_os(self):
+    def test_year_month_day_files_directly_call_from_os(self):
         """Files.from_os generates file list for date w/ month"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
@@ -264,7 +264,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[365]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
-    def test_year_month_day_hour_files_direct_call_to_from_os(self):
+    def test_year_month_day_hour_files_directly_call_from_os(self):
         """Files.from_os generates file list for date w hours"""
         # create a bunch of files by year and doy
         start = dt.datetime(2008, 1, 1)
@@ -284,7 +284,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[1460]) == dt.datetime(2008, 12, 31)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 31)
 
-    def test_year_month_day_hour_minute_files_direct_call_to_from_os(self):
+    def test_year_month_day_hour_minute_files_directly_call_from_os(self):
         """Files.from_os generates file list for date w/ hours and minutes"""
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
                               'stuff_{month:02d}_{hour:02d}{minute:02d}.',
@@ -305,7 +305,7 @@ class TestBasics():
         assert pds.to_datetime(files.index[10]) == dt.datetime(2008, 1, 1, 5, 0)
         assert pds.to_datetime(files.index[-1]) == dt.datetime(2008, 1, 4)
 
-    def test_year_month_day_hour_minute_second_files_direct_call_from_os(self):
+    def test_year_month_day_hms_files_directly_call_from_os(self):
         """Files.from_os generates file list for date w/ hour/min/sec"""
         root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_{day:03d}_',
                               'stuff_{month:02d}_{hour:02d}_{minute:02d}_',

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -13,7 +13,7 @@ class TestBasics():
         """Runs after every method to clean up previous testing."""
 
     def test_parse_delimited_filename(self):
-        """Check ability to parse delimited files"""
+        """Check ability to parse list of delimited files"""
         # Note: Can be removed if future instrument that uses delimited
         # filenames is added to routine travis end-to-end testing
         fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -1,0 +1,45 @@
+import numpy as np
+from pysat.utils import files as futils
+
+
+class TestBasics():
+
+    temporary_file_list = False
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup."""
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+
+    def test_parse_delimited_filename(self):
+        """Check ability to parse delimited files"""
+        # Note: Can be removed if future instrument that uses delimited
+        # filenames is added to routine travis end-to-end testing
+        fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',
+                         '_{minute:2d}_{second:2d}_{version:2s}_r02.cdf'))
+        year = np.ones(6) * 2009
+        month = np.ones(6) * 12
+        day = np.array([12, 15, 17, 19, 22, 24])
+        hour = np.array([8, 10, 6, 18, 3, 23])
+        minute = np.array([8, 10, 6, 18, 3, 59])
+        second = np.array([58, 11, 26, 2, 18, 59])
+        version = np.array(['v1', 'v2', 'r1', 'r3', 'v5', 'a6'])
+        file_list = []
+        for i in range(6):
+            file_list.append(fname.format(year=year[i].astype(int),
+                                          month=month[i].astype(int),
+                                          day=day[i], hour=hour[i],
+                                          minute=minute[i], second=second[i],
+                                          version=version[i]))
+
+        file_dict = futils.parse_delimited_filenames(file_list, fname, '_')
+        assert np.all(file_dict['year'] == year)
+        assert np.all(file_dict['month'] == month)
+        assert np.all(file_dict['day'] == day)
+        assert np.all(file_dict['hour'] == hour)
+        assert np.all(file_dict['minute'] == minute)
+        assert np.all(file_dict['day'] == day)
+        assert np.all(file_dict['version'] == version)
+        assert (file_dict['revision'] is None)
+        assert (file_dict['cycle'] is None)


### PR DESCRIPTION
# Description

Addresses #597, #565 (partial)

- Reduces code duplication in unit tests through classes
- Use `tempfile.tempdir.cleanup()` rather than manually deleting files created during tests
- Moves tests for migrated file utilities to test_utils_files.py
- Adds and improves docstrings, comments, test names

## Type of change

- Testing fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
