### PR TITLE
Deprecation warning for `sat_id`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.3.0] - 2021-XX-XX
+- Allow use of new Instrument kwarg, `inst_id` (replaces `sat_id`)
 - Deprecation warnings added to:
-  - Instrument class (old meta labels)
+   - Instrument class (old meta labels, sat_id)
    - Custom class
 - Documentation
    - Updated docstrings with deprecation notes

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -33,7 +33,7 @@ class Instrument(object):
 
     .. deprecated:: 2.3.0
       Several attributes will be removed or replaced in pysat 3.0.0:
-      units_label, name_label, notes_label, desc_label, min_label,
+      sat_id, units_label, name_label, notes_label, desc_label, min_label,
       max_label, fill_label, plot_label, axis_label, scale_label
 
     Parameters
@@ -44,6 +44,8 @@ class Instrument(object):
         name of instrument.
     tag : string, optional
         identifies particular subset of instrument data.
+    inst_id : string
+        Replaces `sat_id`
     sat_id : string, optional
         identity within constellation
     clean_level : {'clean','dusty','dirty','none'}, optional
@@ -181,8 +183,8 @@ class Instrument(object):
 
     """
 
-    def __init__(self, platform=None, name=None, tag=None, sat_id=None,
-                 clean_level='clean', update_files=None, pad=None,
+    def __init__(self, platform=None, name=None, tag=None, inst_id=None,
+                 sat_id=None, clean_level='clean', update_files=None, pad=None,
                  orbit_info=None, inst_module=None, multi_file_day=None,
                  manual_org=None, directory_format=None, file_format=None,
                  temporary_file_list=False, strict_time_flag=False,
@@ -205,6 +207,14 @@ class Instrument(object):
         dwarns.append("".join(["Meta labels [", ", ".join(dep_meta_kwargs),
                                "] are no longer standard metadata",
                                " quantities in pysat 3.0.0"]))
+
+        if sat_id is None:
+            # Assign new kwarg to old one if the old one was not used
+            sat_id = inst_id
+        else:
+            # Raise warning if old kwarg used
+            dwarns.append("".join(["Instrument kwarg `sat_id` has been ",
+                                   "replaced with `inst_id` in pysat 3.0.0"]))
 
         for dwarn in dwarns:
             warnings.warn(dwarn, DeprecationWarning, stacklevel=2)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1380,7 +1380,7 @@ class TestDeprecation():
         self.warn_msgs = np.array(
             ["accessible through `Instrument.meta.labels`",
              "are no longer standard metadata quantities",
-             "Instrument kwargs `sat_id` has beeen replaced"])
+             "Instrument kwarg `sat_id` has been replaced"])
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -1394,7 +1394,7 @@ class TestDeprecation():
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
-            test_inst = pysat.Instrument(**self.in_kwargs)
+            pysat.Instrument(**self.in_kwargs)
 
         # Ensure the minimum number of warnings were raised
         assert len(war) >= len(self.warn_msgs)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1375,8 +1375,8 @@ class TestDeprecation():
     def setup(self):
         """Runs before every method to create a clean testing setup"""
         warnings.simplefilter("always")
-        self.in_kwargs = {"platform": 'pysat', "name": 'testing',
-                          "sat_id": '10', "clean_level": 'clean'}
+        self.in_kwargs = {"platform": 'pysat', "name": 'testing', "tag": '',
+                          "sat_id": '', "clean_level": 'clean'}
         self.warn_msgs = np.array(
             ["accessible through `Instrument.meta.labels`",
              "are no longer standard metadata quantities",
@@ -1419,7 +1419,9 @@ class TestDeprecation():
         del self.in_kwargs['sat_id']
 
         # Remove associated deprecation warning
-        self.warn_msgs.pop(2)
+        new_msgs = list(self.warn_msgs)
+        new_msgs.pop(2)
+        self.warn_msgs = np.array(new_msgs)
 
         # Evaluate warnings
         self.eval_warnings()

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1377,34 +1377,56 @@ class TestDeprecation():
         warnings.simplefilter("always")
         self.in_kwargs = {"platform": 'pysat', "name": 'testing',
                           "sat_id": '10', "clean_level": 'clean'}
+        self.warn_msgs = np.array(
+            ["accessible through `Instrument.meta.labels`",
+             "are no longer standard metadata quantities",
+             "Instrument kwargs `sat_id` has beeen replaced"])
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.in_kwargs
+        del self.in_kwargs, self.warn_msgs
 
-    def test_standard_kwarg_dep(self):
-        """Test deprecation of standard kwarg input
+    def eval_warnings(self):
+        """Routine to evaluate warnings raised when Instrument instantiated
         """
         # Define the deprecated attributes that are always defined
-        warn_msgs = np.array(["accessible through `Instrument.meta.labels`",
-                              "are no longer standard metadata quantities"])
-        found_msgs = np.array([False, False])
+        found_msgs = np.full(shape=self.warn_msgs.shape, fill_value=False)
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
             test_inst = pysat.Instrument(**self.in_kwargs)
 
         # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(warn_msgs)
+        assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         for iwar in war:
             if iwar.category == DeprecationWarning:
-                for i, msg in enumerate(warn_msgs):
+                for i, msg in enumerate(self.warn_msgs):
                     if str(iwar.message).find(msg) >= 0:
                         found_msgs[i] = True
 
         for i, good in enumerate(found_msgs):
-            assert good, "didn't find warning about: {:}".format(warn_msgs[i])
+            assert good, "didn't find warning about: {:}".format(
+                self.warn_msgs[i])
 
+        return
+
+    def test_new_inst_id(self):
+        """Test use of new `inst_id` kwarg."""
+        # Reassign input to use new kwarg
+        self.in_kwargs['inst_id'] = self.in_kwargs['sat_id']
+        del self.in_kwargs['sat_id']
+
+        # Remove associated deprecation warning
+        self.warn_msgs.pop(2)
+
+        # Evaluate warnings
+        self.eval_warnings()
+        return
+
+    def test_standard_kwarg_dep(self):
+        """Test deprecation of standard kwarg input."""
+        # Evaluate warnings
+        self.eval_warnings()
         return


### PR DESCRIPTION
# Description

Deprecated `sat_id` and allowed use of new `inst_id`, addresses #698.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Added unit test

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
