### PR TITLE
Constellation restriction removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Added support for custom 'add' methods to return xarray.Datasets
   - Added a display utility for discovering pysat Instrument data sets.
   - Added testing utility functions.
+  - Added support for dual specification of Instruments to include in a
+    Constellation
 - Deprecations
   - Migraged instruments to pysatMadrigal, pysatNASA, pysatSpaceWeather,
     pysatIncubator, pysatModels, pysatCDAAC, and pysatMissions
@@ -65,6 +67,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Changed `pysat.instruments.methods.general.list_files` kwarg
     `fake_monthly_files_from_daily` to `file_cadence`
   - Changed name of Instrument method `default` to `preprocess`
+  - Changed `name` kwarg in Constellation to `const_module`
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and inst_id behaviour in testing instruments

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -7,6 +7,7 @@
 """
 
 import importlib
+import numpy as np
 
 
 class Constellation(object):
@@ -14,7 +15,7 @@ class Constellation(object):
 
     Parameters
     ----------
-    constellation_module : string
+    const_module : string
         Name of a pysat constellation module
     instruments : list-like
         A list of pysat Instruments to include in the Constellation
@@ -33,14 +34,14 @@ class Constellation(object):
     # -----------------------------------------------------------------------
     # Define the magic methods
 
-    def __init__(self, constellation_module=None, instruments=None):
+    def __init__(self, const_module=None, instruments=None):
         """
         Constructs a Constellation given a list of instruments or the name of
         a file with a pre-defined constellation.
 
         Parameters
         ----------
-        constellation_module : string
+        const_module : string
             Name of a pysat constellation module
         instruments : list-like
 
@@ -50,16 +51,18 @@ class Constellation(object):
 
         """
 
-        # Load Instruments from the constellation module, if it exists
-        if constellation_module is not None:
-            const = importlib.import_module(constellation_module)
+        # Include Instruments from the constellation module, if it exists
+        if const_module is not None:
+            const = importlib.import_module(const_module)
             self.instruments = const.instruments
         else:
             self.instruments = []
-        
+
+        # Add any Instruments provided in the list
         if instruments is not None:
-            if hasattr(instruments, '__getitem__'):
-                raise ValueError('instruments must be iterable')
+            test_instruments = np.asarray(instruments)
+            if test_instruments.shape == ():
+                raise ValueError('instruments argument must be list-like')
 
             self.instruments.extend(list(instruments))
 

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -146,10 +146,9 @@ class Constellation(object):
         **kwargs : dict reference
             References a dict of input keyword arguments
 
-        Note
-        ----
-        Wraps Instrument.custom_attach; see Instrument.custom_attach for more
-        information.
+        See Also
+        ---------
+        Instrument.custom_attach : base method for attaching custom functions
 
         """
 
@@ -168,9 +167,9 @@ class Constellation(object):
         **kwargs : dict reference
             References a dict of input keyword arguments
 
-        Note
-        ----
-        Wraps pysat.Instrument.load; see Instrument.load for more information.
+        See Also
+        ---------
+        Instrument.load : base method for loading Instrument data
 
         """
 

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -1,46 +1,69 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.1199703
+# ----------------------------------------------------------------------------
+""" Created as part of a Spring 2018 UTDesign project.
+"""
+
 import importlib
 
 
 class Constellation(object):
     """Manage and analyze data from multiple pysat Instruments.
 
-    Created as part of a Spring 2018 UTDesign project.
+    Parameters
+    ----------
+    constellation_module : string
+        Name of a pysat constellation module
+    instruments : list-like
+        A list of pysat Instruments to include in the Constellation
+
+    Attributes
+    ----------
+    instruments : list
+        A list of pysat Instruments that make up the Constellation
+    bounds : (datetime/filename/None, datetime/filename/None)
+        bounds for loading data, supply array_like for a season with gaps.
+        Users may provide as a tuple or tuple of lists, but the attribute is
+        stored as a tuple of lists for consistency
 
     """
 
-    def __init__(self, instruments=None, name=None):
+    # -----------------------------------------------------------------------
+    # Define the magic methods
+
+    def __init__(self, constellation_module=None, instruments=None):
         """
         Constructs a Constellation given a list of instruments or the name of
         a file with a pre-defined constellation.
 
         Parameters
         ----------
-        instruments : list
-            a list of pysat Instruments
-        name : string
-            Name of a file in pysat/constellations containing a list of
-            instruments.
+        constellation_module : string
+            Name of a pysat constellation module
+        instruments : list-like
 
         Note
         ----
-        The name and instruments parameters should not both be set.
-        If neither is given, an empty constellation will be created.
+        Omit `instruments` and `name` to create an empty constellation.
 
         """
 
-        if instruments and name:
-            raise ValueError('When creating a constellation, please specify '
-                             'a list of instruments or a name, not both.')
-        elif instruments and not hasattr(instruments, '__getitem__'):
-            raise ValueError('Constellation: Instruments must be list-like.')
-
-        if instruments:
-            self.instruments = instruments
-        elif name:
-            const = importlib.import_module('pysat.constellations.' + name)
+        # Load Instruments from the constellation module, if it exists
+        if constellation_module is not None:
+            const = importlib.import_module(constellation_module)
             self.instruments = const.instruments
         else:
             self.instruments = []
+        
+        if instruments is not None:
+            if hasattr(instruments, '__getitem__'):
+                raise ValueError('instruments must be iterable')
+
+            self.instruments.extend(list(instruments))
+
+        return
 
     def __getitem__(self, *args, **kwargs):
         """
@@ -80,106 +103,69 @@ class Constellation(object):
 
         return output_str
 
+    # -----------------------------------------------------------------------
+    # Define the public methods and properties
+
     @property
     def bounds(self):
         return self.instruments[0].bounds
 
     @bounds.setter
     def bounds(self, value=None):
-
-        """ Sets boundaries for all instruments in constellation
+        """ Sets boundaries for all Instruments in Constellation
 
         Parameters
         ----------
-        start : dt.datetime
-            Starting time for Instrument bounds attribute
-        stop : dt.datetime
-            Ending time for Instrument bounds attribute
+        value : tuple or NoneType
+            Tuple containing starting time and ending time for Instrument
+            bounds attribute or None (default=None)
 
         """
 
         for instrument in self.instruments:
             instrument.bounds = value
 
+        return
+
     def custom_attach(self, *args, **kwargs):
-        """
-        Register a function to modify data of member Instruments.
-
-        When the Constellation receives a function call to register
-        a function for data modification, it passes the call to each
-        instrument and registers it in the instrument's Custom queue.
-
-        (Wraps Instrument.custom_attach; documentation of that function is
-        reproduced here.)
+        """Register a function to modify data of member Instruments.
 
         Parameters
         ----------
-        function : string or function object
-            name of function or function object to be added to queue
-        kind : {'add', 'modify', 'pass}
-            - add
-                Adds data returned from function to instrument object.
-                A copy of pysat instrument object supplied to routine.
-            - modify
-                pysat instrument object supplied to routine. Any and all
-                changes to object are retained.
-            - pass
-                A copy of pysat object is passed to function. No
-                data is accepted from return.
-            (default='modify')
-
-        at_pos : string or int
-            Accepts string 'end' or a number that will be used to determine
-            the insertion order if multiple custom functions are attached
-            to an Instrument object. (default='end').
-        args : list or tuple
-            Ordered arguments following the instrument object input that are
-            required by the custom function (default=[])
-        kwargs : dict
-            Dictionary of keyword arguements required by the custom function
-            (default={})
+        *args : list reference
+            References a list of input arguments
+        **kwargs : dict reference
+            References a dict of input keyword arguments
 
         Note
         ----
-        Allowed `attach` function returns:
-
-        - {'data' : pandas Series/DataFrame/array_like,
-          'units' : string/array_like of strings,
-          'long_name' : string/array_like of strings,
-          'name' : string/array_like of strings (iff data array_like)}
-
-        - pandas DataFrame, names of columns are used
-
-        - pandas Series, .name required
-
-        - (string/list of strings, numpy array/list of arrays)
+        Wraps Instrument.custom_attach; see Instrument.custom_attach for more
+        information.
 
         """
 
         for instrument in self.instruments:
             instrument.custom_attach(*args, **kwargs)
 
-    def load(self, *args, **kwargs):
-        """
-        Load instrument data into instrument object.data
+        return
 
-        (Wraps pysat.Instrument.load; documentation of that function is
-        reproduced here.)
+    def load(self, *args, **kwargs):
+        """ Load instrument data into Instrument object.data
 
         Parameters
         ----------
-        yr : integer
-            Year for desired data
-        doy : integer
-            day of year
-        data : datetime object
-            date to load
-        fname : string
-            filename to be loaded
-        verifyPad : boolean
-            if true, padding data not removed (debug purposes)
+        *args : list reference
+            References a list of input arguments
+        **kwargs : dict reference
+            References a dict of input keyword arguments
+
+        Note
+        ----
+        Wraps pysat.Instrument.load; see Instrument.load for more information.
 
         """
 
         for instrument in self.instruments:
             instrument.load(*args, **kwargs)
+
+        return

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -44,6 +44,12 @@ class Constellation(object):
         const_module : string
             Name of a pysat constellation module
         instruments : list-like
+            A list of pysat Instruments to include in the Constellation
+
+        Raises
+        ------
+        ValueError
+            When `instruments` is not list-like
 
         Note
         ----

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1,4 +1,8 @@
-# -*- coding: utf-8 -*-
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.1199703
+# ----------------------------------------------------------------------------
 import copy
 import datetime as dt
 import errno
@@ -21,7 +25,6 @@ from pysat import user_modules
 from pysat import logger
 
 
-# main class for users
 class Instrument(object):
     """Download, load, manage, modify and analyze science data.
 

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -1,3 +1,9 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.1199703
+# ----------------------------------------------------------------------------
+
 import datetime as dt
 import pytest
 
@@ -12,7 +18,8 @@ class TestConstellation:
         self.instruments = [pysat.Instrument('pysat', 'testing',
                                              clean_level='clean')
                             for i in range(2)]
-        self.in_kwargs = {"instruments": self.instruments, "name": "testing"}
+        self.in_kwargs = {"instruments": self.instruments,
+                          "const_module": "pysat.constellations.testing"}
         self.const = None
 
     def teardown(self):
@@ -20,25 +27,25 @@ class TestConstellation:
         """
         del self.const, self.instruments, self.in_kwargs
 
-    @pytest.mark.parametrize("ikey,ival,ilen", [("name", None, 2),
-                                                ("instruments", None, 5)])
+    @pytest.mark.parametrize("ikey,ival,ilen",
+                             [("const_module", None, 2),
+                              ("instruments", None, 5),
+                              (None, None, 7)])
     def test_construct_constellation(self, ikey, ival, ilen):
         """Construct a Constellation with good input
         """
-        self.in_kwargs[ikey] = ival
+        if ikey is not None:
+            self.in_kwargs[ikey] = ival
         self.const = pysat.Constellation(**self.in_kwargs)
         assert len(self.const.instruments) == ilen
 
-    @pytest.mark.parametrize("ikeys,ivals",
-                             [([], []), (["instruments", "name"], [42, None])])
-    def test_construct_raises_error(self, ikeys, ivals):
-        """Attempt to construct a Constellation by name and list
+    def test_construct_raises_noniterable_error(self):
+        """Attempt to construct a Constellation by const_module and list
         """
-        for i, ikey in enumerate(ikeys):
-            self.in_kwargs[ikey] = ivals[i]
+        with pytest.raises(ValueError) as verr:
+            self.const = pysat.Constellation(instruments=self.instruments[0])
 
-        with pytest.raises(ValueError):
-            self.const = pysat.Constellation(**self.in_kwargs)
+        assert str(verr).find("instruments argument must be list-like")
 
     def test_construct_null(self):
         """Attempt to construct a Constellation with no arguments
@@ -47,9 +54,9 @@ class TestConstellation:
         assert len(self.const.instruments) == 0
 
     def test_getitem(self):
-        """Test Constellation:__getitem__
+        """Test Constellation iteration through instruments attribute
         """
-        self.in_kwargs['name'] = None
+        self.in_kwargs['const_module'] = None
         self.const = pysat.Constellation(**self.in_kwargs)
 
         assert self.const[0] == self.instruments[0]
@@ -60,7 +67,7 @@ class TestConstellation:
     def test_repr_w_inst(self):
         """Test Constellation string output with instruments loaded
         """
-        self.in_kwargs['name'] = None
+        self.in_kwargs['const_module'] = None
         self.const = pysat.Constellation(**self.in_kwargs)
         out_str = self.const.__repr__()
 
@@ -70,7 +77,7 @@ class TestConstellation:
     def test_str_w_inst(self):
         """Test Constellation string output with instruments loaded
         """
-        self.in_kwargs['name'] = None
+        self.in_kwargs['const_module'] = None
         self.const = pysat.Constellation(**self.in_kwargs)
         out_str = self.const.__str__()
 
@@ -96,7 +103,7 @@ class TestConstellation:
             return dmlt
 
         # Initialize the constellation
-        self.in_kwargs['name'] = None
+        self.in_kwargs['const_module'] = None
         self.const = pysat.Constellation(**self.in_kwargs)
 
         # Add the custom function

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -553,7 +553,7 @@ class TestConstellationBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup
         """
-        self.testInst = pysat.Constellation([
+        self.testInst = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
                              clean_level='clean')
             for i in range(5)])


### PR DESCRIPTION
# Description

Updates the style of the Constellation class and addresses #539 by allowing multiple types of Instrument inputs.  This makes it easier for users to create custom Constellation objects.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

Added unit tests to test_constellation and ran new and existing tests locally.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

I believe that no downstream changes are necessary, because the Instrument repositories don't actually load constellations.  However, individuals code will break if using the old kwarg.
