### PR TITLE
Custom kind removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Changed `name` kwarg in Constellation to `const_module`
   - Removed unnecessary Instrument attribute `labels`
   - Removed unnecessary Instrument kwargs
+  - Removed the Custom function kwarg `kind`, accepting only `modify` behavior
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of tag and inst_id behaviour in testing instruments

--- a/docs/dependency.rst
+++ b/docs/dependency.rst
@@ -88,6 +88,7 @@ developers.  Continuing the above example, developers may copy over the
 
   # Make sure to import your instrument library here
   import customLibrary
+
   # Import the test classes from pysat
   from pysat.tests.instrument_test_class import generate_instrument_list
   from pysat.tests.instrument_test_class import InstTestClass

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -411,9 +411,11 @@ Instrument object itself under inst.kwargs for use in other areas.
 .. code:: python
 
    inst = pysat.Instrument(platform, name, custom1=new_value)
-   # show user supplied value for custom1 keyword
+
+   # Show user supplied value for custom1 keyword
    print(inst.kwargs['custom1'])
-   # show default value applied for custom2 keyword
+
+   # Show default value applied for custom2 keyword
    print(inst.kwargs['custom2'])
 
 If a user supplies a keyword that is not supported by pysat or by the
@@ -430,7 +432,7 @@ If present, the instrument init method runs once at instrument instantiation.
        return None
 
 inst is a pysat.Instrument() instance. init should modify inst
-in-place as needed; equivalent to a 'modify' custom routine.
+in-place as needed; equivalent to a custom routine.
 
 Keywords are not supported within the init module method signature, though
 custom keyword support for instruments is available via inst.kwargs.
@@ -443,11 +445,11 @@ instrument preprocessing.
 
 .. code:: python
 
-   def default(inst):
+   def preprocess(inst):
        return None
 
 inst is a pysat.Instrument() instance. default should modify inst in-place as
-needed; equivalent to a 'modify' custom routine.
+needed; equivalent to a custom routine.
 
 **clean**
 
@@ -464,7 +466,7 @@ Cleans instrument for levels supplied in inst.clean_level.
        return None
 
 inst is a pysat.Instrument() instance. clean should modify inst in-place as
-needed; equivalent to a 'modify' custom routine.
+needed; equivalent to a custom routine.
 
 **list_remote_files**
 

--- a/docs/tutorial_custom.rst
+++ b/docs/tutorial_custom.rst
@@ -2,10 +2,10 @@
 Custom Functions
 ----------------
 
-Science analysis is built upon custom data processing. To simplify this task, and
-enable instrument independent analysis, custom functions may be attached to the
-Instrument object. Each function is run automatically when new data is loaded
-before it is made available in ``inst.data``.
+Science analysis is built upon custom data processing. To simplify this task,
+and enable instrument independent analysis, custom functions may be attached to
+the Instrument object. Each function is run automatically when new data is
+loaded before it is made available in ``inst.data``.
 
 This feature enables a user to hand an Instrument object to an independent
 routine and ensure any desired customizations required are performed without
@@ -15,16 +15,18 @@ becomes available for use in  ``inst.data``.
 
 .. warning:: Custom arguments and keywords are supported for these methods.
    However, these arguments and keywords are only evaluated initially when the
-   method is attached to an Instrument object. Thus the objects passed in must be
-   static or capable of updating themselves from within the custom method itself.
+   method is attached to an Instrument object. Thus the objects passed in must
+   be static or capable of updating themselves from within the custom method
+   itself.
 
 
-**The Modify Functions**
+**Example Function**
 
-The instrument object is passed to function in place, there
+If a custom function is attached to an Instrument, when asking to load data
+into the Instrument, the Instrument object is passed to function in place. There
 is no Instrument copy made in memory. The method is expected to modify the
-supplied Instrument object directly. 'Modify' methods are not allowed to return
-any information via the method itself.
+supplied Instrument object directly and the funtions are not allowed to return
+any information.
 
 .. code:: python
 
@@ -39,82 +41,18 @@ any information via the method itself.
            Label for variable to be multiplied by factor
        factor : int or float
            Value to apply to param_name via multiplication (default=1.)
-       """
 
+       """
+       # Save the old data
+       inst['old_{:s}'.format(param_name)] = inst[param_name]
+
+       # Modify the data by multiplying it by a specified value
        inst[param_name] = inst[param_name] * factor
 
        # Changes to the instrument object are retained
        inst.modify_value_was_here = True
 
        return
-
-**The Add Functions**
-
-A copy of the Instrument is passed to the method thus any changes made
-directly to the object are lost. The data to be added must be returned via
-'return' in the method and is added to the true Instrument object by pysat.
-
-Multiple return types are supported:
-
-===============     ===================================
-**Type** 	        **Notes**
----------------     -----------------------------------
-  tuple             (data_name, data_to_be_added)
-  dict              Data to be added keyed under 'data'
-  Iterable          ((name1, name2, ...), (data1, data2, ...))
-  Series            Variable name must be in .name
-  DataFrame         Columns used as variable names
-  DataArray         Variable name must be in .name
-  Dataset           Merged into existing Instrument.data
-===============     ===================================
-
-Metadata may also be returned when using a dictionary object as the return
-type. In this case, the data must be in 'data', with other keys interpreted
-as metadata parameters. Multiple data variables may be added in this case
-only when using the DataFrame.
-
-.. code:: python
-
-   def add_scaled_value(inst, factor, param_name, output_name=None):
-       """Scales param_name in Instrument by factor and adds as output_name
-
-       Parameters
-       ----------
-       inst : pysat.Instrument
-       factor : int or float
-           Multiplicative scalar applied to `param_name`
-       param_name : str
-           Label for variable to be multiplied by factor
-       output_name : str or None
-           Label the result will be stored as in `inst`. If None,
-           the output label will be generated as 'scaled_' + `param_name`
-           (default=None).
-
-       """
-
-       if output_name is None:
-           output_name = '_'.join(('scaled', param_name))
-
-       # Calculate result
-       output_data = factor * inst[param_name]
-
-       # Get units from input variable
-       output_units = inst.meta[param_name, inst.meta.labels.units]
-
-       # Generate a longer name using param_name's longer descriptive name
-       output_longname = ' * '.join(('{num:.2f}'.format(num=factor),
-                                     inst.meta[param_name,
-                                               inst.meta.labels.name]))
-
-       # Changes to the instrument object are NOT retained after method exits
-       inst.add_value_was_here = True
-
-       # Variable name used to identify and access output is provided
-       # by user in output_name.
-       return {'data': output_data,
-               'name': output_name,
-               inst.meta.labels.name: output_longname,
-               inst.meta.labels.units: output_units}
 
 **Attaching Custom Function**
 
@@ -130,10 +68,8 @@ to automatically apply the method upon every load.
    print(ivm['mlt'])
    stored_data = ivm['mlt'].copy()
 
-   # Attach a 'modify' method and demonstrate execution
-   ivm.custom_attach(modify_value, 'modify',
-                     args=['mlt'],
-                     kwargs={'factor': 2.})
+   # Attach a custom method and demonstrate execution
+   ivm.custom_attach(modify_value, args=['mlt'], kwargs={'factor': 2.})
 
    # `modify_value` is executed as part of the `ivm.load` call.
    ivm.load(2009, 1)
@@ -144,33 +80,23 @@ to automatically apply the method upon every load.
    # Check for attribute added to ivm
    print(ivm.modify_value_was_here)
 
-   # Attach an 'add' method
-   ivm.custom_attach(add_scaled_value, 'add', args=[2., 'mlt'],
-                     kwargs={'output_name': 'double_mlt'})
-
-   # Both `modify_vaule` and `add_scaled_value` are executed by `ivm.load` call.
+   # `modify_vaule` is executed by `ivm.load` call.
    ivm.load(2009, 1)
 
    # Verify results are present
-   print(ivm[['double_mlt', 'mlt']], stored_result)
+   print(ivm[['old_mlt', 'mlt']], stored_result)
 
    # Can also set methods via its string name. This example includes
-   # both required and optional arguments.
-   ivm.custom_attach('add_scaled_value', 'add', args=[3., 'mlt'],
-                     kwargs={'output_name': 'triple_mlt'})
+   # both required and optional arguments, and requires output from
+   # the prior custom function
+   ivm.custom_attach('modify_value', args=['old_mlt'], kwargs={'factor': 3.0})
 
-   # All three methods are executed with each load call.
+   # All three methods are executed with each load call in the order they
+   # were attached.
    ivm.load(2009, 1)
 
    # Verify results are present
-   print(ivm[['triple_mlt', 'double_mlt', 'mlt']], stored_result)
-
-   # set bounds limiting the file/date range the Instrument will iterate over
-   ivm.bounds = (start, stop)
-
-   # Perform analysis. Whatever modifications are enabled by the custom
-   # methods are automatically available within the custom analysis.
-   custom_complicated_analysis_over_season(ivm)
+   print(ivm[['old_mlt', 'old_old_mlt', 'mlt']], stored_result)
 
 
 The output of from these and other custom methods will always be available
@@ -186,38 +112,47 @@ functionality.
     import numpy as np
     import pandas
 
-    # create custom function
+    # Create custom function
     def filter_dmsp(inst, limit=None):
-        # isolate data to locations near geomagnetic equator
+        # Isolate data to locations near geomagnetic equator
         idx, = np.where((dmsp['mlat'] < 5) & (dmsp['mlat'] > -5))
-        # downselect data
-        dmsp.data = dmsp[idx]
 
-    # get list of dates between start and stop
+        # Downselect data
+        dmsp.data = dmsp[idx]
+	return
+
+    # Get a list of dates between start and stop
     start = dt.datetime(2001, 1, 1)
     stop = dt.datetime(2001, 1, 10)
     date_array = pysat.utils.time.create_date_range(start, stop)
 
-    # create empty series to hold result
+    # Create empty series to hold result
     mean_ti = pandas.Series()
 
-    # instantiate pysat.Instrument
+    # Instantiate the pysat.Instrument
     dmsp = pysat.Instrument(platform='dmsp', name='ivm', tag='utd',
                             inst_id='f12')
-    # attach custom method from above
-    dmsp.custom_attach(filter_dmsp, 'modify')
 
-    # iterate over season, calculate the mean Ion Temperature
+    # Attach the custom method defined above
+    dmsp.custom_attach(filter_dmsp)
+
+    # Attach the first custom method, and declare it should run first
+    dmsp.custom_attach('modify_value', at_pos=0, args=['ti'],
+                        kwargs={'factor': 2.0})
+
+    # Iterate over season, calculate the mean Ion Temperature
     for date in date_array:
-       # load data into dmsp.data
+       # Load data into dmsp.data
        dmsp.load(date=date)
-       # check if data present
-       if not dmsp.empty:
-           # compute mean ion temperature using pandas functions and store
-           mean_ti[dmsp.date] = dmsp['ti'].mean(skipna=True)
 
-    # plot the result using pandas functionality
+       # Compute mean ion temperature using pandas functions and store
+       if not dmsp.empty:
+           mean_ti[dmsp.date] = dmsp['old_ti'].mean(skipna=True)
+
+    # Plot the result using pandas functionality
     mean_ti.plot(title='Mean Ion Temperature near Magnetic Equator')
+
+    # Because the custom function didn't add metadata, use the old data name
     plt.ylabel(dmsp.meta['ti', dmsp.desc_label] + ' (' +
                dmsp.meta['ti', dmsp.units_label] + ')')
 
@@ -234,15 +169,14 @@ at instantiation via the `custom` keyword.
 .. code:: python
 
    # Create dictionary for each custom method and associated inputs
-   custom_func_1 = {'function': modify_value, 'kind': 'modify',
-                    'args': ['mlt'], 'kwargs': {'factor': 2.})}
-   custom_func_2 = {'function': add_scaled_value, 'kind': 'add',
-                    'args': [2., 'mlt'], 'kwargs'={'output_name': 'double_mlt'}}
-   custom_func_3 = {'function': add_scaled_value, 'kind': 'add',
-                    'args': [3., 'mlt'], 'kwargs'={'output_name': 'triple_mlt'}}
+   custom_func_1 = {'function': modify_value, 'args': ['mlt'],
+                    'kwargs': {'factor': 2.})}
+   custom_func_2 = {'function': modify_value, 'args': ['old_mlt'],
+                    'kwargs'={'factor': 3.0}}
 
    # Combine all dicts into a list in order of application and execution.
-   custom = [custom_func_1, custom_func_2, custom_func_3]
+   # If you specify the 'at_pos' kwarg, however, it will take precedence.
+   custom = [custom_func_1, custom_func_2]
 
    # Instantiate pysat.Instrument
    inst = pysat.Instrument(platform, name, inst_id=inst_id, tag=tag,

--- a/docs/tutorial_independence.rst
+++ b/docs/tutorial_independence.rst
@@ -45,12 +45,13 @@ to non-DMSP data sets.
                            .mean(skipna=True))
        return mean_val
 
-   # instantiate pysat.Instrument object to get access to data
+   # Instantiate pysat.Instrument object to get access to data
    vefi = pysat.Instrument(platform='cnofs', name='vefi', tag='dc_b')
 
-   # define custom filtering method
+   # Define a custom filtering method
    def filter_inst(inst, data_label, data_gate):
-       # select data within +/- data gate
+       """ Select data within +/- data gate
+       """
        min_gate = -np.abs(data_gate)
        max_gate = np.abs(data_gate)
        idx, = np.where((inst[data_label] < max_gate) &
@@ -58,13 +59,13 @@ to non-DMSP data sets.
        inst.data = inst[idx]
        return
 
-   # attach filter to vefi object, function is run upon every load
-   vefi.custom.add(filter_inst, 'modify', 'latitude', 5.)
+   # Attach filter to vefi object, function is run upon every load
+   vefi.custom_attach(filter_inst, args=['latitude', 5.0])
 
-   # make a plot of daily mean of 'db_mer'
+   # Make a plot of daily mean of 'db_mer'
    mean_dB = daily_mean(vefi, start, stop, 'dB_mer')
 
-   # plot the result using pandas functionality
+   # Plot the result using pandas functionality
    mean_dB.plot(title='Absolute Daily Mean of '
    	        + vefi.meta['dB_mer'].long_name)
    plt.ylabel('Absolute Daily Mean (' + vefi.meta['dB_mer'].units + ')')
@@ -85,12 +86,13 @@ instrument is supplied may be modified in arbitrary ways by the nano-kernel.
 
    cosmic = pysat.Instrument('cosmic', 'gps', tag='ionprf', clean_level='clean',
                              altitude_bin=3)
-   # attach filter method
-   cosmic.custom.add(filter_inst, 'modify', 'edmaxlat', 15.)
-   # perform average
+   # Attach the filter method
+   cosmic.custom_attach(filter_inst, args=['edmaxlat', 15.0])
+
+   # Perform the averaging
    mean_max_dens = daily_mean(cosmic, start, stop, 'edmax')
 
-   # plot the result using pandas functionality
+   # Plot the result using pandas functionality
    long_name = cosmic.meta[data_label, cosmic.name_label]
    units = cosmic.meta[data_label, cosmic.units_label]
    mean_max_dens.plot(title='Absolute Daily Mean of ' + long_name)
@@ -113,11 +115,13 @@ more than 1D datasets.
 
    def daily_mean(inst, start, stop, data_label):
 
-       # create empty series to hold result
+       # Create empty series to hold result
        mean_val = pandas.Series()
-       # get list of dates between start and stop
+
+       # Get list of dates between start and stop
        date_array = pysat.utils.time.create_date_range(start, stop)
-       # iterate over season, calculate the mean
+
+       # Iterate over season, calculate the mean
        for date in date_array:
            inst.load(date=date)
            if not inst.empty:

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -157,6 +157,20 @@ class Constellation(object):
 
         return
 
+    def custom_clear(self):
+        """Clear the custom function list
+
+        See Also
+        ---------
+        Instrument.custom_clear : base method for clearing custom functions
+
+        """
+
+        for instrument in self.instruments:
+            instrument.custom_clear()
+
+        return
+
     def load(self, *args, **kwargs):
         """ Load instrument data into Instrument object.data
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -325,7 +325,7 @@ class Instrument(object):
                 # Check if required keys present in input.
                 if req_key not in cust:
                     estr = ''.join(('Input dict to custom is missing the ',
-                                    'required key: ', rkey))
+                                    'required key: ', req_key))
                     raise ValueError(estr)
 
                 # Check if optional arguments present. If not, provide

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1935,10 +1935,17 @@ class Instrument(object):
         return
 
     def custom_apply_all(self):
-        """
-        Apply all of the custom functions to the satellite data object.
+        """ Apply all of the custom functions to the satellite data object.
 
+        Raises
+        ------
+        ValueError
+            Raised when function returns any value
+
+        Note
+        ----
         This method does not generally need to be invoked directly by users.
+
         """
 
         if len(self.custom_functions) > 0:
@@ -1952,7 +1959,7 @@ class Instrument(object):
                     # by method itself.
                     null_out = func(self, *arg, **kwarg)
                     if null_out is not None:
-                        raise ValueError(''.join(('Modify functions should not',
+                        raise ValueError(''.join(('Custom functions should not',
                                                   ' return any information via',
                                                   ' return. Information may ',
                                                   'only be propagated back by',
@@ -1961,7 +1968,7 @@ class Instrument(object):
         return
 
     def custom_clear(self):
-        """Clear custom function list.
+        """Clear the custom function list.
         """
         self.custom_functions = []
         self.custom_args = []

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1647,8 +1647,8 @@ class Instrument(object):
                 self._iter_width = dt.timedelta(days=1)
             if self._iter_start[0] is not None:
                 # There are files. Use those dates.
-                ustops = [stop - self._iter_width + dt.timedelta(days=1)
-                          for stop in self._iter_stop]
+                ustops = [istop - self._iter_width + dt.timedelta(days=1)
+                          for istop in self._iter_stop]
                 ufreq = self._iter_step
                 self._iter_list = utils.time.create_date_range(self._iter_start,
                                                                ustops,
@@ -1950,8 +1950,8 @@ class Instrument(object):
 
         if len(self.custom_functions) > 0:
             for func, arg, kwarg in zip(self.custom_functions,
-                                              self.custom_args,
-                                              self.custom_kwargs):
+                                        self.custom_args,
+                                        self.custom_kwargs):
                 if not self.empty:
                     # Custom functions do nothing or modify loaded data. Methods
                     # are run on Instrument object directly and any changes to

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -93,9 +93,6 @@ class Instrument(object):
         stored as a tuple of lists for consistency
     custom_functions : list
         List of functions to be applied by instrument nano-kernel
-    custom_kind : list
-        List of strings indicating type of custom function, 'modify', 'add', or
-        'pass'
     custom_args : list
         List of lists containing arguments to be passed to particular
         custom function
@@ -176,14 +173,13 @@ class Instrument(object):
             return None
 
         inst = pysat.Instrument('pysat', 'testing')
-        inst.custom_attach(custom_func, kind='modify',
-                           kwargs={'opt_param1': True})
+        inst.custom_attach(custom_func, kwargs={'opt_param1': True})
 
         # Define custom function that returns data to be added to Instrument.
         def custom_func2(inst, req_param, opt_param=False):
             return ('new_data2', data_to_be_added)
 
-        inst.custom_attach(custom_func2, kind='add', args=[True],
+        inst.custom_attach(custom_func2, args=[True],
                            kwargs={'opt_param': False})
 
         # Custom methods are applied to data when loaded.
@@ -193,12 +189,12 @@ class Instrument(object):
 
         # Custom methods may also be attached at instantiation.
         # Create a dictionary for each custom method and associated inputs
-        custom_func_1 = {'function': custom_func_modify, 'kind': 'modify',
+        custom_func_1 = {'function': custom_func_modify,
                          'kwargs': {'optional_param': True}}
-        custom_func_2 = {'function': custom_func_add_with_args, 'kind': 'add',
+        custom_func_2 = {'function': custom_func_add_with_args,
                          'args'=[arg1, arg2],
                          'kwargs': {'optional_param': True}}
-        custom_func_3 = {'function': custom_func_add, 'kind': 'add',
+        custom_func_3 = {'function': custom_func_add,
                          'kwargs': {'optional_param': False}}
 
         # Combine all dicts into a list in order of application and execution.
@@ -314,25 +310,23 @@ class Instrument(object):
 
         # Nano-kernel processing variables. Feature processes data on each load.
         self.custom_functions = []
-        self.custom_kind = []
         self.custom_args = []
         self.custom_kwargs = []
 
         # Process provided user input for custom methods, if provided.
         if custom is not None:
             # Required keys.
-            req_keys = ['function', 'kind']
+            req_key = 'function'
 
             # Optional inputs with default values
             opt_keys = [('args', []), ('kwargs', {})]
 
             for cust in custom:
                 # Check if required keys present in input.
-                for rkey in req_keys:
-                    if rkey not in cust:
-                        estr = ''.join(('Input dict to custom is missing ',
-                                        'a required key: ', rkey))
-                        raise ValueError(estr)
+                if req_key not in cust:
+                    estr = ''.join(('Input dict to custom is missing the ',
+                                    'required key: ', rkey))
+                    raise ValueError(estr)
 
                 # Check if optional arguments present. If not, provide
                 # default value.
@@ -341,8 +335,8 @@ class Instrument(object):
                         cust[okey] = def_type
 
                 # Inputs have been checked, add to Instrument object.
-                self.custom_attach(cust['function'], kind=cust['kind'],
-                                   args=cust['args'], kwargs=cust['kwargs'])
+                self.custom_attach(cust['function'], args=cust['args'],
+                                   kwargs=cust['kwargs'])
 
         # Create arrays to store data around loaded day. This enables padding
         # across day breaks with minimal loads
@@ -464,12 +458,11 @@ class Instrument(object):
 
         # Create string for custom attached methods
         cstr = '['
-        for func, kind, arg, kwarg in zip(self.custom_functions,
-                                          self.custom_kind, self.custom_args,
-                                          self.custom_kwargs):
-            tstr = "".join(("'function': {sfunc}, 'kind': '{skind}', ",
-                            "'args': {sargs}, 'kwargs': {kargs}"))
-            tstr = tstr.format(sfunc=repr(func), skind=kind, sargs=repr(arg),
+        for func, arg, kwarg in zip(self.custom_functions, self.custom_args,
+                                    self.custom_kwargs):
+            tstr = "".join(("'function': {sfunc}, 'args': {sargs}, ",
+                            "'kwargs': {kargs}"))
+            tstr = tstr.format(sfunc=repr(func), sargs=repr(arg),
                                kargs=repr(kwarg))
             cstr = "".join((cstr, '{', tstr, '}, '))
         cstr += ']'
@@ -1885,8 +1878,7 @@ class Instrument(object):
         self.data = concat_func(new_data, **kwargs)
         return
 
-    def custom_attach(self, function, kind='modify', at_pos='end', args=[],
-                      kwargs={}):
+    def custom_attach(self, function, at_pos='end', args=[], kwargs={}):
         """Attach a function to custom processing queue.
 
         Custom functions are applied automatically whenever `.load()`
@@ -1896,22 +1888,6 @@ class Instrument(object):
         ----------
         function : string or function object
             name of function or function object to be added to queue
-        kind : str
-            Specifies the type of interaction between the custom function and
-            the Instrument data.  Accepts one of 'add', 'modify', or 'pass'.
-
-            - add
-                Adds data returned from function to instrument object.
-                A copy of pysat.Instrument object supplied to routine.
-            - modify
-                pysat.Instrument object supplied to routine. Any and all
-                changes to object are retained.
-            - pass
-                A copy of pysat.Instrument object is passed to function
-                thus no modifications are retained. No data is accepted
-                from return.
-
-            (default='modify')
         at_pos : string or int
             Accepts string 'end' or a number that will be used to determine
             the insertion order if multiple custom functions are attached
@@ -1925,21 +1901,9 @@ class Instrument(object):
 
         Note
         ----
-        Allowed `custom_attach` function returns if `kind` is 'add':
-
-            - {'data' : pandas Series/DataFrame/array_like,
-               meta_label_string : string/array_like of strings,
-               'name' : string/array_like of strings}
-
-            - pandas DataFrame, names of columns are used if not provided
-
-            - pandas Series, Series.name used if not provided in 'name'
-
-            - xarray DataArray, DataArray.name used if not provided in 'name'
-
-            - xarray Dataset, variables names used if not provided in 'name'
-
-            - (string/list of strings, numpy array/list of arrays)
+        Functions applied using `custom_attach` may add, modify, or use
+        the data within Instrument inside of the function, and so should not
+        return anything.
 
         """
 
@@ -1962,13 +1926,13 @@ class Instrument(object):
             self.custom_functions.append(function)
             self.custom_args.append(args)
             self.custom_kwargs.append(kwargs)
-            self.custom_kind.append(kind.lower())
         else:
             # user picked a specific location to insert
             self.custom_functions.insert(at_pos, function)
             self.custom_args.insert(at_pos, args)
             self.custom_kwargs.insert(at_pos, kwargs)
-            self.custom_kind.insert(at_pos, kind)
+
+        return
 
     def custom_apply_all(self):
         """
@@ -1978,152 +1942,31 @@ class Instrument(object):
         """
 
         if len(self.custom_functions) > 0:
-            for func, arg, kwarg, kind in zip(self.custom_functions,
+            for func, arg, kwarg in zip(self.custom_functions,
                                               self.custom_args,
-                                              self.custom_kwargs,
-                                              self.custom_kind):
+                                              self.custom_kwargs):
                 if not self.empty:
-                    # Add method. Apply custom functions to an Instrument copy.
-                    # Take the returned data and add it to self.
-                    if kind == 'add':
-                        tempd = self.copy()
-                        new_data = func(tempd, *arg, **kwarg)
-                        del tempd
-
-                        # Make all returns a dictionary by default.
-                        # If the method itself does not return a dictionary,
-                        # the returned data is placed in 'data' key.
-                        recast_as_dict = False
-                        if not isinstance(new_data, dict):
-                            new_data = {'data': new_data}
-                            var_name = None
-
-                            # Flag if recast to identify if working with
-                            # older style data.
-                            recast_as_dict = True
-                        else:
-                            # Check for name
-                            if 'name' in new_data:
-                                var_name = new_data.pop('name')
-                            else:
-                                var_name = None
-
-                        # pandas.DataFrame returned, add to existing frame.
-                        if isinstance(new_data['data'], pds.DataFrame):
-                            if var_name is None:
-                                var_name = new_data['data'].columns
-
-                            self[var_name] = new_data
-
-                        # pandas.Series or xarray.DataArray returned,
-                        # add it as a column.
-                        elif isinstance(new_data['data'], (pds.Series,
-                                                           xr.DataArray)):
-                            if var_name is None:
-                                if new_data['data'].name is not None:
-                                    var_name = new_data['data'].name
-                                else:
-                                    raise ValueError(
-                                        ''.join(['Must assign a name to ',
-                                                 'Series or return a ',
-                                                 '"name" in dictionary.']))
-
-                            self[var_name] = new_data
-
-                        # xarray.Dataset returned, merge into existing data.
-                        elif isinstance(new_data['data'], xr.Dataset):
-                            # First, merge in dataset data
-                            xr_data = new_data.pop('data')
-                            self.data = xr.merge([self.data, xr_data])
-
-                            # Second, check on names. If not provided, generate
-                            # names from dataset itself.
-                            if var_name is None:
-                                var_name = list(xr_data.variables.keys())[1:]
-                                # Filter out any indexes variables
-                                fnames = [lname for lname in var_name
-                                          if lname not in xr_data.indexes]
-
-                            # Finally, add in the metadata.
-                            self.meta[fnames] = new_data
-
-                        # Some kind of iterable was returned. Add using
-                        # best effort code.
-                        elif hasattr(new_data['data'], '__iter__'):
-                            # Look for variable name in returned dict
-                            if var_name is not None:
-                                self[var_name] = new_data
-                            elif recast_as_dict:
-                                # Falling back to older behavior:
-                                # unpack tuple/list that was returned.
-                                var_name = new_data['data'][0]
-                                new_data = new_data['data'][1]
-                                if len(new_data) > 0:
-                                    # Check doesn't ensure data for all cases,
-                                    # there could be multiple empty arrays
-                                    # returned, [[],[]].
-                                    if isinstance(var_name, str):
-                                        # Only one item to add. Check on
-                                        # new_data above is sufficient for this
-                                        # case.
-                                        self[var_name] = new_data
-                                    else:
-                                        # Multiple items detected. Add one at
-                                        # a time.
-                                        for vname, data in zip(var_name,
-                                                               new_data):
-                                            if len(data) > 0:
-                                                # Fixes up the incomplete check
-                                                # from above
-                                                self[vname] = data
-                                # dstr = ''.join(('Data returned will require ',
-                                #               'a "name" key in the returned ',
-                                #                 'dictionary.'))
-                                # raise DeprecationWarning(dstr)
-                            else:
-                                raise ValueError(''.join(('Must include ',
-                                                          '"name" in ',
-                                                          'returned ',
-                                                          'dictionary.')))
-                        else:
-                            raise ValueError(''.join(("kernel doesn't know ",
-                                                      "what to do with ",
-                                                      "returned data.")))
-
-                    # Modifying loaded data. Methods run on Instrument object
-                    # directly and any changes to object by the method are
-                    # retained. No data may be returned by method itself.
-                    elif kind == 'modify':
-                        null_out = func(self, *arg, **kwarg)
-                        if null_out is not None:
-                            raise ValueError(''.join(('Modify functions ',
-                                                      'should not return ',
-                                                      'any information via ',
-                                                      'return. Information ',
-                                                      'may only be propagated ',
-                                                      'back by modifying ',
-                                                      'supplied pysat object.'
-                                                      )))
-
-                    # Pass function. Method runs on a copy of Instrument,
-                    # thus no modifications to Instrument are retained,
-                    # and no data is allowed to be returned.
-                    elif kind == 'pass':
-                        tempd = self.copy()
-                        null_out = func(tempd, *arg, **kwarg)
-                        del tempd
-                        if null_out is not None:
-                            raise ValueError(''.join(('Pass functions should ',
-                                                      'not return any ',
-                                                      'information via ',
-                                                      'return.')))
+                    # Custom functions do nothing or modify loaded data. Methods
+                    # are run on Instrument object directly and any changes to
+                    # object by the method are retained. No data may be returned
+                    # by method itself.
+                    null_out = func(self, *arg, **kwarg)
+                    if null_out is not None:
+                        raise ValueError(''.join(('Modify functions should not',
+                                                  ' return any information via',
+                                                  ' return. Information may ',
+                                                  'only be propagated back by',
+                                                  ' modifying supplied pysat ',
+                                                  'object.')))
+        return
 
     def custom_clear(self):
-        """Clear custom function list."""
+        """Clear custom function list.
+        """
         self.custom_functions = []
         self.custom_args = []
         self.custom_kwargs = []
-        self.custom_kind = []
+        return
 
     def today(self):
         """Returns today's date (UTC), with no hour, minute, second, etc.

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -93,21 +93,22 @@ class TestConstellation:
         assert out_str.find("pysat Constellation ") >= 0
         assert out_str.find("No loaded Instruments") > 0
 
-    def test_single_adding_custom_function(self):
+    def test_single_attachment_of_custom_function(self):
         """Test successful attachment of custom function
         """
         # Define a custom function
         def double_mlt(inst):
             dmlt = 2.0 * inst.data.mlt
             dmlt.name = 'doubleMLT'
-            return dmlt
+            inst.data[dmlt.name] = dmlt
+            return
 
         # Initialize the constellation
         self.in_kwargs['const_module'] = None
         self.const = pysat.Constellation(**self.in_kwargs)
 
         # Add the custom function
-        self.const.custom_attach(double_mlt, 'add', at_pos='end')
+        self.const.custom_attach(double_mlt, at_pos='end')
         self.const.load(2009, 1)
 
         # Test the added value

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -142,10 +142,35 @@ class TestBasics():
                   {'function': mult_data, 'args': self.custom_args}]
         testInst2 = pysat.Instrument('pysat', 'testing', custom=custom)
 
-        # ensure both instruments have the same custom_* attributes
+        # Ensure both instruments have the same custom_* attributes
         assert self.testInst.custom_functions == testInst2.custom_functions
         assert self.testInst.custom_args == testInst2.custom_args
         assert self.testInst.custom_kwargs == testInst2.custom_kwargs
+
+    def test_custom_positioning(self):
+        """Test custom method ordering specification
+        """
+
+        self.testInst.custom_attach(mult_data, args=[3],
+                                    kwargs={'dkey': '2xmlt'})
+        self.testInst.custom_attach(mult_data, at_pos=0, args=self.custom_args)
+
+        # Create another instance of pysat.Instrument and add custom
+        # via the input keyword
+        custom = [{'function': mult_data, 'args': [3],
+                   'kwargs': {'dkey': '2xmlt'}},
+                  {'function': mult_data, 'at_pos': 0,
+                   'args': self.custom_args}]
+        testInst2 = pysat.Instrument('pysat', 'testing', custom=custom)
+
+        # Ensure both Instruments have the same custom_* attributes
+        assert self.testInst.custom_functions == testInst2.custom_functions
+        assert self.testInst.custom_args == testInst2.custom_args
+        assert self.testInst.custom_kwargs == testInst2.custom_kwargs
+
+        # Ensure the run order was correct
+        assert self.testInst.custom_args[0] == self.custom_args
+        assert self.testInst.custom_args[1] == [3]
 
     def test_custom_keyword_instantiation_poor_format(self):
         """Test for error when custom missing keywords at instantiation

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -1,13 +1,36 @@
 import copy
-import datetime as dt
 from io import StringIO
 import logging
-import numpy as np
-import pandas as pds
 import pytest
-import xarray as xr
 
 import pysat
+
+
+def mult_data(inst, mult, dkey="mlt"):
+    """Function to add a multiplied data value to an Instrument
+
+    Parameters
+    ----------
+    inst : pysat.Instrument
+        pysat Instrument object
+    mult : float or int
+        Multiplicative value
+    dkey : str
+        Key for data that will be multiplied (default='mlt')
+
+    Note
+    ----
+    Adds multiplied data to Instrument using a key name with the format
+    {mult}x{dkey}
+
+    """
+    # Construct the new data key
+    out_key = '{:.0f}x{:s}'.format(mult, dkey)
+
+    # Add the new data to the instrument
+    inst.data[out_key] = mult * inst.data[dkey]
+
+    return
 
 
 class TestLogging():
@@ -31,7 +54,7 @@ class TestLogging():
         """
 
         self.testInst.custom_attach(lambda inst: inst.data['mlt'] * 2.0,
-                                    'add', at_pos=3)
+                                    at_pos=3)
         self.out = self.log_capture.getvalue()
 
         assert self.out.find(
@@ -46,48 +69,44 @@ class TestBasics():
                                          clean_level='clean')
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.load(date=self.load_date)
-        self.ncols = len(self.testInst.data.columns)
+        self.custom_args = [2]
         self.out = None
 
     def teardown(self):
         """Runs after every method to clean up previous testing.
         """
-        del self.testInst, self.ncols, self.out
+        del self.testInst, self.out, self.custom_args
 
     def test_basic_str(self):
         """Check for lines from each decision point in str"""
         self.out = self.testInst.__str__()
         assert isinstance(self.out, str)
+
         # No custom functions
         assert self.out.find('0 applied') > 0
 
     def test_basic_repr(self):
         """Test __repr__ with a custom method"""
-        def custom_func(inst):
-            return
 
-        def custom_func2(inst):
-            return
-        self.testInst.custom_attach(custom_func, 'modify')
-        self.testInst.custom_attach(custom_func2, 'modify')
+        self.testInst.custom_attach(mult_data, args=self.custom_args)
+        self.testInst.custom_attach(mult_data, args=self.custom_args)
         self.out = self.testInst.__repr__()
         assert isinstance(self.out, str)
         assert self.out.find("'function'") >= 0
 
     def test_basic_str_w_function(self):
         """Check for lines from each decision point in str"""
-        def mult_data(inst, mult, dkey="mlt"):
-            out_key = '{:.0f}x{:s}'.format(mult, dkey)
-            inst.data[out_key] = mult * inst.data[dkey]
-            return
 
-        self.testInst.custom_attach(mult_data, 'modify', args=[2.0],
-                                    kwargs={"dkey": "mlt"})
+        self.testInst.custom_attach(mult_data, args=self.custom_args,
+                                    kwargs={'dkey': 'mlt'})
+
         # Execute custom method
         self.testInst.load(date=self.load_date)
+
         # Store output to be tested
         self.out = self.testInst.__str__()
         assert isinstance(self.out, str)
+
         # No custom functions
         assert self.out.find('1 applied') > 0
         assert self.out.find('mult_data') > 0
@@ -97,95 +116,42 @@ class TestBasics():
     def test_single_modifying_custom_function_error(self):
         """Test for error when custom function loaded as modify returns a value
         """
-        def custom1(inst):
+        def custom_with_return_data(inst):
             inst.data['doubleMLT'] = 2.0 * inst.data.mlt
             return 5.0 * inst.data['mlt']
 
-        self.testInst.custom_attach(custom1, 'modify')
-        with pytest.raises(ValueError):
+        self.testInst.custom_attach(custom_with_return_data)
+        with pytest.raises(ValueError) as verr:
             self.testInst.load(date=self.load_date)
 
-    def test_single_adding_custom_function(self):
-        """Test successful use of custom function loaded as add
-        """
-        def custom1(inst):
-            d = 2.0 * inst['mlt']
-            d.name = 'doubleMLT'
-            return d
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert (self.testInst['doubleMLT'].values == 2.0
-                * self.testInst['mlt'].values).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_single_adding_custom_function_wrong_times(self):
-        """Test index alignment with add type custom function
-        """
-        if not self.testInst.pandas_format:
-            pytest.skip('pandas specific test for time index')
-
-        def custom1(inst):
-            new_index = inst.index + dt.timedelta(milliseconds=500)
-            d = pds.Series(2.0 * inst['mlt'], index=new_index)
-            d.name = 'doubleMLT'
-            return d
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert (self.testInst['doubleMLT'].isnull()).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_single_adding_custom_function_that_modifies_passed_data(self):
-        """Ensure in-function instrument modifications don't propagate with add
-        """
-        def custom1(inst):
-            inst.data['doubleMLT'] = 2.0 * inst.data.mlt
-            inst['mlt'] = 0.
-            return inst.data.doubleMLT
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert (self.testInst.data['doubleMLT'] == 2.0
-                * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
+        estr = 'Custom functions should not return any information via return'
+        assert str(verr).find(estr) >= 0
 
     def test_custom_keyword_instantiation(self):
         """Test adding custom methods at Instrument instantiation
         """
-        def custom_add(inst, arg1, arg2, kwarg1=False, kwarg2=True):
-            return
 
-        def custom_modify(inst, arg1, arg2, kwarg1=False, kwarg2=True):
-            return
+        self.testInst.custom_attach(mult_data, args=self.custom_args,
+                                    kwargs={'dkey': 'mlt'})
+        self.testInst.custom_attach(mult_data, args=self.custom_args)
 
-        self.testInst.custom_attach(custom_add, 'add', args=[0, 1],
-                                    kwargs={'kwarg1': True, 'kwarg2': False})
-        self.testInst.custom_attach(custom_modify, 'modify', args=[5, 10],
-                                    kwargs={'kwarg1': True, 'kwarg2': True})
-        self.testInst.custom_attach(custom_modify, 'modify')
-
-        # create another instance of pysat.Instrument and add custom
+        # Create another instance of pysat.Instrument and add custom
         # via the input keyword
-        custom = [{'function': custom_add, 'kind': 'add', 'args': [0, 1],
-                   'kwargs': {'kwarg1': True, 'kwarg2': False}},
-                  {'function': custom_modify, 'kind': 'modify', 'args': [5, 10],
-                   'kwargs': {'kwarg1': True, 'kwarg2': True}},
-                  {'function': custom_modify, 'kind': 'modify'}
-                  ]
+        custom = [{'function': mult_data, 'args': self.custom_args,
+                   'kwargs': {'dkey': 'mlt'}},
+                  {'function': mult_data, 'args': self.custom_args}]
         testInst2 = pysat.Instrument('pysat', 'testing', custom=custom)
 
         # ensure both instruments have the same custom_* attributes
         assert self.testInst.custom_functions == testInst2.custom_functions
-        assert self.testInst.custom_kind == testInst2.custom_kind
         assert self.testInst.custom_args == testInst2.custom_args
         assert self.testInst.custom_kwargs == testInst2.custom_kwargs
 
     def test_custom_keyword_instantiation_poor_format(self):
         """Test for error when custom missing keywords at instantiation
         """
-        req_words = ['function', 'kind']
-        real_custom = [{'function': 1, 'kind': 'add', 'args': [0, 1],
+        req_words = ['function']
+        real_custom = [{'function': 1, 'args': [0, 1],
                         'kwargs': {'kwarg1': True, 'kwarg2': False}}]
         for i, word in enumerate(req_words):
             custom = copy.deepcopy(real_custom)
@@ -195,263 +161,11 @@ class TestBasics():
             with pytest.raises(ValueError) as err:
                 pysat.Instrument('pysat', 'testing', custom=custom)
 
-            # ensure correct error for the missing parameter (word)
+            # Ensure correct error for the missing parameter (word)
             assert str(err).find(word) >= 0
             assert str(err).find('Input dict to custom is missing') >= 0
 
         return
-
-    def test_add_function_tuple_return_style(self):
-        """Test success of add function that returns name and numpy array.
-        """
-        def custom1(inst):
-            return ('doubleMLT', 2.0 * inst.data.mlt.values)
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_multiple_custom_functions_tuple_return_style(self):
-        """Test success of add function with multiple name/array pairs
-        """
-        def custom1(inst):
-            return (['doubleMLT', 'tripleMLT'], [2.0 * inst.data.mlt.values,
-                                                 3.0 * inst.data.mlt.values])
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert (self.testInst.data['doubleMLT'] == 2.0
-                * self.testInst['mlt']).all()
-        assert (self.testInst.data['tripleMLT'] == 3.0
-                * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 2
-
-    def test_add_function_tuple_return_style_too_few_elements(self):
-        """Test failure of add function that too few array elements
-        """
-        if not self.testInst.pandas_format:
-            pytest.skip('pandas specific test for time index')
-
-        def custom1(inst):
-            return ('doubleMLT', 2.0 * inst.data.mlt.values[0:-5])
-
-        self.testInst.custom_attach(custom1, 'add')
-        with pytest.raises(ValueError):
-            self.testInst.load(date=self.load_date)
-
-    def test_add_function_tuple_return_style_too_many_elements(self):
-        """Test failure of add function that too many array elements
-        """
-        if not self.testInst.pandas_format:
-            pytest.skip('pandas specific test for time index')
-
-        def custom1(inst):
-            return ('doubleMLT', np.arange(2.0 * len(inst.data.mlt)))
-
-        self.testInst.custom_attach(custom1, 'add')
-        with pytest.raises(ValueError):
-            self.testInst.load(date=self.load_date)
-
-    def test_add_dataframe(self):
-        """Test add function success with pandas DataFrame return
-        """
-        def custom1(inst):
-            out = pds.DataFrame({'doubleMLT': inst.data.mlt * 2,
-                                 'tripleMLT': inst.data.mlt * 3},
-                                index=inst.index)
-            return out
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert (self.testInst.data['doubleMLT'] == 2.0
-                * self.testInst['mlt']).all()
-        assert (self.testInst.data['tripleMLT'] == 3.0
-                * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 2
-
-    def test_add_dataframe_w_meta(self):
-        """Test add function success with pandas DataFrame and MetaData return
-        """
-        def custom1(inst):
-            out = pds.DataFrame({'doubleMLT': inst.data.mlt * 2,
-                                 'tripleMLT': inst.data.mlt * 3},
-                                index=inst.index)
-            return {'data': out,
-                    'long_name': ['doubleMLTlong', 'tripleMLTlong'],
-                    'units': ['hours1', 'hours2']}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert self.testInst.meta['doubleMLT'].units == 'hours1'
-        assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
-        assert self.testInst.meta['tripleMLT'].units == 'hours2'
-        assert self.testInst.meta['tripleMLT'].long_name == 'tripleMLTlong'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert (self.testInst['tripleMLT'] == 3.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 2
-
-    def test_add_series_w_meta(self):
-        """Test add function success with pandas Series return
-        """
-        def custom1(inst):
-            out = pds.Series(inst.data.mlt * 2, index=inst.index)
-            out.name = 'doubleMLT'
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert self.testInst.meta['doubleMLT'].units == 'hours1'
-        assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_series_w_meta_missing_long_name(self):
-        """Test add function success with Series and allowable partial MetaData
-        """
-        def custom1(inst):
-            out = pds.Series(2.0 * inst.data.mlt.values, index=inst.index)
-            out.name = 'doubleMLT'
-            return {'data': out, 'units': 'hours1'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert self.testInst.meta['doubleMLT', 'units'] == 'hours1'
-        assert self.testInst.meta['doubleMLT', 'long_name'] == 'doubleMLT'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_series_w_meta_name_in_dict(self):
-        """Test add function success with pandas Series and MetaData return
-        """
-        def custom1(inst):
-            out = pds.Series(2.0 * inst.data.mlt.values, index=inst.index)
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1', 'name': 'doubleMLT'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert self.testInst.meta['doubleMLT'].units == 'hours1'
-        assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_series_w_meta_no_name_error(self):
-        """Test add function failure with Series and required MetaData missing
-        """
-        def custom1(inst):
-            out = pds.Series({'doubleMLT': inst.data.mlt * 2}, index=inst.index)
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        with pytest.raises(ValueError):
-            self.testInst.load(date=self.load_date)
-
-    def test_add_xarray_dataarray(self):
-        """Test add function success with xarray"""
-        def custom1(inst):
-            out = xr.DataArray(inst.data.mlt * 2, dims=['time'],
-                               coords=[inst.index])
-            out.name = 'doubleMLT'
-            return {'data': out, inst.meta.labels.name: 'doubleMLTlong',
-                    inst.meta.labels.units: 'hours1'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        units = self.testInst.meta.labels.units
-        lname = self.testInst.meta.labels.name
-        assert self.testInst.meta['doubleMLT', units] == 'hours1'
-        assert self.testInst.meta['doubleMLT', lname] == 'doubleMLTlong'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_xarray_dataset(self):
-        """Test add function success with xarray"""
-        def custom_set(inst):
-            out1 = xr.DataArray(inst.data.mlt * 2, dims=['time'],
-                                coords=[inst.index])
-            out1.name = 'doubleMLT'
-
-            out2 = xr.DataArray(inst.data.mlt * 3, dims=['time'],
-                                coords=[inst.index])
-            out2.name = 'tripleMLT'
-
-            out = xr.Dataset({'doubleMLT': out1, 'tripleMLT': out2})
-
-            return {'data': out, inst.meta.labels.name: ['doubleMLTlong',
-                                                         'tripleMLTyo'],
-                    inst.meta.labels.units: ['hours1', 'hours2']}
-
-        if not self.testInst.pandas_format:
-            self.testInst.custom_attach(custom_set, 'add')
-            self.testInst.load(date=self.load_date)
-            units = self.testInst.meta.labels.units
-            lname = self.testInst.meta.labels.name
-            assert self.testInst.meta['doubleMLT', units] == 'hours1'
-            assert self.testInst.meta['tripleMLT', units] == 'hours2'
-            assert self.testInst.meta['doubleMLT', lname] == 'doubleMLTlong'
-            assert self.testInst.meta['tripleMLT', lname] == 'tripleMLTyo'
-            assert (self.testInst['doubleMLT']
-                    == 2.0 * self.testInst['mlt']).all()
-            assert (self.testInst['tripleMLT']
-                    == 3.0 * self.testInst['mlt']).all()
-            tlen = self.ncols + 2
-            assert len([kk for kk in self.testInst.data.keys()]) == tlen
-
-    def test_add_numpy_array_w_meta_name_in_dict(self):
-        """Test add function success with array and MetaData
-        """
-        def custom1(inst):
-            out = 2. * inst['mlt'].values
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1', 'name': 'doubleMLT'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert self.testInst.meta['doubleMLT'].units == 'hours1'
-        assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_numpy_array_w_meta_no_name_in_dict_error(self):
-        """Test add function failure with array and required MetaData missing
-        """
-        def custom1(inst):
-            out = (inst.data.mlt * 2).values
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        with pytest.raises(ValueError):
-            self.testInst.load(date=self.load_date)
-
-    def test_add_list_w_meta_name_in_dict(self):
-        """Test add function success with list and full MetaData
-        """
-        def custom1(inst):
-            out = (inst.data.mlt * 2).values.tolist()
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1', 'name': 'doubleMLT'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        self.testInst.load(date=self.load_date)
-        assert self.testInst.meta['doubleMLT'].units == 'hours1'
-        assert self.testInst.meta['doubleMLT'].long_name == 'doubleMLTlong'
-        assert (self.testInst['doubleMLT'] == 2.0 * self.testInst['mlt']).all()
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols + 1
-
-    def test_add_list_w_meta_no_name_in_dict_error(self):
-        """Test add function failure with list and required MetaData missing
-        """
-        def custom1(inst):
-            out = (inst.data.mlt * 2).values.tolist()
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1'}
-
-        self.testInst.custom_attach(custom1, 'add')
-        with pytest.raises(ValueError):
-            self.testInst.load(date=self.load_date)
 
     def test_clear_functions(self):
         """Test successful clearance of custom functions
@@ -460,74 +174,18 @@ class TestBasics():
                                     {'data': (inst.data.mlt * imult).values,
                                      'long_name': 'doubleMLTlong',
                                      'units': out_units, 'name': 'doubleMLT'},
-                                    'add', args=[2],
-                                    kwargs={"out_units": "hours1"})
+                                    args=[2], kwargs={"out_units": "hours1"})
 
         # Test to see that the custom function was attached
         assert len(self.testInst.custom_functions) == 1
-        assert len(self.testInst.custom_kind) == 1
         assert len(self.testInst.custom_args) == 1
         assert len(self.testInst.custom_kwargs) == 1
 
         self.testInst.custom_clear()
         # Test to see that the custom function was cleared
         assert self.testInst.custom_functions == []
-        assert self.testInst.custom_kind == []
         assert self.testInst.custom_args == []
         assert self.testInst.custom_kwargs == []
-
-    def test_pass_functions(self):
-        """ Test success of pass function, will not modify or add to instrument
-        """
-        def custom1(inst):
-            _ = (inst.data.mlt * 2).values
-            return
-
-        self.testInst.custom_attach(custom1, 'pass')
-        # Test to see that the custom function was attached
-        assert len(self.testInst.custom_functions) == 1
-        assert len(self.testInst.custom_kind) == 1
-        assert len(self.testInst.custom_args) == 1
-        assert len(self.testInst.custom_kwargs) == 1
-
-        self.testInst.load(date=self.load_date)
-        # Test that the number of data columns is the same
-        assert len([kk for kk in self.testInst.data.keys()]) == self.ncols
-
-    def test_pass_functions_no_return_allowed_error(self):
-        """Test error when a pass function returns a value
-        """
-        def custom1(inst):
-            out = (inst.data.mlt * 2).values
-            return {'data': out, 'long_name': 'doubleMLTlong',
-                    'units': 'hours1', 'name': 'doubleMLT'}
-
-        self.testInst.custom_attach(custom1, 'pass')
-        with pytest.raises(ValueError):
-            self.testInst.load(date=self.load_date)
-
-    def test_add_multiple_functions_one_not_at_end(self):
-        """Test for error if custom functions are run in the wrong order
-        """
-        def custom1(inst, imult):
-            out = (inst.data.mlt * imult).values
-            return {'data': out, 'long_name': 'MLT x {:d}'.format(int(imult)),
-                    'units': 'hours', 'name': 'MLTx{:d}'.format(int(imult))}
-
-        self.testInst.custom_attach(custom1, 'add', args=[4])
-        self.testInst.custom_attach(custom1, 'add', args=[2])
-        self.testInst.custom_attach(lambda inst, imult:
-                                    {'data': (inst.data.MLTx2 * imult).values,
-                                     'long_name': 'MLT x {:d}'.format(imult),
-                                     'units': 'h',
-                                     'name': 'MLTx{:d}'.format(imult)},
-                                    'add', args=[2], at_pos=1)
-
-        # An AttributeError should be thrown, since the data required by the
-        # last attached function (inst.data.MLTx2) won't be present yet
-
-        with pytest.raises(AttributeError):
-            self.testInst.load(date=self.load_date)
 
 
 # Repeat the above tests with xarray
@@ -537,44 +195,100 @@ class TestBasicsXarray(TestBasics):
         """
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          num_samples=10, clean_level='clean')
-        self.load_date = pysat.instruments.pysat_testing_xarray._test_dates
-        self.load_date = self.load_date['']['']
+        self.load_date = pysat.instruments.pysat_testing_xarray._test_dates[
+            '']['']
         self.testInst.load(date=self.load_date)
-        self.ncols = len([kk for kk in self.testInst.data.keys()])
+        self.custom_args = [2]
 
     def teardown(self):
         """Runs after every method to clean up previous testing.
         """
-        del self.testInst
+        del self.testInst, self.load_date, self.custom_args
 
 
-# Repeat the above tests with a Constellation
 class TestConstellationBasics():
     def setup(self):
         """Runs before every method to create a clean testing setup
         """
-        self.testInst = pysat.Constellation(instruments=[
+        self.testConst = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
                              clean_level='clean')
             for i in range(5)])
-
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
+        self.testConst.load(date=self.load_date)
+        self.custom_args = [2]
 
     def teardown(self):
         """ Runs after every method to clean up previous testing
         """
-        del self.testInst
+        del self.testConst, self.load_date, self.custom_args
 
-    def test_add(self):
-        """ Add a function to the object's custom queue
+    def test_basic_repr(self):
+        """Test __repr__ with a custom method"""
+
+        self.testConst.custom_attach(mult_data, args=self.custom_args)
+        self.out = self.testConst.__repr__()
+        assert isinstance(self.out, str)
+        assert self.out.find("'function'") >= 0
+
+    def test_single_modifying_custom_function_error(self):
+        """Test for error when custom function loaded as modify returns a value
         """
-        def custom_test(inst, arg1, kwarg1=None):
-            inst.arg1 = arg1
-            inst.kwarg1 = kwarg1
-            return
-        self.testInst.custom_attach(custom_test, kind='modify', args=['hi'],
-                                    kwargs={'kwarg1': 'bye'})
-        self.testInst.load(date=self.load_date)
-        for inst in self.testInst:
-            assert inst.arg1 == 'hi'
-            assert inst.kwarg1 == 'bye'
+        def custom_with_return_data(inst):
+            inst.data['doubleMLT'] = 2.0 * inst.data.mlt
+            return 5.0 * inst.data['mlt']
+
+        self.testConst.custom_attach(custom_with_return_data)
+        with pytest.raises(ValueError) as verr:
+            self.testConst.load(date=self.load_date)
+
+        estr = 'Custom functions should not return any information via return'
+        assert str(verr).find(estr) >= 0
+
+    def test_custom_keyword_instantiation(self):
+        """Test adding custom methods at Instrument instantiation
+        """
+
+        self.testConst.custom_attach(mult_data, args=self.custom_args,
+                                     kwargs={'dkey': 'mlt'})
+        self.testConst.custom_attach(mult_data, args=self.custom_args)
+
+        # Create another instance of pysat.Instrument and add custom
+        # via the input keyword
+        custom = [{'function': mult_data, 'args': self.custom_args,
+                   'kwargs': {'dkey': 'mlt'}},
+                  {'function': mult_data, 'args': self.custom_args}]
+        testConst2 = pysat.Constellation(instruments=[
+            pysat.Instrument('pysat', 'testing', num_samples=10,
+                             clean_level='clean', custom=custom)
+            for i in range(5)])
+
+        # Ensure all instruments within both constellations have the same
+        # custom_* attributes
+        for i, inst in enumerate(self.testConst.instruments):
+            inst2 = testConst2.instruments[i]
+            assert inst.custom_functions == inst2.custom_functions
+            assert inst.custom_args == inst2.custom_args
+            assert inst.custom_kwargs == inst2.custom_kwargs
+
+    def test_clear_functions(self):
+        """Test successful clearance of custom functions
+        """
+        self.testConst.custom_attach(lambda inst, imult, out_units='h':
+                                     {'data': (inst.data.mlt * imult).values,
+                                      'long_name': 'doubleMLTlong',
+                                      'units': out_units, 'name': 'doubleMLT'},
+                                     args=[2], kwargs={"out_units": "hours1"})
+
+        # Test to see that the custom function was attached
+        for inst in self.testConst.instruments:
+            assert len(inst.custom_functions) == 1
+            assert len(inst.custom_args) == 1
+            assert len(inst.custom_kwargs) == 1
+
+        # Test to see that the custom function was cleared
+        self.testConst.custom_clear()
+        for inst in self.testConst.instruments:
+            assert inst.custom_functions == []
+            assert inst.custom_args == []
+            assert inst.custom_kwargs == []


### PR DESCRIPTION
# Description

Removes the `kind` kwarg from custom functions, addressing issue #635 and partially addresses #528.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

Created new and adapted existing unit tests.  Check out `test_custom.py` for examples.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

## Downstream modules
- [x] pysatKamodo @aburrell
- [x] pysatMissions @jklenzing 
- [x] pysatModels @aburrell - https://github.com/pysat/pysatModels/pull/70
- [x] pysatSeasons @rstoneback 
- [x] pysatCDAAC @jklenzing 
- [x] pysatMadrigal @aburrell 
- [x] pysatNASA @jklenzing 
- [x] pysatSpaceWeather @aburrell - https://github.com/pysat/pysatSpaceWeather/pull/40
- [x] pysatIncubator @rstoneback - https://github.com/pysat/pysatIncubator/pull/7
