### PR TITLE
Multiple file day attribute reorganization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Integrated Custom class directly into Instrument to support mixed use
     of Constellation/Instrument objects in code (#540)
   - Made underlying custom data structures visible (#529)
-  - Updated data_mode method name to custom_attach for the Constellation object (#540)
+  - Updated data_mode method name to custom_attach for the Constellation
+    object (#540)
   - Added support for custom 'add' methods to return xarray.Datasets
   - Added a display utility for discovering pysat Instrument data sets.
   - Added testing utility functions.
@@ -59,7 +60,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed utils.coords.local_horizontal_to_global_geo
   - Deprecation Warnings for methods in `pysat._files`
   - Addressed several Warnings raised by incorrect use of dependent packages
-  - Deprecated use of inst_id for number of simulated samples for test
+  - Deprecated use of `inst_id` for number of simulated samples for test
     instruments
   - Removed writing of custom Meta attributes (deprecated) when producing
     netCDF4 files
@@ -69,6 +70,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Changed name of Instrument method `default` to `preprocess`
   - Changed `name` kwarg in Constellation to `const_module`
   - Removed unnecessary Instrument attribute `labels`
+  - Removed unnecessary Instrument kwargs
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and inst_id behaviour in testing instruments

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -136,8 +136,8 @@ string can be used. The code below only supports loading a single data set.
 The DMSP IVM (dmsp_ivm) instrument module is a practical example of
 a pysat instrument that uses all levels of variable names.
 
-Required Variables
-------------------
+Required Attributes
+-------------------
 
 Because platform, name, tags, and inst_ids are used for loading and maintaining
 different data sets they must be defined for every instrument.
@@ -371,6 +371,24 @@ To fetch data from the internet the download method should have the signature
 * password, string for password
 
 The routine should download the data and write it to the disk at the data_path.
+
+Optional Attributes
+-------------------
+
+Several attributes have default values that you may need to change depending on
+how your data and files are structured.
+
+**pandas_format**
+
+This defaults to `True` and assumes the data are organized as a time series,
+allowing them to be stored as a pandas DataFrame. Setting this attribute to
+`False` tells pysat that the data will be stored in an xarray Dataset.
+
+**multi_file_day**
+
+This defaults to `False`, which means that the files for this data set have one
+or less.  If your data set consists of multiple files per day, this attribute
+should be set to `True`.
 
 Optional Routines and Support
 -----------------------------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -68,10 +68,6 @@ class Instrument(object):
         formatting. The default directory structure would be expressed as
         '{platform}/{name}/{tag}'. If None, the default directory structure is
         used. (default=None)
-    multi_file_day : boolean or NoneType
-        Set to True if Instrument data files for a day are spread across
-        multiple files and data for day n could be found in a file
-        with a timestamp of day n-1 or n+1.  (default=None)
     file_format : str or NoneType
         File naming structure in string format.  Variables such as year,
         month, and inst_id will be filled in as needed using python string
@@ -219,9 +215,8 @@ class Instrument(object):
 
     def __init__(self, platform=None, name=None, tag=None, inst_id=None,
                  clean_level='clean', update_files=False, pad=None,
-                 orbit_info=None, inst_module=None, multi_file_day=None,
-                 directory_format=None, file_format=None,
-                 temporary_file_list=False,
+                 orbit_info=None, inst_module=None, directory_format=None,
+                 file_format=None, temporary_file_list=False,
                  strict_time_flag=True, ignore_empty_files=False,
                  labels={'units': ('units', str), 'name': ('long_name', str),
                          'notes': ('notes', str), 'desc': ('desc', str),
@@ -239,10 +234,10 @@ class Instrument(object):
                 self.platform = platform.lower()
                 self.name = name.lower()
 
-                # look to module for instrument functions and defaults
+                # Look to module for instrument functions and defaults
                 self._assign_attrs(by_name=True)
             elif (platform is None) and (name is None):
-                # creating "empty" Instrument object with this path
+                # Creating "empty" Instrument object with this path
                 self.name = ''
                 self.platform = ''
                 self._assign_attrs()
@@ -250,7 +245,7 @@ class Instrument(object):
                 raise ValueError(' '.join(('Inputs platform and name must both',
                                            'be strings, or both None.')))
         else:
-            # user has provided a module, assign platform and name here
+            # User has provided a module, assign platform and name here
             for iattr in ['platform', 'name']:
                 if hasattr(inst_module, iattr):
                     setattr(self, iattr, getattr(inst_module, iattr).lower())
@@ -264,14 +259,14 @@ class Instrument(object):
             # attribute values
             self._assign_attrs(inst_module=inst_module)
 
-        # more reasonable defaults for optional parameters
+        # More reasonable defaults for optional parameters
         self.clean_level = (clean_level.lower() if clean_level is not None
                             else 'none')
 
-        # assign strict_time_flag
+        # Assign strict_time_flag
         self.strict_time_flag = strict_time_flag
 
-        # assign directory format information, which tells pysat how to look in
+        # Assign directory format information, which tells pysat how to look in
         # sub-directories for files
         if directory_format is not None:
             # assign_func sets some instrument defaults, direct info rules all
@@ -356,11 +351,6 @@ class Instrument(object):
         self._prev_data = self._null_data.copy()
         self._prev_data_track = []
         self._curr_data = self._null_data.copy()
-
-        # If the multi_file_day flag was set update here, otherwise the
-        # default will be set by _assign_attrs
-        if multi_file_day is not None:
-            self.multi_file_day = multi_file_day
 
         # Initialize the padding
         if isinstance(pad, (dt.timedelta, pds.DateOffset)) or pad is None:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2658,18 +2658,17 @@ class Instrument(object):
             inst.load(fname=inst.files[0], stop_fname=inst.files[1])
 
         """
-
-        # set options used by loading routine based upon user input
+        # Set options used by loading routine based upon user input
         if (yr is not None) and (doy is not None):
             if doy < 1 or (doy > 366):
                 estr = ''.join(('Day of year (doy) is only valid between and ',
                                 'including 1-366.'))
                 raise ValueError(estr)
 
-            # verify arguments make sense, in context
+            # Verify arguments make sense, in context
             _check_load_arguments_none([fname, stop_fname, date, end_date],
                                        raise_error=True)
-            # convert yr/doy to a date
+            # Convert yr/doy to a date
             date = dt.datetime.strptime("{:.0f} {:.0f}".format(yr, doy),
                                         "%Y %j")
             self._set_load_parameters(date=date, fid=None)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -226,30 +226,23 @@ class TestBasics():
                 + dt.timedelta(days=1))
         return
 
-    def test_basic_instrument_load_by_file_and_multifile(self):
-        """Ensure multi_file_day has to be False when loading by filename"""
+    @pytest.mark.parametrize('load_in,verr',
+                             [('fname', 'have multi_file_day and load by file'),
+                              (None, 'is not supported with multi_file_day')])
+    def test_basic_instrument_load_by_file_and_multifile(self, load_in, verr):
+        """Ensure some load calls raises ValueError with multi_file_day as True
+        """
         self.testInst.multi_file_day = True
 
+        if load_in == 'fname':
+            load_kwargs = {load_in: self.testInst.files[0]}
+        else:
+            load_kwargs = dict()
+        
         with pytest.raises(ValueError) as err:
-            self.testInst.load(fname=self.testInst.files[0])
+            self.testInst.load(**load_kwargs)
 
-        estr = "have multi_file_day and load by file"
-        assert str(err).find(estr) >= 0
-
-        return
-
-    def test_basic_instrument_load_and_multifile(self):
-        """Ensure .load() only runs when multi_file_day is False"""
-        self.out = pysat.Instrument(platform=self.testInst.platform,
-                                    name=self.testInst.name,
-                                    num_samples=10,
-                                    clean_level='clean',
-                                    update_files=True,
-                                    multi_file_day=True)
-        with pytest.raises(ValueError) as err:
-            self.out.load()
-        estr = '`load()` is not supported with multi_file_day'
-        assert str(err).find(estr) >= 0
+        assert str(err).find(verr) >= 0
 
         return
 
@@ -2740,6 +2733,7 @@ class TestDataPadding():
         """Not allowed to enable data padding when loading all data, load()"""
         with pytest.raises(ValueError) as err:
             self.testInst.load()
+
         if self.testInst.multi_file_day:
             estr = '`load()` is not supported with multi_file_day'
         else:
@@ -2890,8 +2884,8 @@ class TestMultiFileRightDataPaddingBasics(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5},
-                                         multi_file_day=True)
+                                         pad={'minutes': 5})
+        self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
 
@@ -2909,8 +2903,8 @@ class TestMultiFileRightDataPaddingBasicsXarray(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5},
-                                         multi_file_day=True)
+                                         pad={'minutes': 5})
+        self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
 
@@ -2928,8 +2922,8 @@ class TestMultiFileLeftDataPaddingBasics(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5},
-                                         multi_file_day=True)
+                                         pad={'minutes': 5})
+        self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
 
@@ -2947,8 +2941,8 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5},
-                                         multi_file_day=True)
+                                         pad={'minutes': 5})
+        self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -228,14 +228,11 @@ class TestBasics():
 
     def test_basic_instrument_load_by_file_and_multifile(self):
         """Ensure multi_file_day has to be False when loading by filename"""
-        self.out = pysat.Instrument(platform=self.testInst.platform,
-                                    name=self.testInst.name,
-                                    num_samples=10,
-                                    clean_level='clean',
-                                    update_files=True,
-                                    multi_file_day=True)
+        self.testInst.multi_file_day = True
+
         with pytest.raises(ValueError) as err:
-            self.out.load(fname=self.out.files[0])
+            self.testInst.load(fname=self.testInst.files[0])
+
         estr = "have multi_file_day and load by file"
         assert str(err).find(estr) >= 0
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -238,7 +238,7 @@ class TestBasics():
             load_kwargs = {load_in: self.testInst.files[0]}
         else:
             load_kwargs = dict()
-        
+
         with pytest.raises(ValueError) as err:
             self.testInst.load(**load_kwargs)
 


### PR DESCRIPTION
# Description

Removes the `multi_file_day` kwarg, requiring that it be set as an instrument attribute.

Addresses (in whole or part) #389, #620, #512, #266 

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Tested by running unit tests and loading dmsp data:

```
import pysat; import datetime as dt; import pysatMadrigal as py_mad
stime = dt.datetime(1998, 1, 1)
dmsp_f13.load(date=stime)
print(dmsp_f13)
```

Yields
```
pysat Instrument object
-----------------------
Platform: 'dmsp'
Name: 'ivm'
Tag: 'utd'
Instrument id: 'f13'

Data Processing
---------------
Cleaning Level: 'clean'
Data Padding: None
Keyword Arguments Passed to load: {'xarray_coords': [], 'file_type': 'hdf5'}
Keyword Arguments Passed to list_remote_files: {'user': None, 'password': None, 'url': 'http://cedar.openmadrigal.org', 'two_digit_year_break': None}
Custom Functions: 0 applied

Local File Statistics
---------------------
Number of files: 3
Date Range: 31 December 1997 --- 02 January 1998

Loaded Data Statistics
----------------------
Date: 01 January 1998
DOY: 001
Time range: 01 January 1998 01:19:00 --- 01 January 1998 23:39:04
Number of Times: 4615
Number of variables: 30

Variable Names:
year     month    day      
            ...            
rms_x    sigma_vy sigma_vz 

pysat Meta object
-----------------
Tracking 7 metadata values
Metadata for 30 standard variables
Metadata for 0 ND variables
```

OS: OS X Mojave
Python 3.7
pysatMadrigal bug_remote_file_list branch


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
