### PR TITLE
Deprecation warning improvement

### DIFF
--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -110,20 +110,6 @@ class TestBasics():
         coords.calc_solar_local_time(self.testInst, lon_name="not longitude",
                                      slt_name='slt')
 
-    def test_deprecation_warning_scale_units(self):
-        """Test deprecation warning for this function"""
-
-        import warnings
-
-        warnings.simplefilter("always")
-        scale1 = pysat.utils.scale_units("happy", "happy")
-        with warnings.catch_warnings(record=True) as war:
-            scale2 = coords.scale_units("happy", "happy")
-
-        assert scale1 == scale2
-        assert len(war) == 1
-        assert war[0].category == DeprecationWarning
-
     ###################################
     # Geodetic / Geocentric conversions
 
@@ -456,10 +442,21 @@ class TestDeprecation():
 
     def setup(self):
         """Runs before every method to create a clean testing setup"""
-        warnings.simplefilter("always")
+        warnings.simplefilter("always", DeprecationWarning)
 
     def teardown(self):
         """Runs after every method to clean up previous testing"""
+
+    def test_deprecation_warning_scale_units(self):
+        """Test deprecation warning for scale_units"""
+
+        scale1 = pysat.utils.scale_units("happy", "happy")
+        with warnings.catch_warnings(record=True) as war:
+            scale2 = coords.scale_units("happy", "happy")
+
+        assert scale1 == scale2
+        assert len(war) >= 1
+        assert war[0].category == DeprecationWarning
 
     def test_deprecation_warning_geodetic_to_geocentric(self):
         """Test if geodetic_to_geocentric in coords is deprecated"""

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -177,7 +177,7 @@ class TestDeprecation():
     def teardown(self):
         """Runs after every method to clean up previous testing"""
 
-    def test_deprecated_season_date_range():
+    def test_deprecated_season_date_range(self):
         """Tests that deprecation of season_date_range is working"""
 
         start = pds.datetime(2012, 2, 28)

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -2,6 +2,7 @@
 tests the pysat utils.time area
 """
 import numpy as np
+import warnings
 
 from nose.tools import raises
 import pandas as pds
@@ -167,21 +168,27 @@ def test_create_datetime_index_wo_month_day_uts():
     assert len(dates) == 4
 
 
-def test_deprecated_season_date_range():
-    """Tests that deprecation of season_date_range is working"""
+class TestDeprecation():
 
-    import warnings
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.simplefilter("always", DeprecationWarning)
 
-    start = pds.datetime(2012, 2, 28)
-    stop = pds.datetime(2012, 3, 1)
-    warnings.simplefilter("always")
-    with warnings.catch_warnings(record=True) as war1:
-        season1 = pytime.create_date_range(start, stop, freq='D')
-    with warnings.catch_warnings(record=True) as war2:
-        season2 = pytime.season_date_range(start, stop, freq='D')
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
 
-    assert len(season1) == len(season2)
-    assert (season1 == season2).all()
-    assert len(war1) == 0
-    assert len(war2) == 1
-    assert war2[0].category == DeprecationWarning
+    def test_deprecated_season_date_range():
+        """Tests that deprecation of season_date_range is working"""
+
+        start = pds.datetime(2012, 2, 28)
+        stop = pds.datetime(2012, 3, 1)
+        with warnings.catch_warnings(record=True) as war1:
+            season1 = pytime.create_date_range(start, stop, freq='D')
+        with warnings.catch_warnings(record=True) as war2:
+            season2 = pytime.season_date_range(start, stop, freq='D')
+
+        assert len(season1) == len(season2)
+        assert (season1 == season2).all()
+        assert len(war1) == 0
+        assert len(war2) == 1
+        assert war2[0].category == DeprecationWarning

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -135,12 +135,31 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
 
 
 def scale_units(out_unit, in_unit):
-    """Deprecated function, moved to pysat.utils._core"""
+    """ Determine the scaling factor between two units
+
+    .. deprecated:: 2.2.0
+      `utils.coords.scale_units` will be removed in pysat 3.0.0, it will be
+      moved to `utils.scale_units`
+
+    Parameters
+    -------------
+    out_unit : str
+        Desired unit after scaling
+    in_unit : str
+        Unit to be scaled
+
+    Returns
+    -----------
+    unit_scale : float
+        Scaling factor that will convert from in_units to out_units
+
+    """
 
     import warnings
     from pysat import utils
 
-    warnings.warn(' '.join(["utils.coords.scale_units is deprecated, use",
+    warnings.warn(' '.join(["utils.coords.scale_units is deprecated and will",
+                            "be removed in pysat 3.0.0, use",
                             "pysat.utils.scale_units instead"]),
                   DeprecationWarning, stacklevel=2)
     unit_scale = utils.scale_units(out_unit, in_unit)

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -9,6 +9,8 @@ seasons, and calculation of solar local time
 
 import numpy as np
 import pandas as pds
+import warnings
+
 from pysat import datetime
 
 
@@ -136,9 +138,8 @@ def season_date_range(start, stop, freq='D'):
 
     """
 
-    import warnings
-
-    warnings.warn(' '.join(["utils.time.season_date_range is deprecated, use",
+    warnings.warn(' '.join(["utils.time.season_date_range is deprecated and",
+                            "be removed in pysat 3.0.0, use",
                             "utils.time.create_date_range instead"]),
                   DeprecationWarning, stacklevel=2)
 


### PR DESCRIPTION
# Description

Addresses #692 and #693

Updates message content, docstrings, and test standards for deprecation warnings in `utils.time` and `utils.coords`.

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

Existing unit tests, but standardized

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes (part of previous note about improving deprecation docstrings)
