### PR TITLE
STY: Use datetime.timedelta, not pandas.DateOffset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-12-03
+## [3.0.0] - 2020-12-10
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -89,6 +89,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Updated Instrument.concat_func to behave as described in the docstring
   - Moved setup metadata to setup.cfg
   - Improve instrument tests for files
+  - Use dt.timedelta instead of pds.DateOffSet where possible
 
 ## [2.2.2] - 2020-12-31
  - New Features

--- a/docs/tutorial_iteration.rst
+++ b/docs/tutorial_iteration.rst
@@ -204,7 +204,7 @@ set via the bounds attribute.
    # set a season with an expanded load range and increased step size
    # sets a data width of 2 days via the pandas DateOffset
    # sets a data step size of 2 days via the pandas frequency string, '2D'
-   vefi.bounds = (starts, stops, '2D', pds.DateOffset(days=2))
+   vefi.bounds = (starts, stops, '2D', dt.timedelta(days=2))
 
    # similarly, iteration over files is supported
    # file width is 2 files

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -307,13 +307,14 @@ class Instrument(object):
             self.multi_file_day = multi_file_day
 
         # Initialize the padding
-        if isinstance(pad, dt.timedelta) or pad is None:
+        if isinstance(pad, (dt.timedelta, pds.DateOffset)) or pad is None:
             self.pad = pad
         elif isinstance(pad, dict):
-            self.pad = dt.timedelta(**pad)
+            self.pad = pds.DateOffset(**pad)
         else:
-            raise ValueError(''.join(['pad must be a dict, NoneType, or ',
-                                      'pandas.DateOffset instance.']))
+            raise ValueError(' '.join(['pad must be a dict, NoneType,',
+                                       'datetime.timedelta, or',
+                                       'pandas.DateOffset instance.']))
 
         # Store kwargs, passed to standard routines first
         self.kwargs = {}

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -307,10 +307,10 @@ class Instrument(object):
             self.multi_file_day = multi_file_day
 
         # Initialize the padding
-        if isinstance(pad, pds.DateOffset) or pad is None:
+        if isinstance(pad, dt.timedelta) or pad is None:
             self.pad = pad
         elif isinstance(pad, dict):
-            self.pad = pds.DateOffset(**pad)
+            self.pad = dt.timedelta(**pad)
         else:
             raise ValueError(''.join(['pad must be a dict, NoneType, or ',
                                       'pandas.DateOffset instance.']))
@@ -408,7 +408,7 @@ class Instrument(object):
         self._export_meta_post_processing = None
 
         # start with a daily increment for loading
-        self.load_step = pds.DateOffset(days=1)
+        self.load_step = dt.timedelta(days=1)
 
         # Run instrument init function, a basic pass function is used if the
         # user doesn't supply the init function
@@ -1109,7 +1109,7 @@ class Instrument(object):
             file date (default=None)
         fid : int or NoneType
             filename index value (default=None)
-        inc : pds.DateOffset or int
+        inc : dt.timedelta or int
             Increment of files or dates to load, starting from the
             root date or fid (default=None)
 
@@ -1516,7 +1516,7 @@ class Instrument(object):
             day/file (default='1D', 1).
         width : pandas.DateOffset, int, or None
             Data window used when loading data within iteration. Defaults to a
-            single day/file if not assigned. (default=pds.DateOffset(days=1),
+            single day/file if not assigned. (default=dt.timedelta(days=1),
             1)
 
         Note
@@ -1554,7 +1554,7 @@ class Instrument(object):
 
             # Load more than a single day/file at a time when iterating
             inst.bounds = ([start, start2], [stop, stop2], '2D',
-                           pds.DateOffset(days=3))
+                           dt.timedelta(days=3))
 
         """
 
@@ -1580,7 +1580,7 @@ class Instrument(object):
             day/file (default='1D', 1).
         width (value[3]): pandas.DateOffset, int, or None
             Data window used when loading data within iteration. Defaults to a
-            single day/file if not assigned. (default=pds.DateOffset(days=1),
+            single day/file if not assigned. (default=dt.timedelta(days=1),
             1)
 
         Note
@@ -1615,7 +1615,7 @@ class Instrument(object):
 
             # Load more than a single day/file at a time when iterating
             inst.bounds = ([start, start2], [stop, stop2], '2D',
-                           pds.DateOffset(days=3))
+                           dt.timedelta(days=3))
 
         """
         if value is None:
@@ -1654,10 +1654,10 @@ class Instrument(object):
             if self._iter_step is None:
                 self._iter_step = '1D'
             if self._iter_width is None:
-                self._iter_width = pds.DateOffset(days=1)
+                self._iter_width = dt.timedelta(days=1)
             if self._iter_start[0] is not None:
                 # There are files. Use those dates.
-                ustops = [stop - self._iter_width + pds.DateOffset(days=1)
+                ustops = [stop - self._iter_width + dt.timedelta(days=1)
                           for stop in self._iter_stop]
                 ufreq = self._iter_step
                 self._iter_list = utils.time.create_date_range(self._iter_start,
@@ -1759,7 +1759,7 @@ class Instrument(object):
                     self._iter_step = '1D'
                 # default window size
                 if self._iter_width is None:
-                    self._iter_width = pds.DateOffset(days=1)
+                    self._iter_width = dt.timedelta(days=1)
 
                 # create list-like of dates for iteration
                 starts = self._filter_datetime_input(starts)
@@ -1778,7 +1778,7 @@ class Instrument(object):
                         raise ValueError(estr)
 
                 # account for width of load. Don't extend past bound.
-                ustops = [stop - width + pds.DateOffset(days=1)
+                ustops = [stop - width + dt.timedelta(days=1)
                           for stop in stops]
                 self._iter_list = utils.time.create_date_range(starts,
                                                                ustops,
@@ -1910,7 +1910,7 @@ class Instrument(object):
 
         """
 
-        return self.today() + pds.DateOffset(days=1)
+        return self.today() + dt.timedelta(days=1)
 
     def yesterday(self):
         """Returns yesterday's date (UTC), with no hour, minute, second, etc.
@@ -1922,7 +1922,7 @@ class Instrument(object):
 
         """
 
-        return self.today() - pds.DateOffset(days=1)
+        return self.today() - dt.timedelta(days=1)
 
     def next(self, verifyPad=False):
         """Manually iterate through the data loaded in Instrument object.
@@ -2452,7 +2452,7 @@ class Instrument(object):
                 raise ValueError(estr)
             else:
                 # increment end by a day if none supplied
-                self.load_step = pds.DateOffset(days=1)
+                self.load_step = dt.timedelta(days=1)
 
             curr = self.date
 
@@ -2470,7 +2470,7 @@ class Instrument(object):
                 self.load_step = end_date - date
             else:
                 # defaults to single day load
-                self.load_step = pds.DateOffset(days=1)
+                self.load_step = dt.timedelta(days=1)
             curr = date
 
         elif fname is not None:
@@ -2512,7 +2512,7 @@ class Instrument(object):
                 raise ValueError(estr)
 
             date = self.files.files.index[0]
-            end_date = self.files.files.index[-1] + pds.DateOffset(days=1)
+            end_date = self.files.files.index[-1] + dt.timedelta(days=1)
 
             self._set_load_parameters(date=date, fid=None)
             curr = date
@@ -2525,7 +2525,7 @@ class Instrument(object):
 
         # if pad  or multi_file_day is true, need to have a three day/file load
         loop_pad = self.pad if self.pad is not None \
-            else pds.DateOffset(seconds=0)
+            else dt.timedelta(seconds=0)
 
         # check for constiency between loading range and data padding, if any
         if self.pad is not None:

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -196,9 +196,9 @@ class Orbits(object):
                 raise ValueError(estr)
         else:
             # iterating by date
-            # need to check step (frequency string) against width (DateOffset)
+            # need to check step (frequency string) against width (timedelta)
             step = pds.tseries.frequencies.to_offset(self.sat._iter_step)
-            step = pds.DateOffset(seconds=step.delta.total_seconds())
+            step = dt.timedelta(seconds=step.delta.total_seconds())
             root = dt.datetime(2001, 1, 1)
             if root + step < root + self.sat._iter_width:
                 raise ValueError(estr)
@@ -574,7 +574,7 @@ class Orbits(object):
                         # check if we are close to beginning or end of day
                         date = self.sat.date
                         delta_start = self.sat.index[-1] - date
-                        delta_end = (date + pds.DateOffset(days=1)
+                        delta_end = (date + dt.timedelta(days=1)
                                      - self.sat.index[0])
 
                         if delta_start <= self.orbit_period * 1.05:
@@ -596,7 +596,7 @@ class Orbits(object):
                             self.sat.next()
                             self.prev()
                             if self.sat.index[0] > (date - delta_end
-                                                    + pds.DateOffset(days=1)):
+                                                    + dt.timedelta(days=1)):
                                 # we could go forward a day, iterate over orbit,
                                 # as above, and the data we have is the wrong
                                 # day.
@@ -709,7 +709,7 @@ class Orbits(object):
                             # combine this next day's data with previous last
                             # orbit, grab the first one
                             final_val = self.sat.index[0] \
-                                - pds.DateOffset(microseconds=1)
+                                - dt.timedelta(microseconds=1)
                             self.sat.concat_data(temp_orbit_data[:final_val],
                                                  prepend=True)
                             self._getBasicOrbit(orbit=1)
@@ -752,7 +752,7 @@ class Orbits(object):
                         # data and grab second orbit (first is old)
                         self.sat.concat_data(
                             temp_orbit_data[:self.sat.index[0]
-                                            - pds.DateOffset(microseconds=1)],
+                                            - dt.timedelta(microseconds=1)],
                             prepend=True)
 
                         # select second orbit of combined data
@@ -762,7 +762,7 @@ class Orbits(object):
                         # just grab the first orbit of loaded data
                         self._getBasicOrbit(orbit=1)
                         if self.sat._iter_type == 'date':
-                            delta = (self.sat.date + pds.DateOffset(days=1)
+                            delta = (self.sat.date + dt.timedelta(days=1)
                                      - self.sat.index[0])
 
                             if delta < self.orbit_period:

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -94,8 +94,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     # TODO: take file frequency as an input to allow e.g., weekly files
     if (not out.empty) and fake_daily_files_from_monthly:
         emonth = out.index[-1]
-        out.loc[out.index[-1] + pds.DateOffset(months=1)
-                - pds.DateOffset(days=1)] = out.iloc[-1]
+        out.loc[out.index[-1] + dt.timedelta(months=1)
+                - dt.timedelta(days=1)] = out.iloc[-1]
         new_out = out.asfreq('D')
 
         for i, out_month in enumerate(out.index):

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -94,7 +94,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     # TODO: take file frequency as an input to allow e.g., weekly files
     if (not out.empty) and fake_daily_files_from_monthly:
         emonth = out.index[-1]
-        out.loc[out.index[-1] + dt.timedelta(months=1)
+        out.loc[out.index[-1] + pds.DateOffset(months=1)
                 - dt.timedelta(days=1)] = out.iloc[-1]
         new_out = out.asfreq('D')
 

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -220,7 +220,7 @@ def generate_times(fnames, num, freq='1S'):
         dates.append(date)
 
         # Create one day of data at desired frequency
-        end_date = date + pds.DateOffset(seconds=86399)
+        end_date = date + dt.timedelta(seconds=86399)
         index = pds.date_range(start=date, end=end_date, freq=freq)
         index = index[0:num]
         indices.extend(index)

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -81,7 +81,7 @@ def init(self):
     # mess with file dates if kwarg option present
     if self.kwargs['load']['mangle_file_dates']:
         self.files.files.index = \
-            self.files.files.index + pds.DateOffset(minutes=5)
+            self.files.files.index + dt.timedelta(minutes=5)
     return
 
 
@@ -169,7 +169,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
                                                freq='1S')
 
     # Specify the date tag locally and determine the desired date range
-    pds_offset = pds.DateOffset(hours=12)
+    pds_offset = dt.timedelta(hours=12)
     if sim_multi_file_right:
         root_date = root_date or _test_dates[''][''] + pds_offset
     elif sim_multi_file_left:

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -150,7 +150,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     # this time signal used for 2D profiles associated with each time in main
     # DataFrame
     num_profiles = 50 if num_samples >= 50 else num_samples
-    end_date = dates[0] + pds.DateOffset(seconds=2 * num_profiles - 1)
+    end_date = dates[0] + dt.timedelta(seconds=2 * num_profiles - 1)
     high_rate_template = pds.date_range(dates[0], end_date, freq='2S')
 
     # create a few simulated profiles

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -112,7 +112,7 @@ class TestBasics():
             pytest.skip('pandas specific test for time index')
 
         def custom1(inst):
-            new_index = inst.index + pds.DateOffset(milliseconds=500)
+            new_index = inst.index + dt.timedelta(milliseconds=500)
             d = pds.Series(2.0 * inst['mlt'], index=new_index)
             d.name = 'doubleMLT'
             return d

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -1,5 +1,6 @@
-import logging
+import datetime as dt
 from io import StringIO
+import logging
 import numpy as np
 import pandas as pds
 import pytest

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2690,6 +2690,7 @@ class TestDataPadding():
         del self.testInst, self.ref_time, self.ref_doy
 
     def test_data_padding(self):
+        """Ensure that pad works at the instrument level"""
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         assert (self.testInst.index[0]
                 == self.testInst.date - dt.timedelta(minutes=5))

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -734,7 +734,7 @@ class TestBasics():
         """Test string output with data padding """
         self.testInst.pad = dt.timedelta(minutes=5)
         self.out = self.testInst.__str__()
-        assert self.out.find('timedelta: minutes=5') > 0
+        assert self.out.find('Data Padding: 0:05:00') > 0
 
     def test_str_w_custom_func(self):
         """Test string output with custom function """

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2699,9 +2699,10 @@ class TestDataPadding():
                 + dt.timedelta(minutes=5))
 
     @pytest.mark.parametrize('pad', [dt.timedelta(minutes=5),
-                                     pds.DateOffset(minutes=5)])
+                                     pds.DateOffset(minutes=5),
+                                     {'minutes': 5}])
     def test_data_padding_offset_instantiation(self, pad):
-        """Ensure pad can be used as either datetime or pandas"""
+        """Ensure pad can be used as datetime, pandas, or dict"""
         testInst = pysat.Instrument(platform='pysat', name='testing',
                                     clean_level='clean',
                                     pad=pad,

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -99,11 +99,11 @@ class TestBasics():
         if isinstance(step, int):
             step = str(step) + 'D'
         if isinstance(width, int):
-            width = pds.DateOffset(days=width)
+            width = dt.timedelta(days=width)
 
         out = []
         for start, stop in zip(starts, stops):
-            tdate = stop - width + pds.DateOffset(days=1)
+            tdate = stop - width + dt.timedelta(days=1)
             out.extend(pds.date_range(start, tdate, freq=step).tolist())
         if reverse:
             out = out[::-1]
@@ -142,8 +142,8 @@ class TestBasics():
         self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
         assert (self.out == self.testInst.date)
         self.out = self.testInst.index[-1]
-        assert (self.out >= self.ref_time + pds.DateOffset(days=1))
-        assert (self.out <= self.ref_time + pds.DateOffset(days=2))
+        assert (self.out >= self.ref_time + dt.timedelta(days=1))
+        assert (self.out <= self.ref_time + dt.timedelta(days=2))
 
     def test_basic_instrument_bad_keyword(self):
         """Checks for error when instantiating with bad load_rtn keywords"""
@@ -223,7 +223,7 @@ class TestBasics():
         assert (self.testInst.index[0] == self.testInst.files.start_date)
         assert (self.testInst.index[-1] >= self.testInst.files.stop_date)
         assert (self.testInst.index[-1] <= self.testInst.files.stop_date
-                + pds.DateOffset(days=1))
+                + dt.timedelta(days=1))
         return
 
     def test_basic_instrument_load_by_file_and_multifile(self):
@@ -266,15 +266,15 @@ class TestBasics():
 
     def test_basic_instrument_load_by_dates(self):
         """Test date range loading, date and end_date"""
-        end_date = self.ref_time + pds.DateOffset(days=2)
+        end_date = self.ref_time + dt.timedelta(days=2)
         self.testInst.load(date=self.ref_time, end_date=end_date)
         self.out = self.testInst.index[0]
         assert (self.out == self.ref_time)
         self.out = dt.datetime(self.out.year, self.out.month, self.out.day)
         assert (self.out == self.testInst.date)
         self.out = self.testInst.index[-1]
-        assert (self.out >= self.ref_time + pds.DateOffset(days=1))
-        assert (self.out <= self.ref_time + pds.DateOffset(days=2))
+        assert (self.out >= self.ref_time + dt.timedelta(days=1))
+        assert (self.out <= self.ref_time + dt.timedelta(days=2))
 
     def test_basic_instrument_load_by_date_with_extra_time(self):
         """Ensure .load(date=date) only uses year, month, day portion of date"""
@@ -354,9 +354,9 @@ class TestBasics():
         """
         self.testInst.load(date=self.ref_time)
         # set new bounds that doesn't include this date
-        self.testInst.bounds = (self.ref_time + pds.DateOffset(days=1),
-                                self.ref_time + pds.DateOffset(days=10),
-                                '2D', pds.DateOffset(days=1))
+        self.testInst.bounds = (self.ref_time + dt.timedelta(days=1),
+                                self.ref_time + dt.timedelta(days=10),
+                                '2D', dt.timedelta(days=1))
 
         with pytest.raises(StopIteration) as err:
             self.testInst.next()
@@ -371,9 +371,9 @@ class TestBasics():
         self.ref_time = dt.datetime(2008, 1, 2)
         self.testInst.load(date=self.ref_time)
         # set new bounds that doesn't include this date
-        self.testInst.bounds = (self.ref_time + pds.DateOffset(days=1),
-                                self.ref_time + pds.DateOffset(days=10),
-                                '2D', pds.DateOffset(days=1))
+        self.testInst.bounds = (self.ref_time + dt.timedelta(days=1),
+                                self.ref_time + dt.timedelta(days=10),
+                                '2D', dt.timedelta(days=1))
         with pytest.raises(StopIteration) as err:
             self.testInst.prev()
         estr = 'Unable to find loaded date '
@@ -384,7 +384,7 @@ class TestBasics():
     def test_next_load_empty_iteration(self):
         """Ensure empty iteration list handled ok via .next"""
         self.testInst.bounds = (None, None, '10000D',
-                                pds.DateOffset(days=10000))
+                                dt.timedelta(days=10000))
         with pytest.raises(StopIteration) as err:
             self.testInst.next()
         estr = 'File list is empty. '
@@ -395,7 +395,7 @@ class TestBasics():
     def test_prev_load_empty_iteration(self):
         """Ensure empty iteration list handled ok via .prev"""
         self.testInst.bounds = (None, None, '10000D',
-                                pds.DateOffset(days=10000))
+                                dt.timedelta(days=10000))
         with pytest.raises(StopIteration) as err:
             self.testInst.prev()
         estr = 'File list is empty. '
@@ -442,17 +442,17 @@ class TestBasics():
     def test_filenames_load(self):
         """Test if files are loadable by filenames, relative to
         top_data_dir/platform/name/tag"""
-        stop_fname = self.ref_time + pds.DateOffset(days=1)
+        stop_fname = self.ref_time + dt.timedelta(days=1)
         stop_fname = stop_fname.strftime('%Y-%m-%d.nofile')
         self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'),
                            stop_fname=stop_fname)
         assert self.testInst.index[0] == self.ref_time
-        assert self.testInst.index[-1] >= self.ref_time + pds.DateOffset(days=1)
-        assert self.testInst.index[-1] <= self.ref_time + pds.DateOffset(days=2)
+        assert self.testInst.index[-1] >= self.ref_time + dt.timedelta(days=1)
+        assert self.testInst.index[-1] <= self.ref_time + dt.timedelta(days=2)
 
     def test_filenames_load_out_of_order(self):
         """Test error raised if fnames out of temporal order"""
-        stop_fname = self.ref_time + pds.DateOffset(days=1)
+        stop_fname = self.ref_time + dt.timedelta(days=1)
         stop_fname = stop_fname.strftime('%Y-%m-%d.nofile')
         with pytest.raises(ValueError) as err:
             check_fname = self.ref_time.strftime('%Y-%m-%d.nofile')
@@ -557,8 +557,8 @@ class TestBasics():
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         assert self.out == self.testInst.today()
-        assert self.out - pds.DateOffset(days=1) == self.testInst.yesterday()
-        assert self.out + pds.DateOffset(days=1) == self.testInst.tomorrow()
+        assert self.out - dt.timedelta(days=1) == self.testInst.yesterday()
+        assert self.out + dt.timedelta(days=1) == self.testInst.tomorrow()
 
     def test_filter_datetime(self):
         self.ref_time = dt.datetime.now()
@@ -732,7 +732,7 @@ class TestBasics():
 
     def test_str_w_padding(self):
         """Test string output with data padding """
-        self.testInst.pad = pds.DateOffset(minutes=5)
+        self.testInst.pad = dt.timedelta(minutes=5)
         self.out = self.testInst.__str__()
         assert self.out.find('DateOffset: minutes=5') > 0
 
@@ -866,7 +866,7 @@ class TestBasics():
         self.testInst.load(self.ref_time.year, self.ref_doy)
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
-        offset = pds.DateOffset(seconds=(10 * time_step))
+        offset = dt.timedelta(seconds=(10 * time_step))
         start = dt.datetime(2009, 1, 1, 0, 0, 0)
         stop = start + offset
         assert np.all(self.testInst[start:stop, 'uts']
@@ -977,7 +977,7 @@ class TestBasics():
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
-        offset = pds.DateOffset(seconds=(10 * time_step))
+        offset = dt.timedelta(seconds=(10 * time_step))
         start = dt.datetime(2009, 1, 1, 0, 0, 0)
         stop = start + offset
         self.testInst[start:stop, 'doubleMLT'] = 0
@@ -1181,7 +1181,7 @@ class TestBasics():
     def test_set_bounds_with_frequency(self):
         """Test setting bounds with non-default step"""
         start = self.ref_time
-        stop = self.ref_time + pds.DateOffset(days=14)
+        stop = self.ref_time + dt.timedelta(days=14)
         stop = stop.to_pydatetime()
         self.testInst.bounds = (start, stop, 'M')
         assert np.all(self.testInst._iter_list
@@ -1190,7 +1190,7 @@ class TestBasics():
     def test_iterate_bounds_with_frequency(self):
         """Test iterating bounds with non-default step"""
         start = self.ref_time
-        stop = self.ref_time + pds.DateOffset(days=15)
+        stop = self.ref_time + dt.timedelta(days=15)
         stop = stop.to_pydatetime()
         self.testInst.bounds = (start, stop, '2D')
         dates = []
@@ -1202,9 +1202,9 @@ class TestBasics():
     def test_set_bounds_with_frequency_and_width(self):
         """Set date bounds with step/width>1"""
         start = self.ref_time
-        stop = self.ref_time + pds.DateOffset(months=11, days=25)
+        stop = self.ref_time + dt.timedelta(months=11, days=25)
         stop = stop.to_pydatetime()
-        self.testInst.bounds = (start, stop, '10D', pds.DateOffset(days=10))
+        self.testInst.bounds = (start, stop, '10D', dt.timedelta(days=10))
         assert np.all(self.testInst._iter_list
                       == pds.date_range(start, stop, freq='10D').tolist())
 
@@ -1220,9 +1220,9 @@ class TestBasics():
                 # check loaded range is correct
                 assert trange[0] == out['expected_times'][i]
                 check = out['expected_times'][i] + out['width']
-                check -= pds.DateOffset(days=1)
+                check -= dt.timedelta(days=1)
                 assert trange[1] > check
-                check = out['stops'][b_range] + pds.DateOffset(days=1)
+                check = out['stops'][b_range] + dt.timedelta(days=1)
                 assert trange[1] < check
         else:
             # verify range of loaded data when going backwards
@@ -1235,17 +1235,17 @@ class TestBasics():
                 assert trange[0] == out['expected_times'][i]
                 # check end against expectations
                 check = out['expected_times'][i] + out['width']
-                check -= pds.DateOffset(days=1)
+                check -= dt.timedelta(days=1)
                 assert trange[1] > check
-                check = out['stops'][b_range] + pds.DateOffset(days=1)
+                check = out['stops'][b_range] + dt.timedelta(days=1)
                 assert trange[1] < check
                 if i == 0:
                     # check first load is before end of bounds
                     check = out['stops'][b_range] - out['width']
-                    check += pds.DateOffset(days=1)
+                    check += dt.timedelta(days=1)
                     assert trange[0] == check
                     assert trange[1] > out['stops'][b_range]
-                    check = out['stops'][b_range] + pds.DateOffset(days=1)
+                    check = out['stops'][b_range] + dt.timedelta(days=1)
                     assert trange[1] < check
                 elif i == len(out['observed_times']) - 1:
                     # last load at start of bounds
@@ -1267,7 +1267,7 @@ class TestBasics():
                 # check loaded range is correct
                 assert trange[0] == out['expected_times'][i]
                 check = out['expected_times'][i] + out['width']
-                check -= pds.DateOffset(days=1)
+                check -= dt.timedelta(days=1)
                 assert trange[1] > check
                 assert trange[1] < out['stops'][b_range]
 
@@ -1282,14 +1282,14 @@ class TestBasics():
                 assert trange[0] == out['expected_times'][i]
                 # check end against expectations
                 check = out['expected_times'][i] + out['width']
-                check -= pds.DateOffset(days=1)
+                check -= dt.timedelta(days=1)
                 assert trange[1] > check
-                check = out['stops'][b_range] + pds.DateOffset(days=1)
+                check = out['stops'][b_range] + dt.timedelta(days=1)
                 assert trange[1] < check
                 if i == 0:
                     # check first load is before end of bounds
                     check = out['stops'][b_range] - out['width']
-                    check += pds.DateOffset(days=1)
+                    check += dt.timedelta(days=1)
                     assert trange[0] < check
                     assert trange[1] < out['stops'][b_range]
                 elif i == len(out['observed_times']) - 1:
@@ -1302,16 +1302,16 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 3), '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 4), '2D',
-                                         pds.DateOffset(days=3)),
+                                         dt.timedelta(days=3)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 5), '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 17), '5D',
-                                         pds.DateOffset(days=1))
+                                         dt.timedelta(days=1))
                                         ])
     def test_iterate_bounds_with_frequency_and_width(self, values):
         """Iterate via date with mixed step/width, excludes stop date"""
@@ -1323,22 +1323,22 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 4), '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 4), '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 4), '1D',
-                                         pds.DateOffset(days=4)),
+                                         dt.timedelta(days=4)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 5), '4D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 5), '2D',
-                                         pds.DateOffset(days=3)),
+                                         dt.timedelta(days=3)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 5), '3D',
-                                         pds.DateOffset(days=2))])
+                                         dt.timedelta(days=2))])
     def test_iterate_bounds_with_frequency_and_width_incl(self, values):
         """Iterate via date with mixed step/width, includes stop date"""
         out = self.support_iter_evaluations(values, for_loop=True)
@@ -1349,16 +1349,16 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 10), '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 9), '4D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 11), '1D',
-                                         pds.DateOffset(days=3)),
+                                         dt.timedelta(days=3)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 11), '1D',
-                                         pds.DateOffset(days=11)),
+                                         dt.timedelta(days=11)),
                                         ])
     def test_next_date_with_frequency_and_width_incl(self, values):
         """Test .next() via date step/width>1, includes stop date"""
@@ -1370,19 +1370,19 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 11), '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 12), '2D',
-                                         pds.DateOffset(days=3)),
+                                         dt.timedelta(days=3)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 13), '3D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 3), '4D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 12), '2D',
-                                         pds.DateOffset(days=1))])
+                                         dt.timedelta(days=1))])
     def test_next_date_with_frequency_and_width(self, values):
         """Test .next() via date step/width>1, excludes stop date"""
         out = self.support_iter_evaluations(values)
@@ -1396,19 +1396,19 @@ class TestBasics():
                                          (dt.datetime(2009, 1, 4),
                                           dt.datetime(2009, 1, 13)),
                                          '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 7),
                                           dt.datetime(2009, 1, 16)),
                                          '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 6),
                                           dt.datetime(2009, 1, 15)),
                                          '2D',
-                                         pds.DateOffset(days=4))
+                                         dt.timedelta(days=4))
                                         ])
     def test_next_date_season_frequency_and_width_incl(self, values):
         """Test .next() via date season step/width>1, includes stop date"""
@@ -1423,19 +1423,19 @@ class TestBasics():
                                          (dt.datetime(2009, 1, 3),
                                           dt.datetime(2009, 1, 12)),
                                          '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 6),
                                           dt.datetime(2009, 1, 15)),
                                          '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 7),
                                           dt.datetime(2009, 1, 16)),
                                          '2D',
-                                         pds.DateOffset(days=4))
+                                         dt.timedelta(days=4))
                                         ])
     def test_next_date_season_frequency_and_width(self, values):
         """Test .next() via date season step/width>1, excludes stop date"""
@@ -1447,16 +1447,16 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 10), '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 9), '4D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 11), '1D',
-                                         pds.DateOffset(days=3)),
+                                         dt.timedelta(days=3)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 11), '1D',
-                                         pds.DateOffset(days=11)),
+                                         dt.timedelta(days=11)),
                                         ])
     def test_prev_date_with_frequency_and_width_incl(self, values):
         """Test .prev() via date step/width>1, includes stop date"""
@@ -1468,19 +1468,19 @@ class TestBasics():
 
     @pytest.mark.parametrize("values", [(dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 11), '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 12), '2D',
-                                         pds.DateOffset(days=3)),
+                                         dt.timedelta(days=3)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 13), '3D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 3), '4D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         (dt.datetime(2009, 1, 1),
                                          dt.datetime(2009, 1, 12), '2D',
-                                         pds.DateOffset(days=1))])
+                                         dt.timedelta(days=1))])
     def test_prev_date_with_frequency_and_width(self, values):
         """Test .prev() via date step/width>1, excludes stop date"""
         out = self.support_iter_evaluations(values, reverse=True)
@@ -1494,19 +1494,19 @@ class TestBasics():
                                          (dt.datetime(2009, 1, 4),
                                           dt.datetime(2009, 1, 13)),
                                          '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 7),
                                           dt.datetime(2009, 1, 16)),
                                          '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 6),
                                           dt.datetime(2009, 1, 15)),
                                          '2D',
-                                         pds.DateOffset(days=4))
+                                         dt.timedelta(days=4))
                                         ])
     def test_prev_date_season_frequency_and_width_incl(self, values):
         """Test .prev() via date season step/width>1, includes stop date"""
@@ -1521,19 +1521,19 @@ class TestBasics():
                                          (dt.datetime(2009, 1, 3),
                                           dt.datetime(2009, 1, 12)),
                                          '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 6),
                                           dt.datetime(2009, 1, 15)),
                                          '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 7),
                                           dt.datetime(2009, 1, 16)),
                                          '2D',
-                                         pds.DateOffset(days=4))
+                                         dt.timedelta(days=4))
                                         ])
     def test_prev_date_season_frequency_and_width(self, values):
         """Test .prev() via date season step/width>1, excludes stop date"""
@@ -1582,7 +1582,7 @@ class TestBasics():
         """Ensure error if too many inputs to inst.bounds"""
         start = dt.datetime(2009, 1, 1)
         stop = dt.datetime(2009, 1, 1)
-        width = pds.DateOffset(days=1)
+        width = dt.timedelta(days=1)
         with pytest.raises(ValueError) as err:
             self.testInst.bounds = [start, stop, '1D', width, False]
         estr = 'Too many input arguments.'
@@ -1697,19 +1697,19 @@ class TestBasics():
                                          (dt.datetime(2009, 1, 3),
                                           dt.datetime(2009, 1, 12)),
                                          '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 6),
                                           dt.datetime(2009, 1, 15)),
                                          '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 7),
                                           dt.datetime(2009, 1, 16)),
                                          '2D',
-                                         pds.DateOffset(days=4))
+                                         dt.timedelta(days=4))
                                         ])
     def test_iterate_over_bounds_set_by_date_season_step_width(self, values):
         """Iterate over season, step/width > 1, excludes stop bounds"""
@@ -1725,19 +1725,19 @@ class TestBasics():
                                          (dt.datetime(2009, 1, 4),
                                           dt.datetime(2009, 1, 13)),
                                          '2D',
-                                         pds.DateOffset(days=2)),
+                                         dt.timedelta(days=2)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 7),
                                           dt.datetime(2009, 1, 16)),
                                          '3D',
-                                         pds.DateOffset(days=1)),
+                                         dt.timedelta(days=1)),
                                         ((dt.datetime(2009, 1, 1),
                                           dt.datetime(2009, 1, 10)),
                                          (dt.datetime(2009, 1, 6),
                                           dt.datetime(2009, 1, 15)),
                                          '2D',
-                                         pds.DateOffset(days=4))
+                                         dt.timedelta(days=4))
                                         ])
     def test_iterate_bounds_set_by_date_season_step_width_incl(self, values):
         """Iterate over season, step/width > 1, includes stop bounds"""
@@ -1898,7 +1898,7 @@ class TestBasics():
         stop = '2009-01-03.nofile'
         stop_date = dt.datetime(2009, 1, 3)
         self.testInst.bounds = (start, stop, 2, 2)
-        out = pds.date_range(start_date, stop_date - pds.DateOffset(days=1),
+        out = pds.date_range(start_date, stop_date - dt.timedelta(days=1),
                              freq='2D').tolist()
         # convert filenames in list to a date
         date_list = []
@@ -2477,7 +2477,7 @@ class TestDataPaddingbyFile():
         """Test data padding loading by filename"""
         self.testInst.load(fname=self.testInst.files[1], verifyPad=True)
         self.rawInst.load(fname=self.testInst.files[1])
-        self.delta = pds.DateOffset(minutes=5)
+        self.delta = dt.timedelta(minutes=5)
         assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
         assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
@@ -2486,7 +2486,7 @@ class TestDataPaddingbyFile():
         self.testInst.load(fname=self.testInst.files[1], verifyPad=True)
         self.testInst.next(verifyPad=True)
         self.rawInst.load(fname=self.testInst.files[2])
-        self.delta = pds.DateOffset(minutes=5)
+        self.delta = dt.timedelta(minutes=5)
         assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
         assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
@@ -2497,7 +2497,7 @@ class TestDataPaddingbyFile():
         self.testInst.next()
         self.testInst.next(verifyPad=True)
         self.rawInst.load(fname=self.testInst.files[3])
-        self.delta = pds.DateOffset(minutes=5)
+        self.delta = dt.timedelta(minutes=5)
         assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
         assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
@@ -2506,7 +2506,7 @@ class TestDataPaddingbyFile():
         self.testInst.load(fname=self.testInst.files[2], verifyPad=True)
         self.testInst.prev(verifyPad=True)
         self.rawInst.load(fname=self.testInst.files[1])
-        self.delta = pds.DateOffset(minutes=5)
+        self.delta = dt.timedelta(minutes=5)
         assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
         assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
@@ -2517,7 +2517,7 @@ class TestDataPaddingbyFile():
         self.testInst.prev()
         self.testInst.prev(verifyPad=True)
         self.rawInst.load(fname=self.testInst.files[8])
-        self.delta = pds.DateOffset(minutes=5)
+        self.delta = dt.timedelta(minutes=5)
         assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
         assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
@@ -2526,7 +2526,7 @@ class TestDataPaddingbyFile():
         self.testInst.load(fname=self.testInst.files[1], verifyPad=True)
         self.testInst.load(fname=self.testInst.files[10], verifyPad=True)
         self.rawInst.load(fname=self.testInst.files[10])
-        self.delta = pds.DateOffset(minutes=5)
+        self.delta = dt.timedelta(minutes=5)
         assert (self.testInst.index[0] == self.rawInst.index[0] - self.delta)
         assert (self.testInst.index[-1] == self.rawInst.index[-1] + self.delta)
 
@@ -2666,21 +2666,21 @@ class TestDataPadding():
     def test_data_padding(self):
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         assert (self.testInst.index[0]
-                == self.testInst.date - pds.DateOffset(minutes=5))
+                == self.testInst.date - dt.timedelta(minutes=5))
         assert (self.testInst.index[-1] == self.testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_offset_instantiation(self):
         testInst = pysat.Instrument(platform='pysat', name='testing',
                                     clean_level='clean',
-                                    pad=pds.DateOffset(minutes=5),
+                                    pad=dt.timedelta(minutes=5),
                                     update_files=True)
         testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
-        assert (testInst.index[0] == testInst.date - pds.DateOffset(minutes=5))
+        assert (testInst.index[0] == testInst.date - dt.timedelta(minutes=5))
         assert (testInst.index[-1] == testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_bad_instantiation(self):
         """Ensure error when padding input type incorrect"""
@@ -2719,12 +2719,12 @@ class TestDataPadding():
         self.testInst.load(yr, doy, verifyPad=True)
         assert self.testInst.index[0] == self.testInst.date
         assert self.testInst.index[-1] > self.testInst.date \
-               + pds.DateOffset(days=1)
+               + dt.timedelta(days=1)
 
         self.testInst.load(yr, doy)
         assert self.testInst.index[0] == self.testInst.date
         assert self.testInst.index[-1] < self.testInst.date \
-               + pds.DateOffset(days=1)
+               + dt.timedelta(days=1)
 
     def test_yrdoy_data_padding_missing_later_days(self):
         """Test padding feature operates when there are missing later days"""
@@ -2732,12 +2732,12 @@ class TestDataPadding():
         self.testInst.load(yr, doy, verifyPad=True)
         assert self.testInst.index[0] < self.testInst.date
         assert self.testInst.index[-1] < self.testInst.date \
-               + pds.DateOffset(days=1)
+               + dt.timedelta(days=1)
 
         self.testInst.load(yr, doy)
         assert self.testInst.index[0] == self.testInst.date
         assert self.testInst.index[-1] < self.testInst.date \
-               + pds.DateOffset(days=1)
+               + dt.timedelta(days=1)
 
     def test_yrdoy_data_padding_missing_earlier_and_later_days(self):
         """Test padding feature operates when missing earlier/later days"""
@@ -2747,16 +2747,16 @@ class TestDataPadding():
         self.testInst.load(yr, doy, verifyPad=True)
         assert self.testInst.index[0] == self.testInst.date
         assert self.testInst.index[-1] < self.testInst.date \
-               + pds.DateOffset(days=1)
+               + dt.timedelta(days=1)
 
     def test_data_padding_next(self):
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.testInst.next(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
-                - pds.DateOffset(minutes=5))
+                - dt.timedelta(minutes=5))
         assert (self.testInst.index[-1] == self.testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_multi_next(self):
         """This also tests that _prev_data and _next_data cacheing"""
@@ -2764,19 +2764,19 @@ class TestDataPadding():
         self.testInst.next()
         self.testInst.next(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
-                - pds.DateOffset(minutes=5))
+                - dt.timedelta(minutes=5))
         assert (self.testInst.index[-1] == self.testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_prev(self):
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.testInst.prev(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
-                - pds.DateOffset(minutes=5))
+                - dt.timedelta(minutes=5))
         assert (self.testInst.index[-1] == self.testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_multi_prev(self):
         """This also tests that _prev_data and _next_data cacheing"""
@@ -2785,21 +2785,21 @@ class TestDataPadding():
         self.testInst.prev()
         self.testInst.prev(verifyPad=True)
         assert (self.testInst.index[0] == self.testInst.date
-                - pds.DateOffset(minutes=5))
+                - dt.timedelta(minutes=5))
         assert (self.testInst.index[-1] == self.testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_jump(self):
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.testInst.load(self.ref_time.year, self.ref_doy + 10,
                            verifyPad=True)
         assert (self.testInst.index[0]
-                == self.testInst.date - pds.DateOffset(minutes=5))
+                == self.testInst.date - dt.timedelta(minutes=5))
         assert (self.testInst.index[-1]
                 == self.testInst.date
-                + pds.DateOffset(hours=23, minutes=59, seconds=59)
-                + pds.DateOffset(minutes=5))
+                + dt.timedelta(hours=23, minutes=59, seconds=59)
+                + dt.timedelta(minutes=5))
 
     def test_data_padding_uniqueness(self):
         self.ref_doy = 1
@@ -2818,7 +2818,7 @@ class TestDataPadding():
         self.testInst.load(self.ref_time.year, self.ref_doy)
         assert (self.testInst.index[0] == self.testInst.date)
         assert (self.testInst.index[-1] == self.testInst.date
-                + pds.DateOffset(hour=23, minutes=59, seconds=59))
+                + dt.timedelta(hour=23, minutes=59, seconds=59))
 
 
 class TestDataPaddingXarray(TestDataPadding):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2697,10 +2697,13 @@ class TestDataPadding():
                 + dt.timedelta(hours=23, minutes=59, seconds=59)
                 + dt.timedelta(minutes=5))
 
-    def test_data_padding_offset_instantiation(self):
+    @pytest.mark.parametrize('pad', [dt.timedelta(minutes=5),
+                                     pds.DateOffset(minutes=5)])
+    def test_data_padding_offset_instantiation(self, pad):
+        """Ensure pad can be used as either datetime or pandas"""
         testInst = pysat.Instrument(platform='pysat', name='testing',
                                     clean_level='clean',
-                                    pad=dt.timedelta(minutes=5),
+                                    pad=pad,
                                     update_files=True)
         testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         assert (testInst.index[0] == testInst.date - dt.timedelta(minutes=5))

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2715,7 +2715,8 @@ class TestDataPadding():
                              clean_level='clean',
                              pad=2,
                              update_files=True)
-        estr = 'pad must be a dict, NoneType, or pandas.DateOffset instance.'
+        estr = ' '.join(('pad must be a dict, NoneType, datetime.timedelta,',
+                         'or pandas.DateOffset instance.'))
         assert str(err).find(estr) >= 0
 
     def test_data_padding_bad_load(self):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -734,7 +734,7 @@ class TestBasics():
         """Test string output with data padding """
         self.testInst.pad = dt.timedelta(minutes=5)
         self.out = self.testInst.__str__()
-        assert self.out.find('DateOffset: minutes=5') > 0
+        assert self.out.find('timedelta: minutes=5') > 0
 
     def test_str_w_custom_func(self):
         """Test string output with custom function """
@@ -1182,7 +1182,6 @@ class TestBasics():
         """Test setting bounds with non-default step"""
         start = self.ref_time
         stop = self.ref_time + dt.timedelta(days=14)
-        stop = stop.to_pydatetime()
         self.testInst.bounds = (start, stop, 'M')
         assert np.all(self.testInst._iter_list
                       == pds.date_range(start, stop, freq='M').tolist())
@@ -1191,7 +1190,6 @@ class TestBasics():
         """Test iterating bounds with non-default step"""
         start = self.ref_time
         stop = self.ref_time + dt.timedelta(days=15)
-        stop = stop.to_pydatetime()
         self.testInst.bounds = (start, stop, '2D')
         dates = []
         for inst in self.testInst:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2818,7 +2818,7 @@ class TestDataPadding():
         self.testInst.load(self.ref_time.year, self.ref_doy)
         assert (self.testInst.index[0] == self.testInst.date)
         assert (self.testInst.index[-1] == self.testInst.date
-                + dt.timedelta(hour=23, minutes=59, seconds=59))
+                + dt.timedelta(hours=23, minutes=59, seconds=59))
 
 
 class TestDataPaddingXarray(TestDataPadding):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1202,7 +1202,7 @@ class TestBasics():
     def test_set_bounds_with_frequency_and_width(self):
         """Set date bounds with step/width>1"""
         start = self.ref_time
-        stop = self.ref_time + dt.timedelta(months=11, days=25)
+        stop = self.ref_time + pds.DateOffset(months=11, days=25)
         stop = stop.to_pydatetime()
         self.testInst.bounds = (start, stop, '10D', dt.timedelta(days=10))
         assert np.all(self.testInst._iter_list

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -659,7 +659,7 @@ class TestOrbitsGappyData2(TestGeneralOrbitsMLT):
                    + dt.timedelta(days=int(seconds)))
             times.append([day, day
                           + dt.timedelta(hours=1, minutes=37,
-                                           seconds=int(seconds))
+                                         seconds=int(seconds))
                           - dt.timedelta(seconds=20)])
 
         self.testInst.custom.attach(filter_data2, kwargs={'times': times})
@@ -684,7 +684,7 @@ class TestOrbitsGappyData2Xarray(TestGeneralOrbitsMLT):
                    + dt.timedelta(days=int(seconds)))
             times.append([day, day
                           + dt.timedelta(hours=1, minutes=37,
-                                           seconds=int(seconds))
+                                         seconds=int(seconds))
                           - dt.timedelta(seconds=20)])
 
         self.testInst.custom.attach(filter_data2, kwargs={'times': times})

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -466,7 +466,7 @@ class TestGeneralOrbitsNonStandardIteration():
                                          update_files=True)
         self.testInst.bounds = (self.testInst.files.files.index[0],
                                 self.testInst.files.files.index[11],
-                                '2D', pds.DateOffset(days=3))
+                                '2D', dt.timedelta(days=3))
         self.orbit_starts = []
         self.orbit_stops = []
 
@@ -487,7 +487,7 @@ class TestGeneralOrbitsNonStandardIteration():
         if bounds_type == 'by_date':
             bounds = (self.testInst.files.files.index[0],
                       self.testInst.files.files.index[11],
-                      '2D', pds.DateOffset(days=2))
+                      '2D', dt.timedelta(days=2))
         elif bounds_type == 'by_file':
             bounds = (self.testInst.files[0], self.testInst.files[11], 2, 2)
 
@@ -656,11 +656,11 @@ class TestOrbitsGappyData2(TestGeneralOrbitsMLT):
                   dt.datetime(2009, 1, 1, 1, 37)]]
         for seconds in np.arange(38):
             day = (dt.datetime(2009, 1, 2)
-                   + pds.DateOffset(days=int(seconds)))
+                   + dt.timedelta(days=int(seconds)))
             times.append([day, day
-                          + pds.DateOffset(hours=1, minutes=37,
+                          + dt.timedelta(hours=1, minutes=37,
                                            seconds=int(seconds))
-                          - pds.DateOffset(seconds=20)])
+                          - dt.timedelta(seconds=20)])
 
         self.testInst.custom.attach(filter_data2, kwargs={'times': times})
 
@@ -681,11 +681,11 @@ class TestOrbitsGappyData2Xarray(TestGeneralOrbitsMLT):
                   dt.datetime(2009, 1, 1, 1, 37)]]
         for seconds in np.arange(38):
             day = (dt.datetime(2009, 1, 2)
-                   + pds.DateOffset(days=int(seconds)))
+                   + dt.timedelta(days=int(seconds)))
             times.append([day, day
-                          + pds.DateOffset(hours=1, minutes=37,
+                          + dt.timedelta(hours=1, minutes=37,
                                            seconds=int(seconds))
-                          - pds.DateOffset(seconds=20)])
+                          - dt.timedelta(seconds=20)])
 
         self.testInst.custom.attach(filter_data2, kwargs={'times': times})
 


### PR DESCRIPTION
# Description

Replaces `pds.DateOffset` with `dt.timedelta` throughout.   The exceptions are where keywords of `months` or `years` are required, which are not supported by `timedelta`.  This was generated after the results of runtime tests from #622.  There is no significant difference in run time between this and the develop-3 branch, but putting this up as a draft for discussion.

This branch:  https://travis-ci.com/github/pysat/pysat/builds/207865614
develop3:  https://travis-ci.com/github/pysat/pysat/builds/207863988

The test `test_str_w_padding` in test_instrument's output was updated to reflect the change from pandas.

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via pytest.

**Test Configuration**:
* Mac OS X 10.15.7
* Python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
