### PR TITLE
Deprecation warning for default Instrument method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.3.0] - 2021-XX-XX
 - Allow use of new Instrument kwarg, `inst_id` (replaces `sat_id`)
 - Deprecation warnings added to:
-   - Instrument class (old meta labels, sat_id)
+   - Instrument class (old meta labels, sat_id, default)
    - Custom class
 - Documentation
    - Updated docstrings with deprecation notes

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -863,12 +863,13 @@ class Instrument(object):
         try:
             self._default_rtn = inst.default
             
-            warnings.warn(''.join(["The Instrument method `default` has been ",
-                                   "renamed `preprocess` in pysat 3.0.0. ",
-                                   "If this is not a pysat-managed Instrument,",
-                                   " you will need to update this when ",
-                                   "migrating to pysat 3.0.0."]),
-                          DeprecationWarning, stacklevel=2)
+            wstr = ''.join(("The Instrument method `default` has been ",
+                            "renamed `preprocess` in pysat 3.0.0. ",
+                            "If this is not a pysat-managed Instrument,",
+                            " you will need to update this when ",
+                            "migrating to pysat 3.0.0."))
+            warnings.simplefilter('always', DeprecationWarning)
+            warnings.warn(wstr, DeprecationWarning, stacklevel=2)
         except AttributeError:
             pass
         try:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -862,6 +862,13 @@ class Instrument(object):
                                             '{:s}every instrument.'.format(estr))))
         try:
             self._default_rtn = inst.default
+            
+            warnings.warn(''.join(["The Instrument method `default` has been ",
+                                   "renamed `preprocess` in pysat 3.0.0. ",
+                                   "If this is not a pysat-managed Instrument,",
+                                   " you will need to update this when ",
+                                   "migrating to pysat 3.0.0."]),
+                          DeprecationWarning, stacklevel=2)
         except AttributeError:
             pass
         try:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -32,9 +32,9 @@ class Instrument(object):
     """Download, load, manage, modify and analyze science data.
 
     .. deprecated:: 2.3.0
-      Several attributes will be removed or replaced in pysat 3.0.0:
-      sat_id, units_label, name_label, notes_label, desc_label, min_label,
-      max_label, fill_label, plot_label, axis_label, scale_label
+      Several attributes and methods will be removed or replaced in pysat 3.0.0:
+      sat_id, default, units_label, name_label, notes_label, desc_label,
+      min_label, max_label, fill_label, plot_label, axis_label, and scale_label
 
     Parameters
     ----------

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1374,7 +1374,7 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
 class TestDeprecation():
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", DeprecationWarning)
         self.in_kwargs = {"platform": 'pysat', "name": 'testing', "tag": '',
                           "sat_id": '', "clean_level": 'clean'}
         self.warn_msgs = np.array(

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1380,7 +1380,8 @@ class TestDeprecation():
         self.warn_msgs = np.array(
             ["accessible through `Instrument.meta.labels`",
              "are no longer standard metadata quantities",
-             "Instrument kwarg `sat_id` has been replaced"])
+             "Instrument kwarg `sat_id` has been replaced",
+             "Instrument method `default` has been renamed `preprocess`"])
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""


### PR DESCRIPTION
# Description

Added a deprecation warning for Instruments that have a `default` method.  Addresses #684.

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?
Added a unit test

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
