### PR TITLE
Deprecated Instrument class method `_filter_datetime_input`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [2.3.0] - 2021-XX-XX
 - Allow use of new Instrument kwarg, `inst_id` (replaces `sat_id`)
 - Deprecation warnings added to:
-   - Instrument class (old meta labels, sat_id, default, multi_file_day,
-     and manual_org)
+   - Instrument class (old meta labels, `sat_id`, `default`, `multi_file_day`,
+     `manual_org`, and `_filter_datetime_input`)
    - Constellation class kwarg `name`
    - Custom class
   - functions from `_files` class

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -35,7 +35,7 @@ class Instrument(object):
       Several attributes and methods will be removed or replaced in pysat 3.0.0:
       sat_id, default, multi_file_day, manual_org, units_label, name_label,
       notes_label, desc_label, min_label, max_label, fill_label, plot_label,
-      axis_label, and scale_label
+      axis_label, scale_label, and _filter_datetime_input
 
     Parameters
     ----------
@@ -998,6 +998,10 @@ class Instrument(object):
         """
         Returns datetime that only includes year, month, and day.
 
+        .. deprecated:: 2.3.0
+          This method has been deprecated in pysat 3.0.0 and replaced with
+          a new routine: `pysat.utils.time.filter_datetime_input(date)`
+
         Parameters
         ----------
         date : datetime (array_like or single input)
@@ -1008,6 +1012,12 @@ class Instrument(object):
             Only includes year, month, and day from original input
 
         """
+
+        wstr = ''.join(("Class method deprecated, in pysat 3.0.0. it has been",
+                        " replaced with the function ",
+                        "`pysat.utils.time.filter_datetime_input`"))
+        warnings.simplefilter('always', DeprecationWarning)
+        warnings.warn(wstr, DeprecationWarning, stacklevel=2)
 
         if date is None:
             return date

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1387,15 +1387,25 @@ class TestDeprecation():
         """Runs after every method to clean up previous testing."""
         del self.in_kwargs, self.warn_msgs
 
-    def eval_warnings(self):
+    def eval_warnings(self, load=False):
         """Routine to evaluate warnings raised when Instrument instantiated
+
+        Parameters
+        ----------
+        load : boolean
+            Flag indicating whether or not data needs to be loaded into
+            the test instrument (default=False)
+
         """
         # Define the deprecated attributes that are always defined
         found_msgs = np.full(shape=self.warn_msgs.shape, fill_value=False)
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
-            pysat.Instrument(**self.in_kwargs)
+            tinst = pysat.Instrument(**self.in_kwargs)
+
+            if load:
+                tinst.load(2009, 1)
 
         # Ensure the minimum number of warnings were raised
         assert len(war) >= len(self.warn_msgs)
@@ -1440,6 +1450,17 @@ class TestDeprecation():
 
         # Evaluate warnings
         self.eval_warnings()
+        return
+
+    def test_filter_datetime_input_dep(self):
+        """Test deprecation of filter_datetime_input method."""
+        new_msgs = list(self.warn_msgs)
+        new_msgs.append("".join(["it has been replaced with the function ",
+                                 "`pysat.utils.time.filter_datetime_input`"]))
+        self.warn_msgs = np.array(new_msgs)
+
+        # Evaluate warnings
+        self.eval_warnings(load=True)
         return
 
     def test_standard_kwarg_dep(self):


### PR DESCRIPTION
# Description

Deprecated Instrument class method `_filter_datetime_input`.  Addresses #682.

## Type of change

- This change requires a documentation update

# How Has This Been Tested?

Added a new unit test

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [N/A] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
