### PR TITLE
Deprecation warning for functions in `Files` class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Instrument class (old meta labels, sat_id)
    - Constellation class kwarg `name`
    - Custom class
+   - functions from `_files` class
 - Documentation
    - Updated docstrings with deprecation notes
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -12,7 +12,7 @@ import weakref
 
 import pandas as pds
 
-from pysat import data_dir as data_dir
+from pysat import data_dir
 from pysat import logger
 from pysat.utils.time import create_datetime_index
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -1,16 +1,20 @@
 from __future__ import print_function
 from __future__ import absolute_import
 
-import string
-import os
-import weakref
-import re
+import collections
 import glob
 import numpy as np
-import pandas as pds
-from pysat import data_dir as data_dir
+import os
+import re
+import string
+import warnings
+import weakref
 
+import pandas as pds
+
+from pysat import data_dir as data_dir
 from pysat import logger
+from pysat.utils.time import create_datetime_index
 
 
 class Files(object):
@@ -579,7 +583,6 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 
     """
 
-    from pysat.utils.time import create_datetime_index
 
     search_dict = construct_searchstring_from_format(stored['format_str'])
     keys = search_dict['keys']
@@ -675,7 +678,6 @@ def parse_fixed_width_filenames(files, format_str):
 
     """
 
-    import collections
 
     # create storage for data to be parsed from filenames
     stored = collections.OrderedDict()
@@ -758,7 +760,6 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
     """
 
-    import collections
 
     # create storage for data to be parsed from filenames
     ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -559,6 +559,10 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
     """Accepts dict with data parsed from filenames and creates
     a pandas Series object formatted for the Files class.
 
+    .. deprecated:: 2.3.0
+      `_files.process_parsed_filenames` will be removed in pysat 3.0.0, it will
+      be moved to `pysat.utils.files.process_parsed_filenames`
+
     Parameters
     ----------
     stored : orderedDict
@@ -583,6 +587,11 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 
     """
 
+    warnings.warn(' '.join(["_files.process_parsed_filenames is deprecated and",
+                            "will be moved to",
+                            "pysat.utils.files.process_parsed_filenames",
+                            "in pysat 3.0.0."]),
+                  DeprecationWarning, stacklevel=2)
 
     search_dict = construct_searchstring_from_format(stored['format_str'])
     keys = search_dict['keys']
@@ -657,6 +666,10 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 def parse_fixed_width_filenames(files, format_str):
     """Parses list of files, extracting data identified by format_str
 
+    .. deprecated:: 2.3.0
+      `_files.parse_fixed_width_filenames` will be removed in pysat 3.0.0, it
+      will be moved to `pysat.utils.files.parse_fixed_width_filenames`
+
     Parameters
     ----------
     files : list
@@ -678,6 +691,11 @@ def parse_fixed_width_filenames(files, format_str):
 
     """
 
+    warnings.warn(' '.join(["_files.parse_fixed_width_filenames is deprecated",
+                            "and will be moved to",
+                            "pysat.utils.files.parse_fixed_width_filenames",
+                            "in pysat 3.0.0."]),
+                  DeprecationWarning, stacklevel=2)
 
     # create storage for data to be parsed from filenames
     stored = collections.OrderedDict()
@@ -738,6 +756,10 @@ def parse_fixed_width_filenames(files, format_str):
 def parse_delimited_filenames(files, format_str, delimiter):
     """Parses list of files, extracting data identified by format_str
 
+    .. deprecated:: 2.3.0
+      `_files.parse_delimited_filenames` will be removed in pysat 3.0.0, it
+      will be moved to `pysat.utils.files.parse_delimited_filenames`
+
     Parameters
     ----------
     files : list
@@ -760,6 +782,11 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
     """
 
+    warnings.warn(' '.join(["_files.parse_delimited_filenames is deprecated",
+                            "and will be moved to",
+                            "pysat.utils.files.parse_delimited_filenames",
+                            "in pysat 3.0.0."]),
+                  DeprecationWarning, stacklevel=2)
 
     # create storage for data to be parsed from filenames
     ordered_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',
@@ -826,6 +853,11 @@ def construct_searchstring_from_format(format_str, wildcard=False):
     """
     Parses format file string and returns string formatted for searching.
 
+    .. deprecated:: 2.3.0
+      `_files.construct_searchstring_from_format` will be removed in
+      pysat 3.0.0, it will be moved to
+      `pysat.utils.files.construct_searchstring_from_format`
+
     Parameters
     ----------
     format_str : string with python format codes
@@ -858,6 +890,12 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v??.cdf'
 
     """
+
+    warnings.warn(' '.join(["_files.construct_searchstring_from_format is",
+                            "deprecated and will be moved to",
+                            "pysat.utils.files.construct_searchstring_from_format",
+                            "in pysat 3.0.0."]),
+                  DeprecationWarning, stacklevel=2)
 
     if format_str is None:
         raise ValueError("Must supply a filename template (format_str).")
@@ -908,6 +946,11 @@ def search_local_system_formatted_filename(data_path, search_str):
     """
     Parses format file string and returns string formatted for searching.
 
+    .. deprecated:: 2.3.0
+      `_files.search_local_system_formatted_filename` will be removed in
+      pysat 3.0.0, it will be moved to
+      `pysat.utils.files.search_local_system_formatted_filename`
+
     Parameters
     ----------
     data_path : string
@@ -931,6 +974,12 @@ def search_local_system_formatted_filename(data_path, search_str):
     false positive rate.
 
     """
+
+    warnings.warn(' '.join(["_files.search_local_system_formatted_filename is",
+                            "deprecated and will be moved to",
+                            "pysat.utils.files.search_local_system_formatted_filename",
+                            "in pysat 3.0.0."]),
+                  DeprecationWarning, stacklevel=2)
 
     # perform local file search
     abs_search_str = os.path.join(data_path, search_str)

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -5,6 +5,7 @@ import glob
 import numpy as np
 import os
 import sys
+import warnings
 
 from nose.tools import raises
 import pandas as pds
@@ -982,3 +983,56 @@ class TestInstrumentWithVersionedFiles():
 class TestInstrumentWithVersionedFilesNoFileListStorage(TestInstrumentWithVersionedFiles):
 
     temporary_file_list = True
+
+
+class TestDeprecation():
+
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always", DeprecationWarning)
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
+
+    def test_deprecation_warning_process_parsed_filenames(self):
+        """Test if _files.process_parsed_filenames is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            try:
+                pysat._files.process_parsed_filenames({})
+            except KeyError:
+                # Inputting empty dict will produce KeyError
+                pass
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_parse_fixed_width_filenames(self):
+        """Test if _files.parse_fixed_width_filenames is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.parse_fixed_width_filenames([], '')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_parse_delimited_filenames(self):
+        """Test if _files.parse_delimited_filenames is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.parse_delimited_filenames([], '', '')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
+
+    def test_deprecation_warning_construct_searchstring_from_format(self):
+        """Test if _files.construct_searchstring_from_format is deprecated"""
+
+        with warnings.catch_warnings(record=True) as war:
+            # Empty input produces empty output
+            pysat._files.construct_searchstring_from_format('')
+
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning


### PR DESCRIPTION
# Description

Addresses #700

The functions under `Files` that do not operate on the class have been moved to `utils.files`.  This updates the warnings and docstrings with info for users to warn them of this change.

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?

Added unit tests for these functions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
