### PR TITLE
BUG: xarray data access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## [3.0.0] - 2020-12-10
+## [3.0.0] - 2021-01-21
 - New Features
   - Added registry module for registering custom external instruments
   - Added Meta.mutable flag to control attribute mutability
@@ -92,6 +92,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed unused input arguments
   - Corrects Instrument today, yesterday, and tomorrow methods by implementing
     datetime.datetime.utcnow
+  - Fixed access of xarray data with more than one dimension (#471)
 - Maintenance
   - nose dependency removed from unit tests
   - Specify dtype for empty pandas.Series for forward compatibility

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -790,10 +790,11 @@ class Instrument(object):
                 for i, dim in enumerate(self[key[-1]].dims):
                     indict[dim] = key[i]
                 try:
+                    # Try loading as values
                     self.data[key[-1]].loc[indict] = in_data
                 except (TypeError, KeyError):
-                    indict[epoch_name] = self.index[indict[epoch_name]]
-                    self.data[key[-1]].loc[indict] = in_data
+                    # Try loading indexed as integers
+                    self.data[key[-1]][indict] = in_data
                 self.meta[key[-1]] = new
                 return
             elif isinstance(key, str):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -12,6 +12,7 @@ import pysat
 import pysat.instruments.pysat_testing
 import pysat.instruments.pysat_testing_xarray
 import pysat.instruments.pysat_testing2d
+import pysat.instruments.pysat_testing2d_xarray
 from pysat.utils import generate_instrument_list
 
 xarray_epoch_name = 'time'
@@ -2394,6 +2395,29 @@ class TestBasics2D(TestBasics):
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing2d',
                                          num_samples=50,
+                                         clean_level='clean',
+                                         update_files=True)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
+        self.out = None
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.out, self.ref_time, self.ref_doy
+
+
+# -----------------------------------------------------------------------------
+#
+# Repeat tests above with 2d xarray data
+#
+# -----------------------------------------------------------------------------
+class TestBasics2DXarray(TestBasics):
+    def setup(self):
+        reload(pysat.instruments.pysat_testing2d_xarray)
+        """Runs before every method to create a clean testing setup."""
+        self.testInst = pysat.Instrument(platform='pysat',
+                                         name='testing2d_xarray',
+                                         num_samples=10,
                                          clean_level='clean',
                                          update_files=True)
         self.ref_time = dt.datetime(2009, 1, 1)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2393,6 +2393,38 @@ class TestBasics2DXarray(TestBasics):
         assert np.all(self.testInst[index, index, 'profiles']
                       == self.testInst.data['profiles'][index, index])
 
+    def test_data_access_by_2d_tuple_indices_and_name(self):
+        """Check that variables and be accessed by multi-dim tuple index
+        """
+        self.testInst.load(date=self.ref_time)
+        index = ([0, 1, 2, 3], [0, 1, 2, 3])
+        assert np.all(self.testInst[index, 'profiles']
+                      == self.testInst.data['profiles'][index[0], index[1]])
+
+    def test_data_access_bad_dimension_tuple(self):
+        """Test raises ValueError for mismatched tuple index and data dimensions
+        """
+        self.testInst.load(date=self.ref_time)
+        index = ([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3])
+
+        with pytest.raises(ValueError) as verr:
+            self.testInst[index, 'profiles']
+
+        estr = 'not convert tuple'
+        assert str(verr).find(estr) > 0
+
+    def test_data_access_bad_dimension_for_multidim(self):
+        """Test raises ValueError for mismatched index and data dimensions
+        """
+        self.testInst.load(date=self.ref_time)
+        index = [0, 1, 2, 3]
+
+        with pytest.raises(ValueError) as verr:
+            self.testInst[index, index, index, 'profiles']
+
+        estr = "don't match data"
+        assert str(verr).find(estr) > 0
+
     @pytest.mark.parametrize("changed,fixed",
                              [(0, slice(1, None)),
                               ([0, 1, 2, 3], slice(4, None)),

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -960,7 +960,7 @@ class TestBasics():
         else:
             pytest.skip("This notation does not make sense for xarray")
 
-    @pytest.mark.parametrize("change,fixed",
+    @pytest.mark.parametrize("changed,fixed",
                              [(0, slice(1, None)),
                               ([0, 1, 2, 3], slice(4, None)),
                               (slice(0, 10), slice(10, None)),
@@ -969,14 +969,14 @@ class TestBasics():
                               (slice(dt.datetime(2009, 1, 1),
                                      dt.datetime(2009, 1, 1, 0, 1)),
                                slice(dt.datetime(2009, 1, 1, 0, 1), None))])
-    def test_setting_partial_data_by_inputs(self, change, fixed):
+    def test_setting_partial_data_by_inputs(self, changed, fixed):
         """Check that data can be set using each supported input type"""
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
-        self.testInst[change, 'doubleMLT'] = 0
+        self.testInst[changed, 'doubleMLT'] = 0
         assert np.all(self.testInst[fixed, 'doubleMLT']
                       == 2. * self.testInst[fixed, 'mlt'])
-        assert np.all(self.testInst[change, 'doubleMLT'] == 0)
+        assert np.all(self.testInst[changed, 'doubleMLT'] == 0)
 
     def test_setting_partial_data_by_index_and_name(self):
         self.testInst.load(self.ref_time.year, self.ref_doy)
@@ -2392,19 +2392,19 @@ class TestBasics2DXarray(TestBasics):
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.out, self.ref_time, self.ref_doy
 
-    @pytest.mark.parametrize("change,fixed",
+    @pytest.mark.parametrize("changed,fixed",
                              [(0, slice(1, None)),
                               ([0, 1, 2, 3], slice(4, None)),
                               (slice(0, 10), slice(10, None)),
                               (np.array([0, 1, 2, 3]), slice(4, None))])
-    def test_setting_partial_data_by_2d_inputs(self, change, fixed):
+    def test_setting_partial_data_by_2d_inputs(self, changed, fixed):
         """Check that data can be set using each supported input type"""
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleProfile'] = 2. * self.testInst['profiles']
-        self.testInst[change, change, 'doubleProfile'] = 0
+        self.testInst[changed, changed, 'doubleProfile'] = 0
         assert np.all(np.all(self.testInst[fixed, fixed, 'doubleProfile']
                              == 2. * self.testInst[fixed, 'profiles']))
-        assert np.all(np.all(self.testInst[change, change, 'doubleProfile']
+        assert np.all(np.all(self.testInst[changed, changed, 'doubleProfile']
                              == 0))
 
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -865,6 +865,7 @@ class TestBasics():
         assert np.all(self.testInst[labels] == self.testInst.data[labels])
 
     @pytest.mark.parametrize("index", [(0),
+                                       ([0, 1, 2, 3]),
                                        (slice(0, 10)),
                                        (np.arange(0, 10))])
     def test_data_access_by_indices_and_name(self, index):


### PR DESCRIPTION
# Description

Addresses #471

- Fixes a bug when attempting to set data by indices for a multi-dimensional xarray object. 
- Includes `pysat_testing2d_xarray` as part of standard data tests.
  - updated `test_setting_partial_data_by_*` tests with parametrize

Previous code assumes only epoch axis, and converts index values to timestamps.  However, if a secondary axis is used (Altitude in the case below), it will try to load altitude values as index values.  This bypasses the conversion and uses the integers directly as indices in this case.  This is the most flexible, as many types of dimensions can be used.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Load Instrument
```
import numpy as np
import pysat
import pysatNASA
inst = pysat.Instrument(inst_module=pysatNASA.instruments.icon_mighti, tag='vector_wind_green', clean_level='none')
```
- Get data if you don't have it
```
import datetime as dt
inst.download(dt.datetime(2020, 1, 2), dt.datetime(2020, 1, 2)
```
- Try to set some values to nans
```
inst.load(2020, 2)
idx, idy, = np.where(inst['Wind_Quality'] != 1)
inst[idx, idy, 'Zonal_Wind'] = np.nan
```
In develop-3, this gives an error (see #471 for details)

**Test Configuration**:
*Mac OS X 10.15.7
* Python 3.8.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
