### PR TITLE
Deprecation warnings for Instrument kwargs removed in pysat 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.3.0] - 2021-XX-XX
 - Allow use of new Instrument kwarg, `inst_id` (replaces `sat_id`)
 - Deprecation warnings added to:
-   - Instrument class (old meta labels, sat_id, default)
+   - Instrument class (old meta labels, sat_id, default, multi_file_day,
+     and manual_org)
    - Constellation class kwarg `name`
    - Custom class
 - Documentation

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -33,8 +33,9 @@ class Instrument(object):
 
     .. deprecated:: 2.3.0
       Several attributes and methods will be removed or replaced in pysat 3.0.0:
-      sat_id, default, units_label, name_label, notes_label, desc_label,
-      min_label, max_label, fill_label, plot_label, axis_label, and scale_label
+      sat_id, default, multi_file_day, manual_org, units_label, name_label,
+      notes_label, desc_label, min_label, max_label, fill_label, plot_label,
+      axis_label, and scale_label
 
     Parameters
     ----------
@@ -72,10 +73,12 @@ class Instrument(object):
     multi_file_day : boolean, optional
         Set to True if Instrument data files for a day are spread across
         multiple files and data for day n could be found in a file
-        with a timestamp of day n-1 or n+1.
+        with a timestamp of day n-1 or n+1.  Deprecated at this level in
+        pysat 3.0.0.
     manual_org : bool
         if True, then pysat will look directly in pysat data directory
-        for data files and will not use default /platform/name/tag
+        for data files and will not use default /platform/name/tag. Deprecated
+        in pysat 3.0.0, as this flag is not needed to use `directory_format`.
     directory_format : str
         directory naming structure in string format. Variables such as
         platform, name, and tag will be filled in as needed using python
@@ -216,11 +219,21 @@ class Instrument(object):
             dwarns.append("".join(["Instrument kwarg `sat_id` has been ",
                                    "replaced with `inst_id` in pysat 3.0.0"]))
 
+        if multi_file_day is not None:
+            dwarns.append("".join(["Instrument kwarg `multi_file_day` has been",
+                                   " deprecated in pysat 3.0.0 and will only",
+                                   " be allowed to be specified inside ",
+                                   "Instrument sub-modules."]))
+
+        if manual_org is not None:
+            dwarns.append("".join(["Instrument kwarg `manual_org` has been ",
+                                   "deprecated in pysat 3.0.0, use only the ",
+                                   "`directory_format` kwarg instead."]))
+
         for dwarn in dwarns:
             warnings.warn(dwarn, DeprecationWarning, stacklevel=2)
 
         # Start initialization
-
         if inst_module is None:
             # use strings to look up module name
             if isinstance(platform, str) and isinstance(name, str):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1385,7 +1385,7 @@ class TestDeprecation():
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.in_args, self.in_kwargs, self.warn_msgs
+        del self.in_kwargs, self.warn_msgs
 
     def eval_warnings(self):
         """Routine to evaluate warnings raised when Instrument instantiated

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1385,7 +1385,7 @@ class TestDeprecation():
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.in_kwargs, self.warn_msgs
+        del self.in_args, self.in_kwargs, self.warn_msgs
 
     def eval_warnings(self):
         """Routine to evaluate warnings raised when Instrument instantiated
@@ -1422,6 +1422,20 @@ class TestDeprecation():
         # Remove associated deprecation warning
         new_msgs = list(self.warn_msgs)
         new_msgs.pop(2)
+        self.warn_msgs = np.array(new_msgs)
+
+        # Evaluate warnings
+        self.eval_warnings()
+        return
+
+    def test_extra_kwarg_dep(self):
+        """Test deprecation of optional kwarg input."""
+        self.in_kwargs['multi_file_day'] = False
+        self.in_kwargs['manual_org'] = False
+        new_msgs = list(self.warn_msgs)
+        new_msgs.extend([
+            "Instrument kwarg `multi_file_day` has been deprecated",
+            "Instrument kwarg `manual_org` has been deprecated"])
         self.warn_msgs = np.array(new_msgs)
 
         # Evaluate warnings


### PR DESCRIPTION
# Description

Added deprecation warnings for Instrument kwargs removed in pysat 3.0. Addresses #678.

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

Added a new unit test.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
