### PR TITLE
Added soft UTC testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Fixed custom Meta attributes removal when transferred to instrument (#615)
   - Corrected iteration over Instrument within list comprehension
   - Removed unused input arguments
+  - Corrects Instrument today, yesterday, and tomorrow methods by implementing
+    datetime.datetime.utcnow
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,6 +115,8 @@ These include:
   * `import numpy as np`
   * `import pandas as pds`
   * `import xarray as xr`
+* When incrementing a timestamp, use `dt.timedelta` instead of `pds.DateOffset`
+  when possible to reduce program runtime
 * All classes should have `__repr__` and `__str__` functions
 * Docstrings use `Note` instead of `Notes`
 * Try to avoid creating a try/except statement where except passes

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -293,14 +293,14 @@ class Files(object):
         # if not, do nothing
         stored_files = self._load()
         if len(stored_files) != len(self.files):
-            # # of items is different, things are new
+            # The number of items is different, things are new
             new_flag = True
         elif len(stored_files) == len(self.files):
-            # # of items equal, check specifically for equality
+            # The number of items is the same, check specifically for equality
             if stored_files.eq(self.files).all():
                 new_flag = False
             else:
-                # not equal, there are new files
+                # Stored and new data are not equal, there are new files
                 new_flag = True
 
         if new_flag:
@@ -380,7 +380,7 @@ class Files(object):
         if not info.empty:
             if self.ignore_empty_files:
                 self._filter_empty_files()
-            logger.info('Found {ll:d} files locally.'.format(ll=len(info)))
+            logger.info('Found {:d} local files.'.format(len(info)))
         else:
             estr = "Unable to find any files that match the supplied template."
             estr += " If you have the necessary files please check pysat "

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1893,12 +1893,13 @@ class Instrument(object):
 
         Returns
         -------
-        datetime
-            Today's date
+        today_utc: datetime
+            Today's date in UTC
 
         """
+        today_utc = self._filter_datetime_input(dt.datetime.utcnow())
 
-        return self._filter_datetime_input(dt.datetime.today())
+        return today_utc
 
     def tomorrow(self):
         """Returns tomorrow's date (UTC), with no hour, minute, second, etc.
@@ -1906,11 +1907,11 @@ class Instrument(object):
         Returns
         -------
         datetime
-            Tomorrow's date
+            Tomorrow's date in UTC
 
         """
 
-        return self.today() + pds.DateOffset(days=1)
+        return self.today() + dt.timedelta(days=1)
 
     def yesterday(self):
         """Returns yesterday's date (UTC), with no hour, minute, second, etc.
@@ -1918,11 +1919,11 @@ class Instrument(object):
         Returns
         -------
         datetime
-            Yesterday's date
+            Yesterday's date in UTC
 
         """
 
-        return self.today() - pds.DateOffset(days=1)
+        return self.today() - dt.timedelta(days=1)
 
     def next(self, verifyPad=False):
         """Manually iterate through the data loaded in Instrument object.
@@ -2364,7 +2365,7 @@ class Instrument(object):
             Used when loading a range of filenames from `fname` to `stop_fname`,
             inclusive. (default=None)
         verifyPad : bool
-            if True, padding data not removed for debugging. Padding
+            If True, padding data not removed for debugging. Padding
             parameters are provided at Instrument instantiation. (default=False)
 
         Raises

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1084,20 +1084,38 @@ class Instrument(object):
 
         Returns
         -------
-        NoneType, datetime, or list of datetimes
+        out_date: NoneType, datetime, or list of datetimes
             NoneType input yeilds NoneType output, array-like yeilds list,
             datetime object yeilds like.  All datetime output excludes the
             sub-daily temporal increments (keeps only date information).
 
+        Note
+        ----
+        Checks for timezone information not in UTC
+
         """
 
         if date is None:
-            return date
+            out_date = None
         else:
+            # Check for timezone information and remove time of day for
+            # single datetimes and iterable containers of datetime objects
             if hasattr(date, '__iter__'):
-                return [dt.datetime(da.year, da.month, da.day) for da in date]
+                out_date = []
+                for in_date in date:
+                    if(in_date.tzinfo is not None
+                       and in_date.utcoffset() is not None):
+                        in_date = in_date.astimezone(tz=dt.timezone.utc)
+
+                    out_date.append(dt.datetime(in_date.year, in_date.month,
+                                                in_date.day))
             else:
-                return dt.datetime(date.year, date.month, date.day)
+                if date.tzinfo is not None and date.utcoffset() is not None:
+                    date = date.astimezone(tz=dt.timezone.utc)
+
+                out_date = dt.datetime(date.year, date.month, date.day)
+
+        return out_date
 
     def _load_data(self, date=None, fid=None, inc=None):
         """

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -220,7 +220,7 @@ def generate_times(fnames, num, freq='1S'):
         dates.append(date)
 
         # Create one day of data at desired frequency
-        end_date = date + pds.DateOffset(seconds=86399)
+        end_date = date + dt.timedelta(seconds=86399)
         index = pds.date_range(start=date, end=end_date, freq=freq)
         index = index[0:num]
         indices.extend(index)

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -9,7 +9,7 @@ import logging
 import numpy as np
 import warnings
 
-import xarray
+import xarray as xr
 
 import pysat
 from pysat.instruments.methods import testing as mm_test
@@ -125,13 +125,15 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
 
     if malformed_index:
         index = index.tolist()
-        # nonmonotonic
+
+        # Create a nonmonotonic index
         index[0:3], index[3:6] = index[3:6], index[0:3]
-        # non unique
+
+        # Create a non-unique index
         index[6:9] = [index[6]] * 3
 
-    data = xarray.Dataset({'uts': ((epoch_name), index)},
-                          coords={epoch_name: index})
+    data = xr.Dataset({'uts': ((epoch_name), index)},
+                      coords={epoch_name: index})
     # need to create simple orbits here. Have start of first orbit
     # at 2009,1, 0 UT. 14.84 orbits per day
     time_delta = dates[0] - root_date

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -568,7 +568,7 @@ class TestBasics():
     @pytest.mark.parametrize("in_time, islist",
                              [(dt.datetime.utcnow(), False),
                               (dt.datetime(2010, 1, 1, 12, tzinfo=dt.timezone(
-                                 dt.timedelta(seconds=14400))), False),
+                                  dt.timedelta(seconds=14400))), False),
                               ([dt.datetime(2010, 1, 1, 12, i,
                                             tzinfo=dt.timezone(
                                                 dt.timedelta(seconds=14400)))

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -556,6 +556,8 @@ class TestBasics():
     #
     # -------------------------------------------------------------------------
     def test_today_yesterday_and_tomorrow(self):
+        """ Test the correct instantiation of yesterday/today/tomorrow dates
+        """
         self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
@@ -564,12 +566,26 @@ class TestBasics():
         assert self.out + pds.DateOffset(days=1) == self.testInst.tomorrow()
 
     def test_filter_datetime(self):
+        """ Test the removal of time of day information using a filter
+        """
         self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         assert self.out == self.testInst._filter_datetime_input(self.ref_time)
 
+    def test_filter_datetime_aware_to_naive(self):
+        """ Test the transformation of aware to naive UTC by datetime filter
+        """
+        self.ref_time = dt.datetime(2010, 1, 1, tzinfo=dt.timezone.utc)
+        self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
+                               self.ref_time.day)
+        ftime = self.testInst._filter_datetime_input(self.ref_time)
+        assert self.out == ftime
+        assert ftime.tzinfo is None or ftime.utcoffset() is None
+
     def test_filtered_date_attribute(self):
+        """ Test use of filter during date assignment
+        """
         self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
@@ -1875,7 +1891,7 @@ class TestBasics():
         out = pds.date_range(start_date, stop_date, freq='2D').tolist()
 
         # Convert filenames in list to a date
-        for item in self.testInst._iter_list:
+        for i, item in enumerate(self.testInst._iter_list):
             snip = item.split('.')[0]
             ref_snip = out[i].strftime('%Y-%m-%d')
             assert snip == ref_snip

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -520,14 +520,17 @@ class TestBasics():
 
         with caplog.at_level(logging.INFO, logger='pysat'):
             self.testInst.download_updated_files()
-        # Perform a local search
-        assert "files locally" in caplog.text
-        # New files are found
+
+        # Test the logging output for the following conditions:
+        # - perform a local search,
+        # - new files are found,
+        # - download new files, and
+        # - update local file list.
+        assert "local files" in caplog.text
         assert "that are new or updated" in caplog.text
-        # download new files
         assert "Downloading data to" in caplog.text
-        # Update local file list
         assert "Updating pysat file list" in caplog.text
+
         if non_default:
             assert "Updating instrument object bounds " not in caplog.text
         else:
@@ -553,7 +556,7 @@ class TestBasics():
     #
     # -------------------------------------------------------------------------
     def test_today_yesterday_and_tomorrow(self):
-        self.ref_time = dt.datetime.now()
+        self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         assert self.out == self.testInst.today()
@@ -561,13 +564,13 @@ class TestBasics():
         assert self.out + pds.DateOffset(days=1) == self.testInst.tomorrow()
 
     def test_filter_datetime(self):
-        self.ref_time = dt.datetime.now()
+        self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         assert self.out == self.testInst._filter_datetime_input(self.ref_time)
 
     def test_filtered_date_attribute(self):
-        self.ref_time = dt.datetime.now()
+        self.ref_time = dt.datetime.utcnow()
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         self.testInst.date = self.ref_time
@@ -1870,12 +1873,12 @@ class TestBasics():
         stop_date = dt.datetime(2009, 1, 3)
         self.testInst.bounds = (start, stop, 2)
         out = pds.date_range(start_date, stop_date, freq='2D').tolist()
-        # convert filenames in list to a date
-        date_list = []
+
+        # Convert filenames in list to a date
         for item in self.testInst._iter_list:
             snip = item.split('.')[0]
-            date_list.append(dt.datetime.strptime(snip, '%Y-%m-%d'))
-        assert np.all(date_list == out)
+            ref_snip = out[i].strftime('%Y-%m-%d')
+            assert snip == ref_snip
 
     def test_iterate_bounds_fname_with_frequency(self):
         """Test iterate over bounds using filenames and non-default step"""

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -35,7 +35,7 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     ----
         If two files have the same date and time information in the
         filename then the file with the higher version/revision/cycle is used.
-        Series returned only has one file der datetime. Version is required
+        Series returned only has one file per datetime. Version is required
         for this filtering, revision and cycle are optional.
 
     """


### PR DESCRIPTION
# Description

As discussed in #604 and #611 it is too time intensive to define timezones to all timestamps.  However, we should not accidentally treat data from other timezones as UTC.  This PR addresses #514 by:

1) using `utcnow` for today/yesterday/tomorrow,
2) using Instrument time filtering function to convert times with timezones to UTC and then converting them to naive objects in UTC time, and
3) changing pds.DateOffset to dt.timedelta when appropriate.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added a new unit test.  Also did a time analysis of pandas vs datetime incrementation:

```
import timeit

timeit.timeit("import datetime as dt; import pandas as pds; dt.datetime.utcnow() + dt.timedelta(days=1)", number=10000)
timeit.timeit("import datetime as dt; import pandas as pds; dt.datetime.utcnow() + pds.DateOffset(days=1)", number=10000)
```

I got 0.026728390992502682 from the datetime call and 0.7501618139940547 from the pandas call.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
