### PR TITLE
Deprecation warning for `Instrument.x_labels`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.3.0] - 2021-XX-XX
+- Deprecation warnings added to:
+  - Instrument class (old meta labels)
+- Documentation
+   - Updated docstrings with deprecation notes
+
 ## [2.2.2] - 2020-11-23
 - New Features
    - netCDF4 files produced using `to_netcdf4()` now have an unlimited

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -11,7 +11,6 @@ import copy
 import functools
 import inspect
 import os
-import string
 import sys
 import warnings
 
@@ -203,7 +202,7 @@ class Instrument(object):
                                "through `Instrument.meta.labels` or ",
                                "`Instrument.meta_labels` attributes in ",
                                "pysat 3.0.0"]))
-        dep_meta_kwargs = ['plot_label', 'axis_label', 'scale_label']:
+        dep_meta_kwargs = ['plot_label', 'axis_label', 'scale_label']
         dwarns.append("".join(["Meta labels [", ", ".join(dep_meta_kwargs),
                                "] are no longer standard metadata",
                                " quantities in pysat 3.0.0"]))

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -199,7 +199,7 @@ class Instrument(object):
                         'desc_label', 'min_label', 'max_label', 'fill_label']
         dwarns.append("".join(["Instrument attributes [",
                                ", ".join(label_kwargs), "] will be accessible",
-                               "through `Instrument.meta.labels` or ",
+                               " through `Instrument.meta.labels` or ",
                                "`Instrument.meta_labels` attributes in ",
                                "pysat 3.0.0"]))
         dep_meta_kwargs = ['plot_label', 'axis_label', 'scale_label']

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -194,6 +194,25 @@ class Instrument(object):
                  min_label='value_min', max_label='value_max',
                  fill_label='fill', *arg, **kwargs):
 
+        # Raise warnings about deprecated kwargs
+        dwarns = list()
+        label_kwargs = ['units_label', 'name_label', 'notes_label',
+                        'desc_label', 'min_label', 'max_label', 'fill_label']
+        dwarns.append("".join(["Instrument attributes [",
+                               ", ".join(label_kwargs), "] will be accessible",
+                               "through `Instrument.meta.labels` or ",
+                               "`Instrument.meta_labels` attributes in ",
+                               "pysat 3.0.0"]))
+        dep_meta_kwargs = ['plot_label', 'axis_label', 'scale_label']:
+        dwarns.append("".join(["Meta labels [", ", ".join(dep_meta_kwargs),
+                               "] are no longer standard metadata",
+                               " quantities in pysat 3.0.0"]))
+
+        for dwarn in dwarns:
+            warnings.warn(dwarn, DeprecationWarning, stacklevel=2)
+
+        # Start initialization
+
         if inst_module is None:
             # use strings to look up module name
             if isinstance(platform, str) and isinstance(name, str):
@@ -385,27 +404,6 @@ class Instrument(object):
             warnings.warn('Strict times will eventually be enforced upon all'
                           ' instruments. (strict_time_flag)',
                           DeprecationWarning, stacklevel=2)
-
-    def __setattr__(self, name, value):
-        """ Customize setattr to raise a deprecation warning when needed
-        """
-        self.__dict__[name] = value
-        dwarn = None
-
-        if name in ['units_label', 'name_label', 'notes_label', 'desc_label',
-                    'min_label', 'max_label', 'fill_label']:
-            dwarn = "".join(["Instrument attribute '", name, "' will be ",
-                             "accessable through `Instrument.meta.labels` or ",
-                             "`Instrument.meta_labels` attributes in pysat ",
-                             "3.0.0"])
-        elif name in ['plot_label', 'axis_label', 'scale_label']:
-            dwarn = "".join(["Meta label '", name, "' is no longer a standard",
-                             " metadata quantity in pysat 3.0.0"])
-
-        if dwarn is not None:
-            warnings.warn(dwarn, DeprecationWarning, stacklevel=2)
-
-        return
 
     def __getitem__(self, key):
         """

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -199,9 +199,8 @@ class Instrument(object):
                         'desc_label', 'min_label', 'max_label', 'fill_label']
         dwarns.append("".join(["Instrument attributes [",
                                ", ".join(label_kwargs), "] will be accessible",
-                               " through `Instrument.meta.labels` or ",
-                               "`Instrument.meta_labels` attributes in ",
-                               "pysat 3.0.0"]))
+                               " through `Instrument.meta.labels` ",
+                               "in pysat 3.0.0"]))
         dep_meta_kwargs = ['plot_label', 'axis_label', 'scale_label']
         dwarns.append("".join(["Meta labels [", ", ".join(dep_meta_kwargs),
                                "] are no longer standard metadata",

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -32,6 +32,11 @@ from pysat import logger
 class Instrument(object):
     """Download, load, manage, modify and analyze science data.
 
+    .. deprecated:: 2.3.0
+      Several attributes will be removed or replaced in pysat 3.0.0:
+      units_label, name_label, notes_label, desc_label, min_label,
+      max_label, fill_label, plot_label, axis_label, scale_label
+
     Parameters
     ----------
     platform : string
@@ -378,9 +383,29 @@ class Instrument(object):
         # warn about changes coming in the future
         if not self.strict_time_flag:
             warnings.warn('Strict times will eventually be enforced upon all'
-                          ' instruments. (strict_time_flag)', DeprecationWarning,
-                          stacklevel=2)
+                          ' instruments. (strict_time_flag)',
+                          DeprecationWarning, stacklevel=2)
 
+    def __setattr__(self, name, value):
+        """ Customize setattr to raise a deprecation warning when needed
+        """
+        self.__dict__[name] = value
+        dwarn = None
+
+        if name in ['units_label', 'name_label', 'notes_label', 'desc_label',
+                    'min_label', 'max_label', 'fill_label']:
+            dwarn = "".join(["Instrument attribute '", name, "' will be ",
+                             "accessable through `Instrument.meta.labels` or ",
+                             "`Instrument.meta_labels` attributes in pysat ",
+                             "3.0.0"])
+        elif name in ['plot_label', 'axis_label', 'scale_label']:
+            dwarn = "".join(["Meta label '", name, "' is no longer a standard",
+                             " metadata quantity in pysat 3.0.0"])
+
+        if dwarn is not None:
+            warnings.warn(dwarn, DeprecationWarning, stacklevel=2)
+
+        return
 
     def __getitem__(self, key):
         """

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1400,7 +1400,7 @@ class TestDeprecation():
         # Test the warning messages, ensuring each attribute is present
         for iwar in war:
             if iwar.category == DeprecationWarning:
-                for i, msg in enumerate(warn_msgs[~found_msgs]):
+                for i, msg in enumerate(warn_msgs):
                     if str(iwar.message).find(msg) >= 0:
                         found_msgs[i] = True
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1386,27 +1386,25 @@ class TestDeprecation():
         """Test deprecation of standard kwarg input
         """
         # Define the deprecated attributes that are always defined
-        std_kwargs = {'units_label': False, 'name_label': False,
-                      'notes_label': False, 'desc_label': False,
-                      'min_label': False, 'max_label': False,
-                      'fill_label': False, 'plot_label': False,
-                      'axis_label': False, 'scale_label': False}
+        warn_msgs = np.array(["accessible through `Instrument.meta.labels`",
+                              "are no longer standard metadata quantities"])
+        found_msgs = np.array([False, False])
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
             test_inst = pysat.Instrument(**self.in_kwargs)
 
         # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(std_kwargs.keys())
+        assert len(war) >= len(warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         for iwar in war:
             if iwar.category == DeprecationWarning:
-                for skey in std_kwargs.keys():
-                    if str(iwar.message).find(skey) >= 0:
-                        std_kwargs[skey] = True
+                for i, msg in enumerate(warn_msgs[~found_msgs]):
+                    if str(iwar.message).find(msg) >= 0:
+                        found_msgs[i] = True
 
-        for skey in std_kwargs.keys():
-            assert std_kwargs[skey]
+        for i, good in enumerate(found_msgs):
+            assert good, "didn't find warning about: {:}".format(warn_msgs[i])
 
         return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2,6 +2,7 @@
 # Test some of the basic _core functions
 import numpy as np
 import sys
+import warnings
 
 from nose.tools import raises
 import pandas as pds
@@ -1368,3 +1369,44 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         del self.testInst
+
+
+class TestDeprecation():
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+        self.in_kwargs = {"platform": 'pysat', "name": 'testing',
+                          "sat_id": '10', "clean_level": 'clean'}
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.in_kwargs
+
+    def test_standard_kwarg_dep(self):
+        """Test deprecation of standard kwarg input
+        """
+        # Define the deprecated attributes that are always defined
+        std_kwargs = {'units_label': False, 'name_label': False,
+                      'notes_label': False, 'desc_label': False,
+                      'min_label': False, 'max_label': False,
+                      'fill_label': False, 'plot_label': False,
+                      'axis_label': False, 'scale_label': False}
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            test_inst = pysat.Instrument(**self.in_kwargs)
+
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(std_kwargs.keys())
+
+        # Test the warning messages, ensuring each attribute is present
+        for iwar in war:
+            if iwar.category == DeprecationWarning:
+                for skey in std_kwargs.keys():
+                    if str(iwar.message).find(skey) >= 0:
+                        std_kwargs[skey] = True
+
+        for skey in std_kwargs.keys():
+            assert std_kwargs[skey]
+
+        return


### PR DESCRIPTION
# Description

Added deprecation warnings to metadata labels attached to the Instrument object.  Addresses #679.

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?

Added unit tests

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
