### PR TITLE
TST: user support in instrument tests

### DIFF
--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -141,8 +141,10 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
 
     if tag == 'no_download':
         warnings.warn('This simulates an instrument without download support')
+    # Check that user name and password are passed through the unit tests
     if tag == 'user_password':
         if (not user) and (not password):
+            # Note that this line will be uncovered if test succeeds
             raise ValueError(' '.join(('Instrument is not passing user and',
                                        'password to test instruments')))
 

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -145,7 +145,7 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
     if tag == 'user_password':
         if (not user) and (not password):
             # Note that this line will be uncovered if test succeeds
-            raise ValueError(' '.join(('Instrument is not passing user and',
+            raise ValueError(' '.join(('Tests are not passing user and',
                                        'password to test instruments')))
 
     return

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -141,6 +141,10 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
 
     if tag == 'no_download':
         warnings.warn('This simulates an instrument without download support')
+    if tag == 'user_password':
+        if (not user) and (not password):
+            raise ValueError(' '.join(('Instrument is not passing user and',
+                                       'password to test instruments')))
 
     return
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -214,18 +214,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     # create some fake data to support testing of averaging routines
     mlt_int = data['mlt'].astype(int)
     long_int = (data['longitude'] / 15.0).astype(int)
-    if tag == 'ascend':
-        data['dummy1'] = [i for i in range(len(data['mlt']))]
-    elif tag == 'descend':
-        data['dummy1'] = [-i for i in range(len(data['mlt']))]
-    elif tag == 'plus10':
-        data['dummy1'] = [i + 10 for i in range(len(data['mlt']))]
-    elif tag == 'fives':
-        data['dummy1'] = [5 for i in range(len(data['mlt']))]
-    elif tag == 'mlt_offset':
-        data['dummy1'] = mlt_int + 5
-    else:
-        data['dummy1'] = mlt_int
+    data['dummy1'] = mlt_int
     data['dummy2'] = long_int
     data['dummy3'] = mlt_int + long_int * 1000.0
     data['dummy4'] = uts

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -23,21 +23,17 @@ name = 'testing'
 # dictionary of data 'tags' and corresponding description
 # tags are used to choose the behaviour of dummy1
 tags = {'': 'Regular testing data set',
-        'ascend': 'Ascending Integers from 0 testing data set',
-        'descend': 'Descending Integers from 0 testing data set',
-        'plus10': 'Ascending Integers from 10 testing data set',
-        'fives': 'All 5s testing data set',
-        'mlt_offset': 'dummy1 is offset by five from regular testing set',
         'no_download': 'simulate an instrument without download support',
-        'non_strict': 'simulate an instrument without strict_time_flag'}
+        'non_strict': 'simulate an instrument without strict_time_flag',
+        'user_password': 'simulates an instrument that requires a password'}
 
 # dictionary of satellite IDs, list of corresponding tags
 # a numeric string can be used in inst_id to change the number of points per day
-inst_ids = {'': ['', 'ascend', 'descend', 'plus10', 'fives', 'mlt_offset',
-                 'no_download']}
+inst_ids = {'': ['', 'no_download', 'non_strict', 'user_password']}
 _test_dates = {'': {'': dt.datetime(2009, 1, 1),
                     'no_download': dt.datetime(2009, 1, 1),
-                    'non_strict': dt.datetime(2009, 1, 1)}}
+                    'non_strict': dt.datetime(2009, 1, 1),
+                    'user_password': dt.datetime(2009, 1, 1)}}
 _test_download = {'': {'no_download': False}}
 
 

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -11,10 +11,6 @@ import pytest
 
 import pysat
 
-# dict, keyed by pysat instrument, with a list of usernames and passwords
-user_download_dict = {'supermag_magnetometer': {'user': 'rstoneback',
-                                                'password': 'None'}}
-
 
 def initialize_test_inst_and_date(inst_dict):
     """Initializes the instrument object to test and date
@@ -136,9 +132,8 @@ class InstTestClass():
         test_inst, date = initialize_test_inst_and_date(inst_dict)
 
         # check for username
-        inst_name = '_'.join((test_inst.platform, test_inst.name))
-        dl_dict = user_download_dict[inst_name] if inst_name in \
-            user_download_dict.keys() else {}
+        dl_dict = inst_dict['user_info'] if 'user_info' in \
+            inst_dict.keys() else {}
         test_inst.download(date, date, **dl_dict)
         assert len(test_inst.files.files) > 0
 

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -16,17 +16,20 @@ saved_path = pysat.data_dir
 
 # Optional code to pass through user and password info to test instruments
 # dict, keyed by pysat instrument, with a list of usernames and passwords
-# user_info = {'platform_name': {'user': 'rstoneback',
+# user_info = {'platform_name': {'user': 'pysat_user',
 #                                'password': 'None'}}
+user_info = {'pysat_testing': {'user': 'pysat_user',
+                               'password': 'pysat_for_me'}}
 
 # Developers for instrument libraries should update the following line to
 # point to their own subpackage location
 # e.g.,
 # instruments = generate_instrument_list(inst_loc=mypackage.inst)
-instruments = generate_instrument_list(inst_loc=pysat.instruments)
 # If user and password info supplied, use the following instead
 # instruments = generate_instrument_list(inst_loc=mypackage.inst,
 #                                        user_info=user_info)
+instruments = generate_instrument_list(inst_loc=pysat.instruments,
+                                       user_info=user_info)
 
 # The following lines apply the custom instrument lists to each type of test
 method_list = [func for func in dir(InstTestClass)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -14,16 +14,19 @@ from pysat.tests.instrument_test_class import InstTestClass
 
 saved_path = pysat.data_dir
 
+# Optional code to pass through user and password info to test instruments
 # dict, keyed by pysat instrument, with a list of usernames and passwords
-user_info = {'supermag_magnetometer': {'user': 'rstoneback',
-                                       'password': 'None'}}
+# user_info = {'platform_name': {'user': 'rstoneback',
+#                                'password': 'None'}}
 
 # Developers for instrument libraries should update the following line to
 # point to their own subpackage location
 # e.g.,
 # instruments = generate_instrument_list(inst_loc=mypackage.inst)
-instruments = generate_instrument_list(inst_loc=pysat.instruments,
-                                       user_info=user_info)
+instruments = generate_instrument_list(inst_loc=pysat.instruments)
+# If user and password info supplied, use the following instead
+# instruments = generate_instrument_list(inst_loc=mypackage.inst,
+#                                        user_info=user_info)
 
 # The following lines apply the custom instrument lists to each type of test
 method_list = [func for func in dir(InstTestClass)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -18,8 +18,8 @@ saved_path = pysat.data_dir
 # dict, keyed by pysat instrument, with a list of usernames and passwords
 # user_info = {'platform_name': {'user': 'pysat_user',
 #                                'password': 'None'}}
-user_info = {'pysat_testing': {'user': 'pysat_user',
-                               'password': 'pysat_for_me'}}
+user_info = {'pysat_testing': {'user': 'pysat_testing',
+                               'password': 'pysat.developers@gmail.com'}}
 
 # Developers for instrument libraries should update the following line to
 # point to their own subpackage location

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -14,11 +14,16 @@ from pysat.tests.instrument_test_class import InstTestClass
 
 saved_path = pysat.data_dir
 
+# dict, keyed by pysat instrument, with a list of usernames and passwords
+user_info = {'supermag_magnetometer': {'user': 'rstoneback',
+                                       'password': 'None'}}
+
 # Developers for instrument libraries should update the following line to
 # point to their own subpackage location
 # e.g.,
 # instruments = generate_instrument_list(inst_loc=mypackage.inst)
-instruments = generate_instrument_list(inst_loc=pysat.instruments)
+instruments = generate_instrument_list(inst_loc=pysat.instruments,
+                                       user_info=user_info)
 
 # The following lines apply the custom instrument lists to each type of test
 method_list = [func for func in dir(InstTestClass)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -515,7 +515,7 @@ def fmt_output_in_cols(out_strs, ncols=3, max_num=6, lpad=None):
     return output
 
 
-def generate_instrument_list(inst_loc):
+def generate_instrument_list(inst_loc, user_info=None):
     """Iterate through and classify instruments in a given subpackage.
 
 
@@ -524,6 +524,13 @@ def generate_instrument_list(inst_loc):
     inst_loc : python subpackage
         The location of the instrument subpackage to test,
         e.g., 'pysat.instruments'
+    user_info : dict or NoneType
+        Nested dictionary with user and password info for instrument module
+        name.  If None, no user or password is assumed.
+        (default=None)
+        EX: user_info = {'supermag_magnetometer': {'user': 'rstoneback',
+                                                   'password': 'None'}}
+
 
     Note
     ----
@@ -564,6 +571,9 @@ def generate_instrument_list(inst_loc):
                 for tag in info[inst_id].keys():
                     inst_dict = {'inst_module': module, 'tag': tag,
                                  'inst_id': inst_id}
+                    # Add username and password info if needed
+                    if user_info and inst_module in user_info:
+                        inst_dict['user_info'] = user_info[inst_module]
                     # Initialize instrument so that pysat can generate skip
                     # flags where appropriate
                     inst = pysat.Instrument(inst_module=module,


### PR DESCRIPTION
# Description

Addresses #573 

Moves user / password support from hardwired within tests to class structure to better support subpackages.  Leaving as draft until this is tested with pysatMadrigal.  Pinging @aburrell for further discussion and testing.  Syntax is based on the pysat 2.x implementation, but improvement suggestions are welcome.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Ran the unit tests with the `user_info` dictionary and without to validate tests continue to run as expected.

**Test Configuration**:
* Mac OS X 10.15.7
* Python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes -- part of overall test suite upgrade, already in changelog.
