### PR TITLE
BUG: fixed time assignment with start only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Use dt.timedelta instead of pds.DateOffSet where possible
   - Reduced code duplication throughout package
   - Reduced unused code snippets throughout
+  - Ensured download start time is used
 
 ## [2.2.2] - 2020-12-31
  - New Features

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3045,7 +3045,7 @@ class Instrument(object):
                                self.name, '. ', err.message))
                 raise ValueError(msg)
 
-        if ((start is None) or (stop is None)) and (date_array is None):
+        if start is None and stop is None and date_array is None:
             # Defaults for downloads are set here rather than in the method
             # signature since method defaults are only set once! If an
             # Instrument object persists longer than a day then the download
@@ -3055,6 +3055,9 @@ class Instrument(object):
                                  'default (yesterday through tomorrow).']))
             start = self.yesterday()
             stop = self.tomorrow()
+        elif stop is None and date_array is None:
+            stop = start + dt.timedelta(days=1)
+
         logger.info('Downloading data to: {}'.format(self.files.data_path))
 
         if date_array is None:


### PR DESCRIPTION
# Description

Fixed time specification if start but not stop provided.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

This was tested by running the example code in pysatMadrigal:

```
import datetime as dt
import pysat
import pysatMadrigal as py_mad
stime = dt.datetime(2014, 12, 31)
ivm = pysat.Instrument(inst_module=py_mad.instruments.dmsp_ivm, tag='utd', inst_id='f15', update_files=True)
ivm.download(start=stime, user="Name+Surname", password="your@email.com")
ivm.files.files[stime]
'dms_ut_20141231_15.002.hdf5'
```

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
