### PR TITLE
BUG/TST: support user and password kwargs in remote_file_list

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3032,6 +3032,14 @@ class Instrument(object):
         kwargs["start"] = start
         kwargs["stop"] = stop
 
+        # Add the user-supplied kwargs
+        rtn_key = 'list_remote_files'
+        if rtn_key in self.kwargs.keys():
+            for user_key in self.kwargs[rtn_key].keys():
+                # Don't overwrite kwargs supplied directly to this routine
+                if user_key not in kwargs.keys():
+                    kwargs[user_key] = self.kwargs[rtn_key][user_key]
+
         # Return the function call
         return self._list_remote_files_rtn(self.tag, self.inst_id, **kwargs)
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2997,7 +2997,7 @@ class Instrument(object):
         sys.stdout.flush()
         return
 
-    def remote_file_list(self, start=None, stop=None):
+    def remote_file_list(self, start=None, stop=None, **kwargs):
         """List remote files for chosen instrument
 
         Parameters
@@ -3010,6 +3010,10 @@ class Instrument(object):
             Ending time for the file list.  A None value will stop with the last
             file found.
             (default=None)
+        **kwargs : dict
+            Dictionary of keywords that may be options for specific instruments.
+            The keyword arguments 'user' and 'password' are expected for remote
+            databases requiring sign in or registration.
 
         Returns
         -------
@@ -3023,11 +3027,6 @@ class Instrument(object):
         return a subset of available files.
 
         """
-        # Set the user-supplied kwargs
-        if 'list_remote_files' in self.kwargs.keys():
-            kwargs = self.kwargs['list_remote_files']
-        else:
-            kwargs = {}
 
         # Add the function kwargs
         kwargs["start"] = start
@@ -3036,7 +3035,7 @@ class Instrument(object):
         # Return the function call
         return self._list_remote_files_rtn(self.tag, self.inst_id, **kwargs)
 
-    def remote_date_range(self, start=None, stop=None):
+    def remote_date_range(self, start=None, stop=None, **kwargs):
         """Returns fist and last date for remote data
 
         Parameters
@@ -3049,6 +3048,10 @@ class Instrument(object):
             Ending time for the file list.  A None value will stop with the last
             file found.
             (default=None)
+        **kwargs : dict
+            Dictionary of keywords that may be options for specific instruments.
+            The keyword arguments 'user' and 'password' are expected for remote
+            databases requiring sign in or registration.
 
         Returns
         -------
@@ -3063,7 +3066,7 @@ class Instrument(object):
 
         """
 
-        files = self.remote_file_list(start=start, stop=stop)
+        files = self.remote_file_list(start=start, stop=stop, **kwargs)
         return [files.index[0], files.index[-1]]
 
     def download_updated_files(self, **kwargs):

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -62,7 +62,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
 
 def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
-                      start=None, stop=None, test_dates=None):
+                      start=None, stop=None, test_dates=None, user=None,
+                      password=None):
     """Produce a fake list of files spanning three years and one month to
     simulate new data files on a remote server
 
@@ -86,6 +87,12 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
         (default=None)
     test_dates : dt.datetime
         Pass the _test_date object through from the test instrument files
+    user : string
+        User string input used for download. Provided by user and passed via
+        pysat. If an account is required for dowloads this routine here must
+        error if user not supplied. (default=None)
+    password : string
+        Password for data download. (default=None)
 
     Returns
     -------

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -184,7 +184,10 @@ class InstTestClass():
 
         if hasattr(getattr(self.inst_loc, name), 'list_remote_files'):
             assert callable(test_inst.remote_file_list)
-            files = test_inst.remote_file_list(start=date, stop=date)
+            # check for username
+            dl_dict = inst_dict['user_info'] if 'user_info' in \
+                inst_dict.keys() else {}
+            files = test_inst.remote_file_list(start=date, stop=date, **dl_dict)
             # If test date is correctly chosen, files should exist
             assert len(files) > 0
         else:


### PR DESCRIPTION
# Description

Addresses pysat/pysatMadrigal#5

Currently, user and password are not supported by the `remote_file_list` and `remote_date_range` methods.  This updates the syntax to pass all kwargs through both routines.

Additionally, updates the test class to pass these through for packages like pysatMadrigal.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with the `tst/remote_file_list` branch of pysatMadrigal.  See pysat/pysatMadrigal#38.  Currently works with most of the methods there, but requires some bug fixes to some of the jro_isr data products.

```
import datetime as dt
import pysat
import pysatMadrigal as py_mad

dmsp_f13 = pysat.Instrument(inst_module=py_mad.instruments.dmsp_ivm, tag='utd', inst_id='f13')
dl_dict = {'user': 'your name here', 'password': 'email address'}
dmsp_f13.remote_file_list(**dl_dict)
```
Or, to test all routines in the pysatMadrigal home directory
```
pytest -vs pysatMadrigal/tests/test_instruments.py::TestInstruments::test_remote_file_list
```

**Test Configuration**:
* Python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [n/a] Add a note to ``CHANGELOG.md``, summarizing the changes
