### PR TITLE
Deprecated Madrigal instruments and methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Instrument class (old meta labels, sat_id, default)
    - Constellation class kwarg `name`
    - Custom class
-   - functions from `_files` class
+  - functions from `_files` class
+  - Instrument modules:
+    - the pysatMadrigal: jro_isr, dmsp_ivm
+  - Madrigal instrument methods
 - Documentation
    - Updated docstrings with deprecation notes
 

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -258,7 +258,7 @@ def smooth_ram_drifts(inst, rpa_flag_key=None, rpa_vel_key='ion_v_sat_for'):
 
     """
 
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.dmsp.",
                            "smooth_ram_drifts` instead: ",
@@ -293,7 +293,7 @@ def update_DMSP_ephemeris(inst, ephem=None):
 
     """
 
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.dmsp.",
                            "update_DMSP_ephemeris` instead: ",
@@ -348,7 +348,7 @@ def add_drift_unit_vectors(inst):
 
     """
 
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.dmsp.",
                            "add_drift_unit_vectors` instead: ",
@@ -419,7 +419,7 @@ def add_drifts_polar_cap_x_y(inst, rpa_flag_key=None,
     velocities
     """
 
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.dmsp.",
                            "add_drifts_polar_cap_x_y` instead: ",

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -16,6 +16,10 @@ The routine is configured to utilize data files with instrument
 performance flags generated at the Center for Space Sciences at the
 University of Texas at Dallas.
 
+.. deprecated:: 2.3.0
+  This Instrument module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatMadrigal (https://github.com/pysat/pysatMadrigal)
+
 Properties
 ----------
 platform
@@ -132,6 +136,12 @@ def init(self):
 
     """
 
+    warnings.warn("".join(["dmsp_ivm has been removed from the pysat-managed ",
+                           "Instruments in pysat 3.0.0, and now resides in ",
+                           "pysatMadrigal ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
+
     logger.info(mad_meth.cedar_rules())
     self.acknowledgements = "".join(("See 'self.Experiment_Notes' for ",
                                      "instrument specific acknowledgements\n",
@@ -229,6 +239,10 @@ def clean(inst):
 def smooth_ram_drifts(inst, rpa_flag_key=None, rpa_vel_key='ion_v_sat_for'):
     """ Smooth the ram drifts using a rolling mean
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.dmsp.smooth_ram_drifts`
+
     Parameters
     -----------
     rpa_flag_key : string or NoneType
@@ -243,6 +257,13 @@ def smooth_ram_drifts(inst, rpa_flag_key=None, rpa_vel_key='ion_v_sat_for'):
 
     """
 
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.dmsp.",
+                           "smooth_ram_drifts` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
+
     if rpa_flag_key in list(inst.data.keys()):
         rpa_idx, = np.where(inst[rpa_flag_key] == 1)
     else:
@@ -256,6 +277,10 @@ def smooth_ram_drifts(inst, rpa_flag_key=None, rpa_vel_key='ion_v_sat_for'):
 def update_DMSP_ephemeris(inst, ephem=None):
     """Updates DMSP instrument data with DMSP ephemeris
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.dmsp.update_DMSP_ephemeris`
+
     Parameters
     ----------
     ephem : pysat.Instrument or NoneType
@@ -266,6 +291,13 @@ def update_DMSP_ephemeris(inst, ephem=None):
     Updates 'mlt' and 'mlat'
 
     """
+
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.dmsp.",
+                           "update_DMSP_ephemeris` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Ensure the right ephemera is loaded
     if ephem is None:
@@ -298,6 +330,10 @@ def update_DMSP_ephemeris(inst, ephem=None):
 def add_drift_unit_vectors(inst):
     """ Add unit vectors for the satellite velocity
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.dmsp.add_drift_unit_vectors`
+
     Returns
     ---------
     Adds unit vectors in cartesian and polar coordinates for RAM and
@@ -310,6 +346,14 @@ def add_drift_unit_vectors(inst):
     Assumes that the RAM vector is pointed perfectly forward
 
     """
+
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.dmsp.",
+                           "add_drift_unit_vectors` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
+
     # Calculate theta and R in radians from MLT and MLat, respectively
     theta = inst['mlt'] * (np.pi / 12.0) - np.pi * 0.5
     r = np.radians(90.0 - inst['mlat'].abs())
@@ -349,6 +393,10 @@ def add_drifts_polar_cap_x_y(inst, rpa_flag_key=None,
                              cross_vel_key='ion_v_sat_left'):
     """ Add polar cap drifts in cartesian coordinates
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.dmsp.add_drifts_polar_cap_x_y`
+
     Parameters
     ------------
     rpa_flag_key : string or NoneType
@@ -369,6 +417,13 @@ def add_drifts_polar_cap_x_y(inst, rpa_flag_key=None,
     Polar cap drifts assume there is no vertical component to the X-Y
     velocities
     """
+
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.dmsp.",
+                           "add_drifts_polar_cap_x_y` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Get the good RPA data, if available
     if rpa_flag_key in list(inst.data.keys()):

--- a/pysat/instruments/dmsp_ivm.py
+++ b/pysat/instruments/dmsp_ivm.py
@@ -66,6 +66,7 @@ from __future__ import absolute_import
 import functools
 import numpy as np
 import pandas as pds
+import warnings
 
 import pysat
 from pysat.instruments.methods import madrigal as mad_meth

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -8,6 +8,10 @@ experiments.
 
 Downloads data from the JRO Madrigal Database.
 
+.. deprecated:: 2.3.0
+  This Instrument module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatMadrigal (https://github.com/pysat/pysatMadrigal)
+
 Properties
 ----------
 platform
@@ -37,6 +41,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import functools
 import numpy as np
+import warnings
 
 import pysat
 from pysat.instruments.methods import madrigal as mad_meth
@@ -112,6 +117,12 @@ def init(self):
         This object
 
     """
+
+    warnings.warn("".join(["jro_isr has been removed from the pysat-managed ",
+                           "Instruments in pysat 3.0.0, and now resides in ",
+                           "pysatMadrigal: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     logger.info("The Jicamarca Radio Observatory is operated by the Instituto " +
           "Geofisico del Peru, Ministry of Education, with support from the" +
@@ -210,6 +221,10 @@ def clean(self):
 def calc_measurement_loc(self):
     """ Calculate the instrument measurement location in geographic coordinates
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.jro.calc_measurement_loc`
+
     Returns
     -------
     Void : adds 'gdlat#', 'gdlon#' to the instrument, for all directions that
@@ -218,6 +233,13 @@ def calc_measurement_loc(self):
     """
 
     from pysat.utils import coords
+
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.jro.",
+                           "calc_measurement_loc` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     az_keys = [kk[5:] for kk in list(self.data.keys())
                if kk.find('azdir') == 0]

--- a/pysat/instruments/jro_isr.py
+++ b/pysat/instruments/jro_isr.py
@@ -234,7 +234,7 @@ def calc_measurement_loc(self):
 
     from pysat.utils import coords
 
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.jro.",
                            "calc_measurement_loc` instead: ",

--- a/pysat/instruments/methods/madrigal.py
+++ b/pysat/instruments/methods/madrigal.py
@@ -40,7 +40,7 @@ def cedar_rules():
         String with general acknowledgement for all CEDAR Madrigal data
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "cedar_rules` instead: ",
@@ -95,7 +95,7 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
         inst.load(2010,18)
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "load` instead: ",
@@ -254,7 +254,7 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
     downloads.
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "download` instead: ",
@@ -357,7 +357,7 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
 
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "get_remote_filenames` instead: ",
@@ -441,7 +441,7 @@ def good_exp(exp, date_array=None):
         True if good, False if bad
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "good_exp` instead: ",
@@ -540,7 +540,7 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
                                               inst_code=madrigal_inst_code)
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "list_remote_files` instead: ",
@@ -627,7 +627,7 @@ def filter_data_single_date(self):
     at the top level
 
     """
-    warnings.warn("".join(["This funciton is deprecated here and will be ",
+    warnings.warn("".join(["This function is deprecated here and will be ",
                            "removed in pysat 3.0.0. Please use ",
                            "`pysatMadrigal.instruments.methods.madrigal`",
                            "filter_data_single_date` instead: ",

--- a/pysat/instruments/methods/madrigal.py
+++ b/pysat/instruments/methods/madrigal.py
@@ -2,6 +2,10 @@
 """Provides default routines for integrating CEDAR Madrigal instruments into
 pysat, reducing the amount of user intervention.
 
+.. deprecated:: 2.3.0
+  This module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatMadrigal (https://github.com/pysat/pysatMadrigal)
+
  """
 
 from __future__ import absolute_import
@@ -14,6 +18,7 @@ import os
 import pandas as pds
 import subprocess
 import sys
+import warnings
 
 import h5py
 from madrigalWeb import madrigalWeb
@@ -25,12 +30,23 @@ logger = logging.getLogger(__name__)
 def cedar_rules():
     """ General acknowledgement statement for Madrigal data.
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
+
     Returns
     -------
     ackn : string
         String with general acknowledgement for all CEDAR Madrigal data
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "cedar_rules` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
+
     ackn = "Contact the PI when using this data, in accordance with the CEDAR"
     ackn += " 'Rules of the Road'"
     return ackn
@@ -39,6 +55,10 @@ def cedar_rules():
 # support load routine
 def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
     """Loads data from Madrigal into Pandas.
+
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.
@@ -75,6 +95,12 @@ def load(fnames, tag=None, sat_id=None, xarray_coords=[]):
         inst.load(2010,18)
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "load` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Ensure 'time' wasn't included as a coordinate, since it is the default
     if 'time' in xarray_coords:
@@ -181,6 +207,10 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
              file_format='hdf5'):
     """Downloads data from Madrigal.
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
+
     Parameters
     ----------
     date_array : array-like
@@ -224,6 +254,12 @@ def download(date_array, inst_code=None, kindat=None, data_path=None,
     downloads.
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "download` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     if inst_code is None:
         raise ValueError("Must supply Madrigal instrument code")
@@ -269,6 +305,10 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
                          date_array=None):
     """Retrieve the remote filenames for a specified Madrigal instrument
     (and experiment)
+
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
 
     Parameters
     ----------
@@ -317,6 +357,12 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
 
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "get_remote_filenames` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     if inst_code is None:
         raise ValueError("Must supply Madrigal instrument code")
@@ -377,6 +423,10 @@ def get_remote_filenames(inst_code=None, kindat=None, user=None,
 def good_exp(exp, date_array=None):
     """ Determine if a Madrigal experiment has good data for specified dates
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
+
     Parameters
     ----------
     exp : MadrigalExperimentFile
@@ -391,6 +441,12 @@ def good_exp(exp, date_array=None):
         True if good, False if bad
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "good_exp` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     gflag = False
 
@@ -416,6 +472,10 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
                       two_digit_year_break=None, start=dt.datetime(1900,1,1),
                       stop=dt.datetime.now()):
     """List files available from Madrigal.
+
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
 
     Parameters
     ----------
@@ -480,6 +540,13 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
                                               inst_code=madrigal_inst_code)
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "list_remote_files` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
+
     if inst_code is None:
         raise ValueError("Must supply Madrigal instrument code")
 
@@ -516,6 +583,10 @@ def list_remote_files(tag, sat_id, inst_code=None, kindat=None, user=None,
 
 def filter_data_single_date(self):
     """Filters data to a single date.
+
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatMadrigal.instruments.methods.madrigal`
 
     Parameters
     ----------
@@ -556,6 +627,12 @@ def filter_data_single_date(self):
     at the top level
 
     """
+    warnings.warn("".join(["This funciton is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatMadrigal.instruments.methods.madrigal`",
+                           "filter_data_single_date` instead: ",
+                           "https://github.com/pysat/pysatMadrigal"]),
+                  DeprecationWarning, stacklevel=2)
 
     # only do this if loading by date!
     if self._load_by_date and self.pad is None:

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -149,6 +149,7 @@ class TestInstrumentQualifier():
 
     def check_init_warning(self, module, name, tag, sat_id):
         """Check for the existance of a deprecation warning."""
+        global dep_list
         if name not in dep_list:
             warnings.warn('{:} has not yet been deprecated'.format(module))
         else:


### PR DESCRIPTION
# Description

Added deprecation warnings to Madrigal instruments, routines, and methods.  Partially addresses #697 

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

Added a unit test for presence of a deprecation warning in an instrument module.  Did not add deprecation warnings for untested routines or methods.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
