### PR TITLE
Dep2 spaceweather

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - functions from `_files` class
   - Instrument modules:
     - the pysatMadrigal: jro_isr, dmsp_ivm
-  - Madrigal instrument methods
+    - the pysatSpaceWeather: sw_dst, sw_f107, sw_kp
+  - SpaceWeather and Madrigal instrument methods
 - Documentation
    - Updated docstrings with deprecation notes
 

--- a/pysat/instruments/methods/sw.py
+++ b/pysat/instruments/methods/sw.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-.
 """Provides default routines for solar wind and geospace indices
 
+.. deprecated:: 2.3.0
+  This Instrument module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatSpaceWeather
+  (https://github.com/pysat/pysatSpaceWeather)
+
 """
 
 from __future__ import print_function
@@ -8,12 +13,18 @@ from __future__ import absolute_import
 
 import pandas as pds
 import numpy as np
+import warnings
+
 import pysat
 
 
 def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
                start=None, stop=None, fill_val=np.nan):
     """ Combine the output from the different Kp sources for a range of dates
+
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with `pysatSpaceWeather.instruments.methods.kp_ap.combine_kp`
 
     Parameters
     ----------
@@ -51,6 +62,14 @@ def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
     Will not attempt to download any missing data, but will load data
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.kp_ap.",
+                           "combine_kp` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
+
     notes = "Combines data from"
 
     # Create an ordered list of the Instruments, excluding any that are None
@@ -241,6 +260,10 @@ def combine_kp(standard_inst=None, recent_inst=None, forecast_inst=None,
 def combine_f107(standard_inst, forecast_inst, start=None, stop=None):
     """ Combine the output from the measured and forecasted F10.7 sources
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with `pysatSpaceWeather.instruments.methods.f107.combine_f107`
+
     Parameters
     ----------
     standard_inst : (pysat.Instrument or NoneType)
@@ -271,6 +294,14 @@ def combine_f107(standard_inst, forecast_inst, start=None, stop=None):
     Will not attempt to download any missing data, but will load data
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.f107.",
+                           "combine_f107` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
+
     # Initialize metadata and flags
     notes = "Combines data from"
     stag = standard_inst.tag if len(standard_inst.tag) > 0 else 'default'
@@ -437,6 +468,10 @@ def calc_daily_Ap(ap_inst, ap_name='3hr_ap', daily_name='Ap',
                   running_name=None):
     """ Calculate the daily Ap index from the 3hr ap index
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with `pysatSpaceWeather.instruments.methods.kp_ap.calc_daily_Ap`
+
     Parameters
     ----------
     ap_inst : (pysat.Instrument)
@@ -461,6 +496,13 @@ def calc_daily_Ap(ap_inst, ap_name='3hr_ap', daily_name='Ap',
     by MSIS when running with sub-daily geophysical inputs
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.kp_ap.",
+                           "calc_daily_Ap` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Test that the necessary data is available
     if ap_name not in ap_inst.data.columns:
@@ -528,6 +570,10 @@ def calc_daily_Ap(ap_inst, ap_name='3hr_ap', daily_name='Ap',
 def convert_ap_to_kp(ap_data, fill_val=-1, ap_name='ap'):
     """ Convert Ap into Kp
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with `pysatSpaceWeather.instruments.methods.kp_ap.convert_ap_to_kp`
+
     Parameters
     ----------
     ap_data : array-like
@@ -545,6 +591,13 @@ def convert_ap_to_kp(ap_data, fill_val=-1, ap_name='ap'):
         Metadata object containing information about transformed data
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.kp_ap.",
+                           "convert_ap_to_kp` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Ap are keys, Kp returned as double (N- = N.6667, N+=N.3333333)
     one_third = 1.0 / 3.0

--- a/pysat/instruments/sw_dst.py
+++ b/pysat/instruments/sw_dst.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Supports Dst values. Downloads data from NGDC.
 
+.. deprecated:: 2.3.0
+  This Instrument module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatSpaceWeather
+  (https://github.com/pysat/pysatSpaceWeather)
+
 Properties
 ----------
 platform
@@ -29,6 +34,7 @@ of the National Science Foundation.
 import os
 import pandas as pds
 import numpy as np
+import warnings
 
 import pysat
 
@@ -40,6 +46,19 @@ name = 'dst'
 tags = {'': ''}
 sat_ids = {'': ['']}
 _test_dates = {'': {'': pysat.datetime(2007, 1, 1)}}
+
+
+def init(self):
+    """Initializes the Instrument object
+    """
+
+    warnings.warn("".join(["sw_dst has been removed from the pysat-managed ",
+                           "Instruments in pysat 3.0.0, and now resides in ",
+                           "pysatSpaceWeather: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
+
+    return
 
 
 def load(fnames, tag=None, sat_id=None):

--- a/pysat/instruments/sw_f107.py
+++ b/pysat/instruments/sw_f107.py
@@ -1,6 +1,11 @@
 # -*- coding: utf-8 -*-
 """Supports F10.7 index values. Downloads data from LASP and the SWPC.
 
+.. deprecated:: 2.3.0
+  This Instrument module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatSpaceWeather
+  (https://github.com/pysat/pysatSpaceWeather)
+
 Properties
 ----------
 platform
@@ -77,6 +82,19 @@ _test_dates = {'': {'': pysat.datetime(2009, 1, 1),
                     'daily': tomorrow,
                     'forecast': tomorrow,
                     '45day': tomorrow}}
+
+
+def init(self):
+    """Initializes the Instrument object
+    """
+
+    warnings.warn("".join(["sw_f107 has been removed from the pysat-managed ",
+                           "Instruments in pysat 3.0.0, and now resides in ",
+                           "pysatSpaceWeather: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
+
+    return
 
 
 def load(fnames, tag=None, sat_id=None):
@@ -618,6 +636,10 @@ def parse_45day_block(block_lines):
     """ Parse the data blocks used in the 45-day Ap and F10.7 Flux Forecast
     file
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatSpaceWeather.instruments.sw_f107.parse_45day_block`
+
     Parameters
     ----------
     block_lines : list
@@ -631,6 +653,13 @@ def parse_45day_block(block_lines):
         List of values for each date/data pair in this block
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.sw_f107.",
+                           "parse_45day_block` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Initialize the output
     dates = list()
@@ -654,6 +683,10 @@ def parse_45day_block(block_lines):
 def rewrite_daily_file(year, outfile, lines):
     """ Rewrite the SWPC Daily Solar Data files
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatSpaceWeather.instruments.sw_f107.rewrite_daily_file`
+
     Parameters
     ----------
     year : int
@@ -664,6 +697,13 @@ def rewrite_daily_file(year, outfile, lines):
         String containing all output data (result of 'read')
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.sw_f107.",
+                           "rewrite_daily_file` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # get to the solar index data
     if year > 2000:
@@ -694,6 +734,10 @@ def rewrite_daily_file(year, outfile, lines):
 def parse_daily_solar_data(data_lines, year, optical):
     """ Parse the data in the SWPC daily solar index file
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatSpaceWeather.instruments.sw_f107.parse_daily_solar_data`
+
     Parameters
     ----------
     data_lines : list
@@ -711,6 +755,13 @@ def parse_daily_solar_data(data_lines, year, optical):
         Dict of lists of values, where each key is the value name
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.sw_f107.",
+                           "parse_daily_solar_data` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Initialize the output
     dates = list()
@@ -757,6 +808,10 @@ def parse_daily_solar_data(data_lines, year, optical):
 def calc_f107a(f107_inst, f107_name='f107', f107a_name='f107a', min_pnts=41):
     """ Calculate the 81 day mean F10.7
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and will be accessible
+      in `pysatSpaceWeather.instruments.sw_f107.calc_f107a`
+
     Parameters
     ----------
     f107_inst : pysat.Instrument
@@ -777,6 +832,13 @@ def calc_f107a(f107_inst, f107_name='f107', f107a_name='f107a', min_pnts=41):
     Will not pad data on its own
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.sw_f107.",
+                           "calc_f107a` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Test to see that the input data is present
     if f107_name not in f107_inst.data.columns:

--- a/pysat/instruments/sw_kp.py
+++ b/pysat/instruments/sw_kp.py
@@ -1,6 +1,12 @@
 # -*- coding: utf-8 -*-
 """Supports Kp index values. Downloads data from ftp.gfz-potsdam.de or SWPC.
 
+.. deprecated:: 2.3.0
+  This Instrument module has been removed from pysat in the 3.0.0 release and
+  can now be found in pysatSpaceWeather
+  (https://github.com/pysat/pysatSpaceWeather)
+
+
 Parameters
 ----------
 platform
@@ -62,6 +68,7 @@ filter_geoquiet
 import functools
 import numpy as np
 import os
+import warnings
 
 import pandas as pds
 
@@ -84,6 +91,19 @@ today = pysat.datetime(now.year, now.month, now.day)
 # set test dates
 _test_dates = {'': {'': pysat.datetime(2009, 1, 1),
                     'forecast': today + pds.DateOffset(days=1)}}
+
+
+def init(self):
+    """Initializes the Instrument object
+    """
+
+    warnings.warn("".join(["sw_kp has been removed from the pysat-managed ",
+                           "Instruments in pysat 3.0.0, and now resides in ",
+                           "pysatSpaceWeather: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
+
+    return
 
 
 def load(fnames, tag=None, sat_id=None):
@@ -406,6 +426,12 @@ def filter_geoquiet(sat, maxKp=None, filterTime=None, kpData=None,
                     kp_inst=None):
     """Filters pysat.Instrument data for given time after Kp drops below gate.
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with the more adaptable function,
+      `pysatSpaceWeather.instruments.methods.kp_ap.filter_geomag`. Be sure to
+      update to use the new kwargs.
+
     Parameters
     ----------
     sat : pysat.Instrument
@@ -430,6 +456,14 @@ def filter_geoquiet(sat, maxKp=None, filterTime=None, kpData=None,
     data.
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.kp_ap.",
+                           "filter_geomag` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
+
     if kp_inst is not None:
         kp_inst.load(date=sat.date, verifyPad=True)
         kpData = kp_inst
@@ -461,6 +495,10 @@ def filter_geoquiet(sat, maxKp=None, filterTime=None, kpData=None,
 def initialize_kp_metadata(meta, data_key, fill_val=-1):
     """ Initialize the Kp meta data using our knowledge of the index
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with `pysatSpaceWeather.instruments.methods.kp_ap.initialize_kp_metadata`
+
     Parameters
     ----------
     meta : pysat._meta.Meta
@@ -471,6 +509,13 @@ def initialize_kp_metadata(meta, data_key, fill_val=-1):
         File-specific fill value (default=-1)
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.kp_ap.",
+                           "initialize_kp_metadata` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     data_label = data_key.replace("_", " ")
     format_label = data_label[0].upper() + data_label[1:]
@@ -488,6 +533,10 @@ def initialize_kp_metadata(meta, data_key, fill_val=-1):
 def convert_3hr_kp_to_ap(kp_inst):
     """ Calculate 3 hour ap from 3 hour Kp index
 
+    .. deprecated:: 2.3.0
+      This routine has been deprecated in pysat 3.0.0, and has been replaced
+      with `pysatSpaceWeather.instruments.methods.kp_ap.convert_3hr_kp_to_ap`
+
     Parameters
     ----------
     kp_inst : pysat.Instrument
@@ -503,6 +552,13 @@ def convert_3hr_kp_to_ap(kp_inst):
     https://www.ngdc.noaa.gov/stp/GEOMAG/kp_ap.html
 
     """
+
+    warnings.warn("".join(["This function is deprecated here and will be ",
+                           "removed in pysat 3.0.0. Please use ",
+                           "`pysatSpaceWeather.instruments.methods.kp_ap.",
+                           "convert_3hr_kp_to_ap` instead: ",
+                           "https://github.com/pysat/pysatSpaceWeather"]),
+                  DeprecationWarning, stacklevel=2)
 
     # Kp are keys, where n.3 = n+ and n.6 = (n+1)-. E.g., 0.6 = 1-
     kp_to_ap = {0: 0, 0.3: 2, 0.6: 3, 1: 4, 1.3: 5, 1.6: 6, 2: 7, 2.3: 9,

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -14,7 +14,7 @@ import pysat
 import pysat.instruments.pysat_testing
 
 # modules in the list below have deprecation warnings
-dep_list = ['jro_isr', 'dmsp_ivm']
+dep_list = ['jro_isr', 'dmsp_ivm', 'sw_dst', 'sw_kp', 'sw_f107']
 
 # module in list below are excluded from download checks
 exclude_list = ['champ_star', 'superdarn_grdex', 'cosmic_gps',

--- a/pysat/tests/test_sw.py
+++ b/pysat/tests/test_sw.py
@@ -1,6 +1,7 @@
 import datetime as dt
 import numpy as np
 import os
+import warnings
 
 from nose.tools import assert_raises
 from nose.plugins import skip
@@ -38,6 +39,24 @@ class TestSWKp():
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.testMeta
+
+    def test_convert_kp_to_ap_warning(self):
+        """ Test conversion of Kp to ap raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            sw_kp.convert_3hr_kp_to_ap(self.testInst)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
 
     def test_convert_kp_to_ap(self):
         """ Test conversion of Kp to ap"""
@@ -79,6 +98,24 @@ class TestSWKp():
         self.testInst.data.rename(columns={"Kp": "bad"}, inplace=True)
 
         assert_raises(ValueError, sw_kp.convert_3hr_kp_to_ap, self.testInst)
+
+    def test_initialize_kp_metadata_warning(self):
+        """ Test initialize_kp_metadata raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            sw_kp.initialize_kp_metadata(self.testInst.meta, 'Kp')
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
 
     def test_initialize_kp_metadata(self):
         """Test default Kp metadata initialization"""
@@ -162,6 +199,24 @@ class TestSWKp():
 
         del kp_out, kp_meta
 
+    def test_convert_ap_to_kp_warning(self):
+        """ Test convert_ap_to_kp raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            sw_meth.convert_ap_to_kp(self.testInst['ap_nan'])
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
+
     def test_convert_ap_to_kp_nan_input(self):
         """ Test conversion of ap to Kp where ap is NaN"""
 
@@ -236,6 +291,28 @@ class TestSwKpCombine():
         """ Test combine_kp failure when no input is provided"""
 
         assert_raises(ValueError, sw_meth.combine_kp)
+
+    def test_combine_kp_warning(self):
+        """ Test combine_kp raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        combo_in = {kk: self.combine['forecast_inst'] for kk in
+                    ['standard_inst', 'recent_inst', 'forecast_inst']}
+        combo_in['start'] = pysat.datetime(2014, 2, 19)
+        combo_in['stop'] = pysat.datetime(2014, 2, 24)
+        with warnings.catch_warnings(record=True) as war:
+            sw_meth.combine_kp(**combo_in)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
 
     def test_combine_kp_one(self):
         """ Test combine_kp failure when only one instrument is provided"""
@@ -398,6 +475,25 @@ class TestSWF107():
         assert_raises(ValueError, sw_f107.calc_f107a, self.testInst, 'f107',
                       'f107')
 
+    def test_calc_f107a_warning(self):
+        """ Test calc_f107a raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            sw_f107.calc_f107a(self.testInst, f107_name='f107',
+                               f107a_name='f107a')
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
+
     def test_calc_f107a_daily(self):
         """ Test the calc_f107a routine with daily data"""
 
@@ -487,6 +583,28 @@ class TestSWF107Combine():
         assert_raises(ValueError, sw_meth.combine_f107,
                       self.combineInst[''], self.combineInst['forecast'])
 
+    def test_combine_f107_warning(self):
+        """ Test combine_f107 raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        combo_in = {kk: self.combineInst['forecast'] for kk in
+                    ['standard_inst', 'forecast_inst']}
+        combo_in['start'] = pysat.datetime(2014, 2, 19)
+        combo_in['stop'] = pysat.datetime(2014, 2, 24)
+        with warnings.catch_warnings(record=True) as war:
+            sw_meth.combine_f107(**combo_in)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
+
     def test_combine_f107_no_data(self):
         """Test combine_f107 when no data is present for specified times"""
 
@@ -558,6 +676,24 @@ class TestSWAp():
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.meta_dict
+
+    def test_calc_daily_Ap_warning(self):
+        """ Test calc_daily_Ap raises deprecation warning"""
+        warnings.simplefilter("always", DeprecationWarning)
+        wmsg = "function is deprecated here and will be removed in pysat 3.0.0."
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            sw_meth.calc_daily_Ap(self.testInst)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msg = False
+        for iwar in war:
+            if(iwar.category == DeprecationWarning
+               and str(iwar.message).find(wmsg) >= 0):
+                found_msg = True
+
+        assert found_msg, "warning was not raised: {:}".format(wmsg)
 
     def test_calc_daily_Ap(self):
         """ Test daily Ap calculation"""


### PR DESCRIPTION
# Description

Deprecated the pysatSpaceWeather instruments and methods.  Partially addresses #697 .

## Type of change

Please delete options that are not relevant.

- This change requires a documentation update

# How Has This Been Tested?

Added new unit tests

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
