### PR TITLE
BUG: SLT calculation with xarray instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed weak reference back to Instrument within Files class
   - Fixed access of xarray data with more than one dimension (#471)
   - Improved robustness of eval(inst.__repr__()) (#636)
+  - Fixed `calc_solar_local_time` for data sets with longitude coordinates
 - Maintenance
   - nose dependency removed from unit tests
   - Specified `dtype` for empty pandas.Series for forward compatibility

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -109,7 +109,7 @@ class TestLonSLT():
         assert (abs(self.py_inst['slt'] - self.py_inst['slt2'])).max() < 1.0e-6
 
     def test_bad_lon_name_calc_solar_local_time(self):
-        """Test calc_solar_local_time with a bad longitude name"""
+        """Test calc_solar_local_time with a bad longitude name."""
 
         self.py_inst = pysat.Instrument(platform='pysat', name="testing")
         self.py_inst.load(date=self.inst_time)
@@ -118,3 +118,14 @@ class TestLonSLT():
             coords.calc_solar_local_time(self.py_inst,
                                          lon_name="not longitude",
                                          slt_name='slt')
+
+    def test_lon_broadcasting_calc_solar_local_time(self):
+        """Test calc_solar_local_time with longitude coordinates."""
+
+        self.py_inst = pysat.Instrument(platform='pysat', name="testmodel")
+        self.py_inst.load(date=self.inst_time)
+        coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
+                                     slt_name='slt')
+
+        assert self.py_inst['slt'].max() < 24.0
+        assert self.py_inst['slt'].min() >= 0.0

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -140,7 +140,7 @@ class TestLonSLT():
         # Create a second longitude with a single value
         self.py_inst.data = self.py_inst.data.update({lon_name: (lon_name,
                                                                  [10.0])})
-        py_inst.data = py_inst.data.squeeze(dim=lon_name)
+        self.py_inst.data = self.py_inst.data.squeeze(dim=lon_name)
 
         # Calculate and test the SLT
         coords.calc_solar_local_time(self.py_inst, lon_name=lon_name,

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -129,3 +129,23 @@ class TestLonSLT():
 
         assert self.py_inst['slt'].max() < 24.0
         assert self.py_inst['slt'].min() >= 0.0
+
+    def test_single_lon_calc_solar_local_time(self):
+        """Test calc_solar_local_time with a single longitude value."""
+
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing_xarray")
+        self.py_inst.load(date=self.inst_time)
+        lon_name = 'lon2'
+
+        # Create a second longitude with a single value
+        self.py_inst.data = self.py_inst.data.update({lon_name: (lon_name,
+                                                                 [10.0])})
+        py_inst.data = py_inst.data.squeeze(dim=lon_name)
+
+        # Calculate and test the SLT
+        coords.calc_solar_local_time(self.py_inst, lon_name=lon_name,
+                                     slt_name='slt')
+
+        assert self.py_inst['slt'].max() < 24.0
+        assert self.py_inst['slt'].min() >= 0.0
+        assert self.py_inst['slt'].shape == self.py_inst.index.shape

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -113,8 +113,13 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
 
     # Calculate solar local time
     if inst[lon_name].shape == ut_hr.shape or inst[lon_name].shape == ():
-        slt = ut_hr + inst[lon_name] / 15.0
-        coords = inst.data.index
+        if inst[lon_name].shape == ():
+            lon = float(inst[lon_name])
+        else:
+            lon = inst[lon_name]
+
+        slt = ut_hr + lon / 15.0
+        coords = inst.index.name
     else:
         # Initalize the new shape and coordinates
         sshape = list(ut_hr.shape)
@@ -134,7 +139,7 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt'):
 
     # Add the solar local time to the instrument
     if inst.pandas_format:
-        inst[slt_name] = pds.Series(slt, index=coords)
+        inst[slt_name] = pds.Series(slt, index=inst.index)
     else:
         inst.data = inst.data.assign({slt_name: (coords, slt)})
 


### PR DESCRIPTION
# Description

Fixes an error with the SLT calculation method, which only worked for pandas or xarray data that only has coordinates in the time dimension.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Created new unit tests, and ran in a local (complicated) function that originally revealed this error.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: 3.7
* Any details about your local setup that are relevant

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
