### PR TITLE
Deprecated cdaweb methods

### DIFF
--- a/pysat/instruments/methods/nasa_cdaweb.py
+++ b/pysat/instruments/methods/nasa_cdaweb.py
@@ -96,6 +96,10 @@ def load(fnames, tag=None, sat_id=None,
          flatten_twod=True):
     """Load NASA CDAWeb CDF files.
 
+    .. deprecated:: 2.3.0
+      This routine will be removed in pysat 3.0.0, it will be moved to the
+      pysatNASA repository
+
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
 
@@ -141,6 +145,12 @@ def load(fnames, tag=None, sat_id=None,
 
     import pysatCDF
 
+    warnings.warn(' '.join(["methods.nasa_cdaweb.load has been deprecated and",
+                            "will be removed in pysat 3.0.0. Please use",
+                            "pysatNASA.instruments.methods.cdaweb.load",
+                            "instead"]),
+                  DeprecationWarning, stacklevel=2)
+
     if len(fnames) <= 0:
         return pysat.DataFrame(None), None
     else:
@@ -174,6 +184,10 @@ def download(supported_tags, date_array, tag, sat_id,
              fake_daily_files_from_monthly=False,
              multi_file_day=False):
     """Routine to download NASA CDAWeb CDF data.
+
+    .. deprecated:: 2.3.0
+      This routine will be removed in pysat 3.0.0, it will be moved to the
+      pysatNASA repository
 
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
@@ -232,6 +246,12 @@ def download(supported_tags, date_array, tag, sat_id,
 
     import os
     import requests
+
+    warnings.warn(' '.join(["methods.nasa_cdaweb.download has been deprecated",
+                            "and will be removed in pysat 3.0.0. Please use",
+                            "pysatNASA.instruments.methods.cdaweb.download",
+                            "instead"]),
+                  DeprecationWarning, stacklevel=2)
 
     try:
         inst_dict = supported_tags[sat_id][tag]
@@ -336,9 +356,11 @@ def list_remote_files(tag, sat_id,
                       year=None, month=None, day=None):
     """Return a Pandas Series of every file for chosen remote data.
 
-    .. deprecated:: 2.2.0
-      `year/month/day` keywords will be removed in pysat 3.0.0, they will be
-      replaced with a start/stop syntax consistent with the download routine
+    .. deprecated:: 2.3.0
+      This routine will be removed in pysat 3.0.0, it will be moved to the
+      pysatNASA repository.  Also, as of 2.2.0 the `year/month/day` keywords
+      will be removed in pysat 3.0.0, they will be replaced with a start/stop
+      syntax consistent with the download routine
 
     This routine is intended to be used by pysat instrument modules supporting
     a particular NASA CDAWeb dataset.
@@ -417,6 +439,13 @@ def list_remote_files(tag, sat_id,
     import requests
     import warnings
     from bs4 import BeautifulSoup
+
+
+    warnings.warn(''.join(["methods.nasa_cdaweb.list_remote_files has been ",
+                           "deprecated and will be removed in pysat 3.0.0. ",
+                            "Please use pyspysatNASA.instruments.methods.",
+                            "cdaweb.list_remote_files instead"]),
+                  DeprecationWarning, stacklevel=2)
 
     if tag is None:
         tag = ''

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -61,7 +61,7 @@ class TestCDAWeb():
             # testing with single day since we just need the warning
             cdw.download(self.supported_tags, [], '', '')
 
-        assert len(war) == 1
+        assert len(war) >= 1
         assert war[0].category == DeprecationWarning
         assert str(war[0].message).find(".download has been deprecated") >= 0
 

--- a/pysat/tests/test_methods_cdaweb.py
+++ b/pysat/tests/test_methods_cdaweb.py
@@ -9,6 +9,8 @@ class TestCDAWeb():
 
     def setup(self):
         """Runs before every method to create a clean testing setup."""
+        warnings.simplefilter("always")
+
         self.supported_tags = pysat.instruments.cnofs_plp.supported_tags
 
     def teardown(self):
@@ -29,25 +31,43 @@ class TestCDAWeb():
         else:
             raise(ValueError, 'Test was expected to raise an Exception.')
 
-    def test_remote_file_list_deprecation_warning(self):
-        """Test generation of deprecation warning for remote_file_list kwargs
+    def test_list_remote_files_deprecation_warning(self):
+        """Test deprecation warnings for remote_file_list routine and kwargs
         """
-        warnings.simplefilter("always")
-
         with warnings.catch_warnings(record=True) as war:
             # testing with single day since we just need the warning
             cdw.list_remote_files(tag='', sat_id='',
                                   supported_tags=self.supported_tags,
                                   year=2009, month=1, day=1)
 
-        assert len(war) >= 1
+        assert len(war) >= 2
         assert war[0].category == DeprecationWarning
+
+    def test_load_deprecation_warning(self):
+        """Test generation of deprecation warning for load
+        """
+        with warnings.catch_warnings(record=True) as war:
+            # testing with single day since we just need the warning
+            cdw.load([], tag='', sat_id='')
+
+        assert len(war) == 1
+        assert war[0].category == DeprecationWarning
+        assert str(war[0].message).find(".load has been deprecated") >= 0
+
+    def test_download_deprecation_warning(self):
+        """Test generation of deprecation warning for download
+        """
+        with warnings.catch_warnings(record=True) as war:
+            # testing with single day since we just need the warning
+            cdw.download(self.supported_tags, [], '', '')
+
+        assert len(war) == 1
+        assert war[0].category == DeprecationWarning
+        assert str(war[0].message).find(".download has been deprecated") >= 0
 
     def test_list_files_deprecation_warning(self):
         """Test generation of deprecation warning for list_files kwargs
         """
-        warnings.simplefilter("always")
-
         with warnings.catch_warnings(record=True) as war1:
             # testing with single day since we just need the warning
             try:


### PR DESCRIPTION
# Description

Added deprecation warnings for CDAWEB methods.  Addresses #699 

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?

Added unit tests for new deprecation warnings

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
