### PR TITLE
Deprecation warning to Constellation kwarg `name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [2.3.0] - 2021-XX-XX
 - Deprecation warnings added to:
-  - Instrument class (old meta labels)
+   - Instrument class (old meta labels)
+   - Constellation class kwarg `name`
    - Custom class
 - Documentation
    - Updated docstrings with deprecation notes

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -11,11 +11,18 @@ class Constellation(object):
     """Manage and analyze data from multiple pysat Instruments.
 
     Created as part of a Spring 2018 UTDesign project.
+
+    .. deprecated:: 2.3.0
+      The `name` kwarg was changed to `const_module` in pysat 3.0.0
+
     """
     def __init__(self, instruments=None, name=None):
         """
         Constructs a Constellation given a list of instruments or the name of
         a file with a pre-defined constellation.
+
+        .. deprecated:: 2.3.0
+          The `name` kwarg was changed to `const_module` in pysat 3.0.0
 
         Parameters
         ----------
@@ -24,13 +31,26 @@ class Constellation(object):
         name : string
             Name of a file in pysat/constellations containing a list of
             instruments.
+        const_module : string or NoneType
+            Name of a pysat constellation module (default=None)
 
         Note
         ----
         The name and instruments parameters should not both be set.
         If neither is given, an empty constellation will be created.
+
         """
 
+        # Raise warnings about deprecated kwargs/attributes
+        if name is None:
+            name = const_module
+        else:
+            dwarn = "".join(["Constellation attribute and kwarg input `name`",
+                             " has been renamed `const_module` in pysat ",
+                             "3.0.0"])
+            warnings.warn(dwarn, DeprecationWarning, stacklevel=2)
+
+        # Start initialization
         if instruments and name:
             raise ValueError('When creating a constellation, please specify '
                              'a list of instruments or a name, not both.')

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -16,7 +16,7 @@ class Constellation(object):
       The `name` kwarg was changed to `const_module` in pysat 3.0.0
 
     """
-    def __init__(self, instruments=None, name=None):
+    def __init__(self, instruments=None, name=None, const_module=None):
         """
         Constructs a Constellation given a list of instruments or the name of
         a file with a pre-defined constellation.

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -332,7 +332,7 @@ class TestDeprecation():
                 # Setting data_labels to None should produce a TypeError after
                 # warning is generated
                 # ==> Save time in unit tests
-                test_const.difference(self.testC[0], self.testC[1],
+                test_const.difference(self.test_const[0], self.test_const[1],
                                       bounds=None, data_labels=None,
                                       cost_function=None)
             except TypeError:

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -332,7 +332,7 @@ class TestDeprecation():
                 # Setting data_labels to None should produce a TypeError after
                 # warning is generated
                 # ==> Save time in unit tests
-                test_const.difference(self.test_const[0], self.test_const[1],
+                test_const.difference(test_const[0], test_const[1],
                                       bounds=None, data_labels=None,
                                       cost_function=None)
             except TypeError:

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -288,18 +288,21 @@ class TestDeprecation():
         """Runs before every method to create a clean testing setup"""
         warnings.simplefilter("always")
 
-        instruments = [pysat.Instrument(platform='pysat', name='testing',
-                                        sat_id='10', clean_level='clean')
-                       for i in range(2)]
-        self.testC = pysat.Constellation(instruments)
+        self.instruments = [pysat.Instrument(platform='pysat', name='testing',
+                                             sat_id='10', clean_level='clean')
+                            for i in range(2)]
+        self.in_kwargs = {"name": 'single_test',
+                          'instruments': self.instruments}
 
     def teardown(self):
         """Runs after every method to clean up previous testing"""
 
-        del self.testC
+        del self.instruments, self.in_kwargs
 
     def test_deprecation_warning_add(self):
         """Test if constellation.add is deprecated"""
+        del self.in_kwargs['name']
+        test_const = pysat.Constellation(**self.in_kwargs)
 
         with warnings.catch_warnings(record=True) as war:
             try:
@@ -308,7 +311,7 @@ class TestDeprecation():
                 # Setting data_label to None should produce a ValueError after
                 # warning is generated
                 # ==> Save time in unit tests
-                self.testC.add(bounds1=None, label1=None, bounds2=None,
+                test_const.add(bounds1=None, label1=None, bounds2=None,
                                label2=None, bin3=None, label3=None,
                                data_label=None)
             except ValueError:
@@ -319,6 +322,8 @@ class TestDeprecation():
 
     def test_deprecation_warning_difference(self):
         """Test if constellation.difference is deprecated"""
+        del self.in_kwargs['name']
+        test_const = pysat.Constellation(**self.in_kwargs)
 
         with warnings.catch_warnings(record=True) as war:
             try:
@@ -327,7 +332,7 @@ class TestDeprecation():
                 # Setting data_labels to None should produce a TypeError after
                 # warning is generated
                 # ==> Save time in unit tests
-                self.testC.difference(self.testC[0], self.testC[1],
+                test_const.difference(self.testC[0], self.testC[1],
                                       bounds=None, data_labels=None,
                                       cost_function=None)
             except TypeError:
@@ -336,22 +341,12 @@ class TestDeprecation():
         assert len(war) >= 1
         assert war[0].category == DeprecationWarning
 
-
-class TestDeprecation():
-    def setup(self):
-        """Runs before every method to create a clean testing setup"""
-        warnings.simplefilter("always")
-        self.in_kwargs = {"name": 'single_test'}
-
-    def teardown(self):
-        """Runs after every method to clean up previous testing."""
-        del self.in_kwargs
-
     def test_name_kwarg_dep(self):
         """Test deprecation of standard kwarg input, `name`
         """
         # Define the deprecated attributes that are always defined
-        warn_msg ="Constellation attribute and kwarg input `name` has been"
+        warn_msg = "Constellation attribute and kwarg input `name` has been"
+        del self.in_kwargs['instruments']
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
@@ -361,7 +356,7 @@ class TestDeprecation():
         assert len(war) >= 1
 
         # Test the warning messages, ensuring each attribute is present
-        assert war[0].category == DeprecationWarning:
+        assert war[0].category == DeprecationWarning
         assert str(war[0].message).find(warn_msg) >= 0
 
         return

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -335,3 +335,33 @@ class TestDeprecation():
 
         assert len(war) >= 1
         assert war[0].category == DeprecationWarning
+
+
+class TestDeprecation():
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always")
+        self.in_kwargs = {"name": 'single_test'}
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.in_kwargs
+
+    def test_name_kwarg_dep(self):
+        """Test deprecation of standard kwarg input, `name`
+        """
+        # Define the deprecated attributes that are always defined
+        warn_msg ="Constellation attribute and kwarg input `name` has been"
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            pysat.Constellation(**self.in_kwargs)
+
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= 1
+
+        # Test the warning messages, ensuring each attribute is present
+        assert war[0].category == DeprecationWarning:
+        assert str(war[0].message).find(warn_msg) >= 0
+
+        return


### PR DESCRIPTION
# Description

Added a deprecation warning for the old Constellation kwarg `name`, which has been replaced with `const_module`. Addresses #680.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Added a unit test for the new deprecation warning

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
