### PR TITLE
ENH/BUG: Add No Modulus Option to SLT Calculations, .copy() Fix, and More!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     exclusive
   - Added support for SLT calculations outside [0, 24)
   - Added support for continuous SLT calculations when loading multiple days
+  - Instrument support functions now respond to local changes in 
+    Instrument.kwargs
+  - Added support for pysat.Instrument, Files, and Orbits equality comparisons
+  - Added .copy function to Instrument, Files, and Orbits classes
 - Deprecations
   - Migraged instruments to pysatMadrigal, pysatNASA, pysatSpaceWeather,
     pysatIncubator, pysatModels, pysatCDAAC, and pysatMissions
@@ -88,7 +92,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Removed unnecessary Instrument attribute `labels`
   - Removed unnecessary Instrument kwargs
   - Removed the Custom class, incorporating it into Instrument
-  - Added support for pysat.Instrument equality comparisons
+  - Removed deprecated calls to 'modify' type custom functions
 - Documentation
   - Added info on how to register new instruments
   - Fixed description of `tag` and `inst_id` behaviour in testing instruments
@@ -121,6 +125,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Improved robustness of eval(inst.__repr__()) (#636)
   - Fixed `calc_solar_local_time` for data sets with longitude coordinates
   - Fixed .copy() when pysat.Instrument instantiated with `inst_module` (#728)
+  - Modified storage of Instrument.kwargs to include all methods so that
+    eval(Instrument.__repr__()) works in more cases
+  - Modified storage of Instrument.kwargs to only include user supplied keywords
+  - Improved robustness when working with file dates that aren't centered on 
+    midnight
 - Maintenance
   - nose dependency removed from unit tests
   - Specified `dtype` for empty pandas.Series for forward compatibility
@@ -137,6 +146,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Reduced code duplication throughout package
   - Reduced unused code snippets throughout
   - Ensured download start time is used
+  - Condensed testing support functions into methods/testing.py
 
 ## [2.2.2] - 2020-12-31
 - New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,11 +124,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Ensured pysat.Meta instances are immutable at Instrument instantiation
   - Removed weak reference back to Instrument within Files class
   - Fixed access of xarray data with more than one dimension (#471)
-  - Improved robustness of eval(inst.__repr__()) (#636)
+  - Improved robustness of `eval(inst.__repr__())` (#636)
   - Fixed `calc_solar_local_time` for data sets with longitude coordinates
   - Fixed .copy() when pysat.Instrument instantiated with `inst_module` (#728)
   - Modified storage of Instrument.kwargs to include all methods so that
-    eval(Instrument.__repr__()) works in more cases
+    `eval(Instrument.__repr__())` works in more cases
   - Modified storage of Instrument.kwargs to only include user supplied keywords
   - Improved robustness when working with file dates that aren't centered on 
     midnight

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -36,7 +36,7 @@ part of pysat's user instrument registry using the following syntax:
   registry.register_from_module(my_package.instruments)
 
 After registry the instrument module name is stored in the user's home
-directory under :code:`~.pysat/user_modules.txt`. The instrument may then
+directory under :code:`~.pysat`. The instrument may then
 be instantiated with the instrument's platform and name:
 
 .. code-block:: python
@@ -47,8 +47,8 @@ be instantiated with the instrument's platform and name:
 Instrument Libraries
 --------------------
 pysat instruments can reside in external libraries.  The registry methods
-described  above can be used to provide links to these instrument libraries
-for rapid access.  For instance, pysat instruments which handle the outputs
+described above can be used to provide links to these instrument libraries
+for rapid access. For instance, pysat instruments which handle the outputs
 of geophysical models (such as the TIE-GCM model) reside in the pysatModels
 package.
 
@@ -229,13 +229,13 @@ instrument module to work with those files.
 
 pysat will by default store data in pysat_data_dir/platform/name/tag,
 helpfully provided in data_path, where pysat_data_dir is specified by using
-``pysat.utils.set_data_dir(pysat_data_dir)``. Note that an alternative
+``pysat.params['data_dirs'] = pysat_data_dir``. Note that an alternative
 directory structure may be specified using the pysat.Instrument keyword
 directory_format at instantiation. The default is recreated using
 
 .. code:: python
 
-    dformat = '{platform}/{name}/{tag}'
+    dformat = '{platform}/{name}/{tag}/{inst_id}'
     inst=pysat.Instrument(platform, name, directory_format=dformat)
 
 Note that pysat handles the path information thus instrument module developers
@@ -433,33 +433,44 @@ allowing them to be stored as a pandas DataFrame. Setting this attribute to
 Optional Routines and Support
 -----------------------------
 
-Custom Keywords in load Method
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Custom Keywords in Support Methods
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If provided, pysat supports the definition and use of keywords for an
-instrument module so that users may trigger optional features. All custom
-keywords for an instrument module must be defined in the ``load`` method.
+instrument module so that users may trigger optional features. A custom
+keyword for an instrument module must be defined in each function that
+will receive that keyword argument if provided by the user. All instrument
+functions, ``init``, ``preprocess``, ``load``, ``clean``, ``list_files``,
+``list_remote_files``, and ``download`` support custom keywords. The same
+keyword may be used in more than one function but the same value will be passed
+to each.
 
+An example ``load`` function definition with two custom keyword arguments.
 .. code:: python
 
    def load(fnames, tag=None, inst_id=None, custom1=default1, custom2=default2):
        return data, meta
 
-pysat passes any supported custom keywords and values to ``load`` with every
-call. All custom keywords along with the assigned defaults are copied into the
-Instrument object itself under inst.kwargs for use in other areas.
+If a user provides ``custom1`` or ``custom2`` at instantiation, then pysat will
+pass those custom keyword arguments to ``load`` with every call.
+All user provided custom keywords are copied into the
+Instrument object itself under ``inst.kwargs`` for use in other areas. All
+available keywords, including default values, are also grouped by relevant
+function in a dictionary, ``inst.kwargs_supported``, attached to the Instrument
+object. Updates to values in ``inst.kwargs`` will be propagated to the relevant
+function the next time that function is invoked.
 
 .. code:: python
 
    inst = pysat.Instrument(platform, name, custom1=new_value)
 
-   # Show user supplied value for custom1 keyword
-   print(inst.kwargs['custom1'])
+   # Show user supplied value for custom1 keyword for the 'load' function
+   print(inst.kwargs['load']['custom1'])
 
    # Show default value applied for custom2 keyword
-   print(inst.kwargs['custom2'])
+   print(inst.kwargs_supported['load']['custom2'])
 
-If a user supplies a keyword that is not supported by pysat or by the
+If a user supplies a keyword that is not supported by pysat or by any
 specific instrument module then an error is raised.
 
 
@@ -476,8 +487,6 @@ If present, the instrument init method runs once at instrument instantiation.
 `inst` is a ``pysat.Instrument()`` object. ``init`` should modify `inst`
 in-place as needed; equivalent to a custom routine.
 
-Keywords are not supported within the init module method signature, though
-custom keyword support for instruments is available via inst.kwargs.
 
 preprocess
 ^^^^^^^^^^

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -36,7 +36,7 @@ part of pysat's user instrument registry using the following syntax:
   registry.register_from_module(my_package.instruments)
 
 After registry the instrument module name is stored in the user's home
-directory under :code:`~.pysat`. The instrument may then
+directory in a hidden directory named :code:`~.pysat`. The instrument may then
 be instantiated with the instrument's platform and name:
 
 .. code-block:: python
@@ -437,7 +437,7 @@ Custom Keywords in Support Methods
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 If provided, pysat supports the definition and use of keywords for an
-instrument module so that users may trigger optional features. A custom
+instrument module so that users may define their preferred default values. A custom
 keyword for an instrument module must be defined in each function that
 will receive that keyword argument if provided by the user. All instrument
 functions, ``init``, ``preprocess``, ``load``, ``clean``, ``list_files``,

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -9,6 +9,7 @@ import datetime as dt
 from functools import partial
 import numpy as np
 import os
+import weakref
 
 import pandas as pds
 
@@ -153,7 +154,7 @@ class Files(object):
         self.inst_info = {'platform': inst.platform, 'name': inst.name,
                           'tag': inst.tag, 'inst_id': inst.inst_id,
                           'inst_module': inst.inst_module,
-                          'inst': inst}
+                          'inst': weakref.proxy(inst)}
 
         self.multi_file_day = inst.multi_file_day
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -152,7 +152,8 @@ class Files(object):
         # Grab Instrument info
         self.inst_info = {'platform': inst.platform, 'name': inst.name,
                           'tag': inst.tag, 'inst_id': inst.inst_id,
-                          'inst_module': inst.inst_module}
+                          'inst_module': inst.inst_module,
+                          'inst': inst}
         self.list_files_rtn = inst._list_files_rtn
 
         self.multi_file_day = inst.multi_file_day
@@ -237,7 +238,7 @@ class Files(object):
     def __repr__(self):
         """ Representation of the class and its current state
         """
-        inst_repr = pysat.Instrument(**self.inst_info).__repr__()
+        inst_repr = self.inst_info['inst'].__repr__()
 
         out_str = "".join(["pysat.Files(", inst_repr, ", directory_format=",
                            "'{:}'".format(self.directory_format),
@@ -633,10 +634,13 @@ class Files(object):
         # Check all potential directory locations for files.
         # Stop as soon as we find some.
         for path in self.data_paths:
-            new_files = self.list_files_rtn(tag=self.inst_info['tag'],
-                                            inst_id=self.inst_info['inst_id'],
-                                            data_path=path,
-                                            format_str=self.file_format)
+            list_files_rtn = self.inst_info['inst']._list_files_rtn
+            kwarg_inputs = self.inst_info['inst'].kwargs['list_files']
+            new_files = list_files_rtn(tag=self.inst_info['tag'],
+                                       inst_id=self.inst_info['inst_id'],
+                                       data_path=path,
+                                       format_str=self.file_format,
+                                       **kwarg_inputs)
 
             # Check if list_files_rtn is actually returning filename or a
             # dict to be passed to filename creator function.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -279,7 +279,7 @@ class Files(object):
         Returns
         -------
         bool
-            True if objects are identical
+            True if objects are identical, False if they are not
 
         """
         if not isinstance(other, self.__class__):

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -641,8 +641,8 @@ class Files(object):
         # The copy module does not copy modules. Treat self.inst_info
         # differently since it possibly contains a python module, plus
         # it also contains a weakref back to Instrument.  Because the Instrument
-        # reference contains another Files object, it could cause the creation of
-        # an infinite, recursive copy.
+        # reference contains another Files object, it could cause the creation
+        # of an infinite, recursive copy.
         saved_info = self.inst_info
         self.inst_info = None
 
@@ -652,9 +652,9 @@ class Files(object):
         # Restore the saved information, then copy over items that can be copied
         self.inst_info = saved_info
         files_copy.inst_info = {}
-        for item in saved_info:
-            if item not in ['inst', 'inst_module']:
-                files_copy.inst_info[item] = copy.deepcopy(self.inst_info[item])
+        for key in saved_info.keys():
+            if key not in ['inst', 'inst_module']:
+                files_copy.inst_info[key] = copy.deepcopy(self.inst_info[key])
 
         # Can't copy the weakreference
         files_copy.inst_info['inst'] = self.inst_info['inst']

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -154,7 +154,6 @@ class Files(object):
                           'tag': inst.tag, 'inst_id': inst.inst_id,
                           'inst_module': inst.inst_module,
                           'inst': inst}
-        self.list_files_rtn = inst._list_files_rtn
 
         self.multi_file_day = inst.multi_file_day
 
@@ -290,22 +289,30 @@ class Files(object):
         for item in self.__dict__:
             item_check.append(item)
             if item in other.__dict__:
-                if item not in ['files', 'list_files_rtn']:
+                if item not in ['files', '_previous_file_list',
+                                '_current_file_list', 'inst_info']:
                     test = np.all(self.__dict__[item] == other.__dict__[item])
                     checks.append(test)
                 else:
-                    if item == 'files':
+                    if item not in ['inst_info']:
                         try:
                             # Comparison only works for identically-labeled
                             # series.
-                            check = np.all(self.files == other.files)
+                            check = np.all(self.__dict__[item]
+                                           == other.__dict__[item])
                         except ValueError:
                             check = False
                         checks.append(check)
-                    else:
-                        test = str(self.__dict__[item]) \
-                            == str(other.__dict__[item])
-                        checks.append(test)
+                    elif item == 'inst_info':
+                        ichecks = []
+                        for sitem in self.inst_info:
+                            if sitem != 'inst':
+                                ichecks.append(self.inst_info[sitem]
+                                               == other.inst_info[sitem])
+                            else:
+                                ichecks.append(str(self.inst_info[sitem])
+                                               == str(other.inst_info[sitem]))
+                        checks.append(np.all(ichecks))
             else:
                 checks.append(False)
                 break

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -309,7 +309,7 @@ class Files(object):
                                            == other.__dict__[item])
                         except ValueError:
                             # If there is an error they aren't the same.
-                            check = False
+                            return False
                         checks.append(check)
                     elif item == 'inst_info':
                         ichecks = []
@@ -322,13 +322,17 @@ class Files(object):
                                 # Don't want a recursive check on 'inst', which
                                 # contains Files. If the string representations
                                 # are the same we consider them the same.
-                                ichecks.append(str(self.inst_info[sitem])
-                                               == str(other.inst_info[sitem]))
+                                try:
+                                    oitem = other.inst_info[sitem]
+                                    ichecks.append(str(self.inst_info[sitem])
+                                                   == str(oitem))
+                                except AttributeError:
+                                    # If one object is missing a required item
+                                    return False
                         checks.append(np.all(ichecks))
             else:
                 # other did not have an item that self did
-                checks.append(False)
-                break
+                return False
 
         # Confirm that other doesn't have extra terms
         for item in other.__dict__:

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -287,7 +287,7 @@ class Files(object):
 
         checks = []
         key_check = []
-        for key in self.__dict__:
+        for key in self.__dict__.keys():
             key_check.append(key)
             # Confirm each object has the same keys
             if key in other.__dict__:
@@ -336,7 +336,7 @@ class Files(object):
                 return False
 
         # Confirm that other doesn't have extra terms
-        for key in other.__dict__:
+        for key in other.__dict__.keys():
             if key not in self.__dict__:
                 return False
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -302,6 +302,7 @@ class Files(object):
                                '_current_file_list', 'inst_info']:
                     test = np.all(self.__dict__[key] == other.__dict__[key])
                     checks.append(test)
+
                 else:
                     if key not in ['inst_info']:
                         # Comparing one of the stored pandas Series
@@ -314,6 +315,7 @@ class Files(object):
                         except ValueError:
                             # If there is an error they aren't the same.
                             return False
+
                     elif key == 'inst_info':
                         ichecks = []
                         for ii_key in self.inst_info.keys():
@@ -321,6 +323,7 @@ class Files(object):
                                 # Standard check
                                 ichecks.append(self.inst_info[ii_key]
                                                == other.inst_info[ii_key])
+
                             else:
                                 # Don't want a recursive check on 'inst', which
                                 # contains Files. If the string representations
@@ -333,6 +336,7 @@ class Files(object):
                                     # If one object is missing a required key
                                     return False
                         checks.append(np.all(ichecks))
+
             else:
                 # other did not have an key that self did
                 return False

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -314,18 +314,18 @@ class Files(object):
                         checks.append(check)
                     elif item == 'inst_info':
                         ichecks = []
-                        for sitem in self.inst_info:
-                            if sitem != 'inst':
+                        for ii_key in self.inst_info.keys():
+                            if ii_key != 'inst':
                                 # Standard check
-                                ichecks.append(self.inst_info[sitem]
-                                               == other.inst_info[sitem])
+                                ichecks.append(self.inst_info[ii_key]
+                                               == other.inst_info[ii_key])
                             else:
                                 # Don't want a recursive check on 'inst', which
                                 # contains Files. If the string representations
                                 # are the same we consider them the same.
                                 try:
-                                    oitem = other.inst_info[sitem]
-                                    ichecks.append(str(self.inst_info[sitem])
+                                    oitem = other.inst_info[ii_key]
+                                    ichecks.append(str(self.inst_info[ii_key])
                                                    == str(oitem))
                                 except AttributeError:
                                     # If one object is missing a required item

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -291,8 +291,9 @@ class Files(object):
             item_check.append(item)
             # Confirm each object has the same items
             if item in other.__dict__:
-                # Define default comparison. Series comparisons can error
-                # for simply being different (files, _*_file_list).
+                # Define default comparison. Testing equality between two Series
+                # will produce an error if they don't have the same index
+                # (files, _*_file_list).
                 # 'inst_info' contains a weakref back to Instrument that
                 # requires a different check.
                 if item not in ['files', '_previous_file_list',

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -292,7 +292,7 @@ class Files(object):
         for key in self.__dict__.keys():
             key_check.append(key)
             # Confirm each object has the same keys
-            if key in other.__dict__:
+            if key in other.__dict__.keys():
                 # Define default comparison. Testing equality between two Series
                 # will produce an error if they don't have the same index
                 # (files, _*_file_list).
@@ -343,7 +343,7 @@ class Files(object):
 
         # Confirm that Files object `other` doesn't have extra terms
         for key in other.__dict__.keys():
-            if key not in self.__dict__:
+            if key not in self.__dict__.keys():
                 return False
 
         test_data = np.all(checks)

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -324,9 +324,9 @@ class Files(object):
                                 # contains Files. If the string representations
                                 # are the same we consider them the same.
                                 try:
-                                    oitem = other.inst_info[ii_key]
+                                    oinst = other.inst_info[ii_key]
                                     ichecks.append(str(self.inst_info[ii_key])
-                                                   == str(oitem))
+                                                   == str(oinst))
                                 except AttributeError:
                                     # If one object is missing a required item
                                     return False

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -294,11 +294,7 @@ class Files(object):
             key_check.append(key)
             # Confirm each object has the same keys
             if key in other.__dict__.keys():
-                # Define default comparison. Testing equality between two Series
-                # will produce an error if they don't have the same index
-                # (files, _*_file_list) instead of False.
-                # 'inst_info' contains a weakref back to Instrument that
-                # requires a different check.
+                # Define default comparison.
                 if key not in ['files', '_previous_file_list',
                                '_current_file_list', 'inst_info']:
                     test = np.all(self.__dict__[key] == other.__dict__[key])

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -286,33 +286,33 @@ class Files(object):
             return False
 
         checks = []
-        item_check = []
-        for item in self.__dict__:
-            item_check.append(item)
-            # Confirm each object has the same items
-            if item in other.__dict__:
+        key_check = []
+        for key in self.__dict__:
+            key_check.append(key)
+            # Confirm each object has the same keys
+            if key in other.__dict__:
                 # Define default comparison. Testing equality between two Series
                 # will produce an error if they don't have the same index
                 # (files, _*_file_list).
                 # 'inst_info' contains a weakref back to Instrument that
                 # requires a different check.
-                if item not in ['files', '_previous_file_list',
-                                '_current_file_list', 'inst_info']:
-                    test = np.all(self.__dict__[item] == other.__dict__[item])
+                if key not in ['files', '_previous_file_list',
+                               '_current_file_list', 'inst_info']:
+                    test = np.all(self.__dict__[key] == other.__dict__[key])
                     checks.append(test)
                 else:
-                    if item not in ['inst_info']:
+                    if key not in ['inst_info']:
                         # Comparing one of the stored pandas Series
                         try:
                             # Comparison only works for identically-labeled
                             # series.
-                            check = np.all(self.__dict__[item]
-                                           == other.__dict__[item])
+                            check = np.all(self.__dict__[key]
+                                           == other.__dict__[key])
+                            checks.append(check)
                         except ValueError:
                             # If there is an error they aren't the same.
                             return False
-                        checks.append(check)
-                    elif item == 'inst_info':
+                    elif key == 'inst_info':
                         ichecks = []
                         for ii_key in self.inst_info.keys():
                             if ii_key != 'inst':
@@ -328,16 +328,16 @@ class Files(object):
                                     ichecks.append(str(self.inst_info[ii_key])
                                                    == str(oinst))
                                 except AttributeError:
-                                    # If one object is missing a required item
+                                    # If one object is missing a required key
                                     return False
                         checks.append(np.all(ichecks))
             else:
-                # other did not have an item that self did
+                # other did not have an key that self did
                 return False
 
         # Confirm that other doesn't have extra terms
-        for item in other.__dict__:
-            if item not in self.__dict__:
+        for key in other.__dict__:
+            if key not in self.__dict__:
                 return False
 
         test_data = np.all(checks)

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -286,7 +286,8 @@ class Files(object):
         if not isinstance(other, self.__class__):
             return False
 
-        # If the type is the same CHECK FOR ALL THESE THINGS
+        # If the type is the same then check everything that is attached to
+        # the Files object. Includes attributes, methods, variables, etc.
         checks = []
         key_check = []
         for key in self.__dict__.keys():
@@ -295,7 +296,7 @@ class Files(object):
             if key in other.__dict__.keys():
                 # Define default comparison. Testing equality between two Series
                 # will produce an error if they don't have the same index
-                # (files, _*_file_list).
+                # (files, _*_file_list) instead of False.
                 # 'inst_info' contains a weakref back to Instrument that
                 # requires a different check.
                 if key not in ['files', '_previous_file_list',
@@ -320,7 +321,7 @@ class Files(object):
                         ichecks = []
                         for ii_key in self.inst_info.keys():
                             if ii_key != 'inst':
-                                # Standard check
+                                # Standard attribute check
                                 ichecks.append(self.inst_info[ii_key]
                                                == other.inst_info[ii_key])
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -514,7 +514,7 @@ class Instrument(object):
             if key not in ['data', '_null_data', '_next_data',
                            '_curr_data', '_prev_data']:
                 key_check.append(key)
-                if key in other.__dict__:
+                if key in other.__dict__.keys():
                     if key in partial_funcs:
                         # Partial function comparison doesn't work directly.
                         try:
@@ -549,7 +549,7 @@ class Instrument(object):
 
         # Confirm that other Instrument object doesn't have extra terms
         for key in other.__dict__.keys():
-            if key not in self.__dict__:
+            if key not in self.__dict__.keys():
                 return False
 
         # Confirm all checks are True

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -509,24 +509,24 @@ class Instrument(object):
                          '_list_remote_files_rtn', '_load_rtn']
 
         checks = []
-        item_check = []
-        for item in self.__dict__:
-            if item not in ['data', '_null_data', '_next_data',
-                            '_curr_data', '_prev_data']:
-                item_check.append(item)
-                if item in other.__dict__:
-                    if item in partial_funcs:
+        key_check = []
+        for key in self.__dict__:
+            if key not in ['data', '_null_data', '_next_data',
+                           '_curr_data', '_prev_data']:
+                key_check.append(key)
+                if key in other.__dict__:
+                    if key in partial_funcs:
                         # Partial function comparison doesn't work directly.
                         try:
-                            checks.append(str(self.__dict__[item])
-                                          == str(other.__dict__[item]))
+                            checks.append(str(self.__dict__[key])
+                                          == str(other.__dict__[key]))
                         except AttributeError:
                             # If an item missing a required attribute
                             return False
                     else:
                         # General check for everything else.
-                        checks.append(np.all(self.__dict__[item]
-                                             == other.__dict__[item]))
+                        checks.append(np.all(self.__dict__[key]
+                                             == other.__dict__[key]))
                 else:
                     # Both objects don't have the same attached objects
                     return False
@@ -536,19 +536,20 @@ class Instrument(object):
                     try:
                         # Check is sensitive to the index labels. Errors
                         # if index is not identical.
-                        checks.append(np.all(self.__dict__[item]
-                                             == other.__dict__[item]))
+                        checks.append(np.all(self.__dict__[key]
+                                             == other.__dict__[key]))
                     except ValueError:
                         return False
                 else:
                     checks.append(xr.Dataset.equals(self.data,
                                                     other.data))
 
-        # Confirm that other doesn't have extra terms
-        for item in other.__dict__:
-            if item not in self.__dict__:
+        # Confirm that other Instrument object doesn't have extra terms
+        for key in other.__dict__:
+            if key not in self.__dict__:
                 return False
 
+        # Confirm all checks are True
         test_data = np.all(checks)
 
         return test_data

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3181,11 +3181,26 @@ class Instrument(object):
                     self.bounds = (self.files.start_date, self.files.stop_date,
                                    curr_bound[2], curr_bound[3])
             if self._iter_type == 'file':
-                if (curr_bound[0][0] == self.files[first_date]
-                        and curr_bound[1][0] == self.files[last_date]):
+                # Account for the fact the file datetimes may not land
+                # exactly at start or end of a day.
+                dsel1 = slice(first_date, first_date + dt.timedelta(hours=23,
+                                                                    minutes=59,
+                                                                    seconds=59))
+                dsel2 = slice(last_date, last_date + dt.timedelta(hours=23,
+                                                                  minutes=59,
+                                                                  seconds=59))
+                if (curr_bound[0][0] == self.files[dsel1][0]
+                        and curr_bound[1][0] == self.files[dsel2][-1]):
                     logger.info('Updating instrument object bounds by file.')
-                    self.bounds = (self.files[self.files.start_date],
-                                   self.files[self.files.stop_date],
+                    dsel1 = slice(self.files.start_date,
+                                  self.files.start_date
+                                  + dt.timedelta(hours=23, minutes=59,
+                                                 seconds=59))
+                    dsel2 = slice(self.files.stop_date, self.files.stop_date
+                                  + dt.timedelta(hours=23, minutes=59,
+                                                 seconds=59))
+                    self.bounds = (self.files[dsel1][0],
+                                   self.files[dsel2][-1],
                                    curr_bound[2], curr_bound[3])
 
         return

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -359,6 +359,7 @@ class Instrument(object):
 
         # Store kwargs, passed to standard routines first
         self.kwargs = {}
+        self.kwargs_supported = {}
         saved_keys = []
         partial_func = ['list_files', 'list_remote_files', 'download',
                         'preprocess', 'clean', 'load', 'init']
@@ -378,6 +379,9 @@ class Instrument(object):
 
             # Store appropriate user supplied keywords for this function
             self.kwargs[fkey] = {gkey: kwargs[gkey] for gkey in good_kwargs}
+
+            # Store all supported keywords for user edification
+            self.kwargs_supported[fkey] = default_kwargs
 
             # Keep a copy of user provided values
             user_values = copy.deepcopy(self.kwargs[fkey])

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -523,10 +523,12 @@ class Instrument(object):
                         except AttributeError:
                             # If an item missing a required attribute
                             return False
+
                     else:
                         # General check for everything else.
                         checks.append(np.all(self.__dict__[key]
                                              == other.__dict__[key]))
+
                 else:
                     # Both objects don't have the same attached objects
                     return False
@@ -540,6 +542,7 @@ class Instrument(object):
                                              == other.__dict__[key]))
                     except ValueError:
                         return False
+
                 else:
                     checks.append(xr.Dataset.equals(self.data,
                                                     other.data))

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -488,9 +488,11 @@ class Instrument(object):
 
         """
 
+        # Check if other is the same class (Instrument). Exit early if not.
         if not isinstance(other, self.__class__):
             return False
 
+        # Check if both objects are the same data type. Exit early if not.
         if self.pandas_format != other.pandas_format:
             return False
 
@@ -499,7 +501,7 @@ class Instrument(object):
             # This check needed to establish next check
             pass
         elif self.empty or other.empty:
-            # Only one has data
+            # Only one has data, exit early.
             return False
 
         # If data is the same, check other attributes. Partial functions

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -510,7 +510,7 @@ class Instrument(object):
 
         checks = []
         key_check = []
-        for key in self.__dict__:
+        for key in self.__dict__.keys():
             if key not in ['data', '_null_data', '_next_data',
                            '_curr_data', '_prev_data']:
                 key_check.append(key)
@@ -545,7 +545,7 @@ class Instrument(object):
                                                     other.data))
 
         # Confirm that other Instrument object doesn't have extra terms
-        for key in other.__dict__:
+        for key in other.__dict__.keys():
             if key not in self.__dict__:
                 return False
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -394,15 +394,13 @@ class Instrument(object):
             # Determine the number of kwargs in this function
             fkwargs = [gkey for gkey in self.kwargs[fkey].keys()]
 
-            # Only save the kwargs if they exist and have not been assigned
-            # through partial
+            # Keep only the user provided kwargs
             if len(fkwargs) > 0:
-                # Store the saved keys
+                # Store these keys so they may be used as part of a comparison
+                # test to ensure all user supplied keys are used.
                 saved_keys.extend(fkwargs)
 
-                # If the function can't access this dict, use partial
-                # The functions that truly can't access the dict are load,
-                # list_files, list_remote_files, download.
+                # Assign user keywords to relevant function
                 if fkey in partial_func:
                     pfunc = functools.partial(func, **self.kwargs[fkey])
                     setattr(self, func_name, pfunc)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -508,6 +508,8 @@ class Instrument(object):
                          '_list_files_rtn', '_download_rtn',
                          '_list_remote_files_rtn', '_load_rtn']
 
+        # If the type is the same then check everything that is attached to
+        # the Instrument object. Includes attributes, methods, variables, etc.
         checks = []
         key_check = []
         for key in self.__dict__.keys():

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -516,17 +516,20 @@ class Instrument(object):
                 item_check.append(item)
                 if item in other.__dict__:
                     if item in partial_funcs:
-                        # Partial function comparison doesn't work directly
-                        checks.append(str(self.__dict__[item])
-                                      == str(other.__dict__[item]))
+                        # Partial function comparison doesn't work directly.
+                        try:
+                            checks.append(str(self.__dict__[item])
+                                          == str(other.__dict__[item]))
+                        except AttributeError:
+                            # If an item missing a required attribute
+                            return False
                     else:
                         # General check for everything else.
                         checks.append(np.all(self.__dict__[item]
                                              == other.__dict__[item]))
                 else:
                     # Both objects don't have the same attached objects
-                    checks.append(False)
-                    break
+                    return False
             else:
                 # Data comparison area. Established earlier both have data.
                 if self.pandas_format:
@@ -540,6 +543,11 @@ class Instrument(object):
                 else:
                     checks.append(xr.Dataset.equals(self.data,
                                                     other.data))
+
+        # Confirm that other doesn't have extra terms
+        for item in other.__dict__:
+            if item not in self.__dict__:
+                return False
 
         test_data = np.all(checks)
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -13,6 +13,7 @@ import os
 import sys
 import types
 import warnings
+import weakref
 
 import netCDF4
 import numpy as np
@@ -1932,6 +1933,8 @@ class Instrument(object):
         self.inst_module = saved_module
 
         inst_copy.files = saved_files.copy()
+        inst_copy.inst_info['inst'] = weakref.proxy(inst_copy)
+        inst_copy.orbits.inst = weakref.proxy(inst_copy)
         self.files = saved_files
 
         return inst_copy

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1933,7 +1933,7 @@ class Instrument(object):
         self.inst_module = saved_module
 
         inst_copy.files = saved_files.copy()
-        inst_copy.inst_info['inst'] = weakref.proxy(inst_copy)
+        inst_copy.files.inst_info['inst'] = weakref.proxy(inst_copy)
         inst_copy.orbits.inst = weakref.proxy(inst_copy)
         self.files = saved_files
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3196,9 +3196,9 @@ class Instrument(object):
         kwargs['tag'] = self.tag
         kwargs['inst_id'] = self.inst_id
         kwargs['data_path'] = self.files.data_path
-        for kwrd in self.kwargs['download']:
-            if kwrd not in kwargs:
-                kwargs[kwrd] = self.kwargs['download'][kwrd]
+        for kwarg in self.kwargs['download']:
+            if kwarg not in kwargs:
+                kwargs[kwarg] = self.kwargs['download'][kwarg]
 
         # Download the data
         self._download_rtn(date_array, **kwargs)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1926,20 +1926,39 @@ class Instrument(object):
         # set module variable/files to `None`, make the copy, reassign the
         # saved modules.
         saved_module = self.inst_module
+
+        # The files/orbits class copy() not invoked with deepcopy
         saved_files = self.files
+        saved_orbits = self.orbits
 
         self.inst_module = None
         self.files = None
+        self.orbits = None
 
+        # Copy non-problematic parameters
         inst_copy = copy.deepcopy(self)
 
+        # Restore links to the instrument support functions module
         inst_copy.inst_module = saved_module
         self.inst_module = saved_module
 
+        # Reattach files and copy
         inst_copy.files = saved_files.copy()
-        inst_copy.files.inst_info['inst'] = weakref.proxy(inst_copy)
-        inst_copy.orbits.inst = weakref.proxy(inst_copy)
         self.files = saved_files
+
+        # Reattach orbits and copy
+        inst_copy.orbits = saved_orbits.copy()
+        self.orbits = saved_orbits
+
+        # Support a copy if a user does something like,
+        # self.orbits.inst.copy(), or
+        # self.files.inst_info['inst'].copy()
+        if not isinstance(inst_copy, weakref.ProxyType):
+            inst_copy.files.inst_info['inst'] = weakref.proxy(inst_copy)
+            inst_copy.orbits.inst = weakref.proxy(inst_copy)
+        else:
+            inst_copy.files.inst_info['inst'] = inst_copy
+            inst_copy.orbits.inst = inst_copy
 
         return inst_copy
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -484,7 +484,7 @@ class Instrument(object):
         Returns
         -------
         bool
-            True if objects are identical
+            True if objects are identical, False if they are not.
 
         """
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3862,8 +3862,7 @@ def _get_supported_keywords(local_func):
     while len(func_args) > len(func_defaults):
         func_args.pop(0)
 
-    # Remove pre-existing keywords from output
-    # First, identify locations
+    # Remove pre-existing keywords from output. Start by identifying locations
     pop_list = [i for i, arg in enumerate(func_args) if arg in pre_kws]
 
     # Remove pre-selected by cycling backwards through the list of indices

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -182,9 +182,6 @@ class Orbits(object):
         key_check = []
         for key in self.__dict__.keys():
             if key in other.__dict__.keys():
-                # partial function comparisons (_det_breaks), data
-                # objects (_full_daya_data), and the pysat.Instrument ref
-                # require different treatment.
                 if key not in ['_full_day_data', 'inst', '_det_breaks']:
                     # Standard equality comparison
                     test = np.all(self.__dict__[key] == other.__dict__[key])

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -200,8 +200,10 @@ class Orbits(object):
                         except ValueError:
                             # If there is an error they aren't the same
                             return False
+
                         checks.append(check)
                         key_check.append(key)
+
                     else:
                         # xarray comparison
                         test = xr.Dataset.equals(self.__dict__[key],
@@ -218,6 +220,7 @@ class Orbits(object):
                     except AttributeError:
                         # One object is missing a required attribute
                         return False
+
                     checks.append(check)
                     key_check.append(key)
 

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -177,37 +177,39 @@ class Orbits(object):
             return False
 
         checks = []
-        item_check = []
-        for item in self.__dict__:
-            if item in other.__dict__:
+        key_check = []
+        for key in self.__dict__.keys():
+            if key in other.__dict__:
                 # partial function comparisons (_det_breaks), data
                 # objects (_full_daya_data), and the pysat.Instrument ref
                 # require different treatment.
-                if item not in ['_full_day_data', 'inst', '_det_breaks']:
+                if key not in ['_full_day_data', 'inst', '_det_breaks']:
                     # Standard equality comparison
-                    test = np.all(self.__dict__[item] == other.__dict__[item])
+                    test = np.all(self.__dict__[key] == other.__dict__[key])
                     checks.append(test)
-                    item_check.append(item)
-                elif item in ['_full_day_data']:
+                    key_check.append(key)
+
+                elif key in ['_full_day_data']:
                     # Compare data
-                    if isinstance(self.__dict__[item], pds.DataFrame):
+                    if isinstance(self.__dict__[key], pds.DataFrame):
                         try:
                             # Comparisons can error simply for having
                             # different DataFrames
-                            check = np.all(self.__dict__[item]
-                                           == other.__dict__[item])
+                            check = np.all(self.__dict__[key]
+                                           == other.__dict__[key])
                         except ValueError:
                             # If there is an error they aren't the same
                             return False
                         checks.append(check)
-                        item_check.append(item)
+                        key_check.append(key)
                     else:
                         # xarray comparison
-                        test = xr.Dataset.equals(self.__dict__[item],
-                                                 other.__dict__[item])
+                        test = xr.Dataset.equals(self.__dict__[key],
+                                                 other.__dict__[key])
                         checks.append(test)
-                        item_check.append(item)
-                elif item == '_det_breaks':
+                        key_check.append(key)
+
+                elif key == '_det_breaks':
                     # Equality of partial functions does not work well.
                     # Using a string comparison instead. This can also break
                     # if one of the objects is missing some attributes.
@@ -217,15 +219,16 @@ class Orbits(object):
                         # One object is missing a required attribute
                         return False
                     checks.append(check)
-                    item_check.append(item)
+                    key_check.append(key)
+
             else:
                 checks.append(False)
-                item_check.append(item)
+                key_check.append(key)
                 return False
 
-        # Confirm that other doesn't have extra terms
-        for item in other.__dict__:
-            if item not in self.__dict__:
+        # Confirm that Orbits object `other` doesn't have extra terms
+        for key in other.__dict__.keys():
+            if key not in self.__dict__:
                 return False
 
         test_data = np.all(checks)

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -188,7 +188,7 @@ class Orbits(object):
                     test = np.all(self.__dict__[item] == other.__dict__[item])
                     checks.append(test)
                     item_check.append(item)
-                elif item in ['full_day_data']:
+                elif item in ['_full_day_data']:
                     # Compare data
                     if isinstance(self.__dict__[item], pds.DataFrame):
                         try:
@@ -198,10 +198,9 @@ class Orbits(object):
                                            == other.__dict__[item])
                         except ValueError:
                             # If there is an error they aren't the same
-                            check = False
+                            return False
                         checks.append(check)
                         item_check.append(item)
-
                     else:
                         # xarray comparison
                         test = xr.Dataset.equals(self.__dict__[item],
@@ -210,14 +209,24 @@ class Orbits(object):
                         item_check.append(item)
                 elif item == '_det_breaks':
                     # Equality of partial functions does not work well.
-                    # Using a string comparison instead.
-                    check = str(self._det_breaks) == str(other._det_breaks)
+                    # Using a string comparison instead. This can also break
+                    # if one of the objects is missing some attributes.
+                    try:
+                        check = str(self._det_breaks) == str(other._det_breaks)
+                    except AttributeError:
+                        # One object is missing a required attribute
+                        return False
                     checks.append(check)
                     item_check.append(item)
             else:
                 checks.append(False)
                 item_check.append(item)
-                break
+                return False
+
+        # Confirm that other doesn't have extra terms
+        for item in other.__dict__:
+            if item not in self.__dict__:
+                return False
 
         test_data = np.all(checks)
 

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -173,6 +173,7 @@ class Orbits(object):
 
         """
 
+        # Check if other is the same class (Orbits). Exit early if not.
         if not isinstance(other, self.__class__):
             return False
 

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -10,6 +10,7 @@ import functools
 import numpy as np
 import pandas as pds
 import xarray as xr
+import weakref
 
 from pysat import logger
 
@@ -106,7 +107,7 @@ class Orbits(object):
     def __init__(self, inst, index=None, kind='local time', period=None):
 
         # Set the class attributes
-        self.inst = inst  # In the past weakref was used to create a proxy
+        self.inst = weakref.proxy(inst)
         self.kind = kind.lower()
 
         if period is None:

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -169,7 +169,7 @@ class Orbits(object):
         Returns
         -------
         bool
-            True if objects are identical
+            True if objects are identical, False if they are not
 
         """
 

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -176,6 +176,8 @@ class Orbits(object):
         if not isinstance(other, self.__class__):
             return False
 
+        # If the type is the same then check everything that is attached to
+        # the Orbits object. Includes attributes, methods, variables, etc.
         checks = []
         key_check = []
         for key in self.__dict__.keys():

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -179,7 +179,7 @@ class Orbits(object):
         checks = []
         key_check = []
         for key in self.__dict__.keys():
-            if key in other.__dict__:
+            if key in other.__dict__.keys():
                 # partial function comparisons (_det_breaks), data
                 # objects (_full_daya_data), and the pysat.Instrument ref
                 # require different treatment.
@@ -231,7 +231,7 @@ class Orbits(object):
 
         # Confirm that Orbits object `other` doesn't have extra terms
         for key in other.__dict__.keys():
-            if key not in self.__dict__:
+            if key not in self.__dict__.keys():
                 return False
 
         test_data = np.all(checks)

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -1,5 +1,4 @@
 import datetime as dt
-import functools
 import numpy as np
 import os
 import pandas as pds

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -17,7 +17,7 @@ with pysat.utils.NetworkLock(os.path.join(pysat.here, 'citation.txt'), 'r') as \
     refs = locked_file.read()
 
 
-def init(self, test_init_kwrd=None):
+def init(self, test_init_kwarg=None):
     """Initializes the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
@@ -32,7 +32,7 @@ def init(self, test_init_kwrd=None):
     ----------
     self : pysat.Instrument
         This object
-    test_init_kwrd : any or NoneType
+    test_init_kwarg : any or NoneType
         Testing keyword (default=None)
 
     """
@@ -43,30 +43,30 @@ def init(self, test_init_kwrd=None):
 
     # Assign parameters for testing purposes
     self.new_thing = True
-    self.test_init_kwrd = test_init_kwrd
+    self.test_init_kwarg = test_init_kwarg
 
     return
 
 
-def clean(self, test_clean_kwrd=None):
+def clean(self, test_clean_kwarg=None):
     """Cleaning function
 
     Parameters
     ----------
     self : pysat.Instrument
         This object
-    test_clean_kwrd : any or NoneType
+    test_clean_kwarg : any or NoneType
         Testing keyword (default=None)
 
     """
 
-    self.test_clean_kwrd = test_clean_kwrd
+    self.test_clean_kwarg = test_clean_kwarg
 
     return
 
 
 # Optional method
-def preprocess(self, test_preprocess_kwrd=None):
+def preprocess(self, test_preprocess_kwarg=None):
     """Customization method that performs standard preprocessing.
 
     This routine is automatically applied to the Instrument object
@@ -77,19 +77,19 @@ def preprocess(self, test_preprocess_kwrd=None):
     ----------
     self : pysat.Instrument
         This object
-    test_preprocess_kwrd : any or NoneType
+    test_preprocess_kwarg : any or NoneType
         Testing keyword (default=None)
 
     """
 
-    self.test_preprocess_kwrd = test_preprocess_kwrd
+    self.test_preprocess_kwarg = test_preprocess_kwarg
 
     return
 
 
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
                file_date_range=None, test_dates=None, mangle_file_dates=False,
-               test_list_files_kwrd=None):
+               test_list_files_kwarg=None):
     """Produce a fake list of files spanning three years
 
     Parameters
@@ -112,7 +112,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         Pass the _test_date object through from the test instrument files
     mangle_file_dates : bool
         If True, file dates are shifted by 5 minutes. (default=False)
-    test_list_files_kwrd : any or NoneType
+    test_list_files_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -122,8 +122,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_list_files_kwrd = ',
-                         str(test_list_files_kwrd))))
+    logger.info(''.join(('test_list_files_kwarg = ',
+                         str(test_list_files_kwarg))))
 
     if data_path is None:
         data_path = ''
@@ -151,7 +151,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
                       start=None, stop=None, test_dates=None, user=None,
                       password=None, mangle_file_dates=False,
-                      test_list_remote_kwrd=None):
+                      test_list_remote_kwarg=None):
     """Produce a fake list of files spanning three years and one month to
     simulate new data files on a remote server
 
@@ -183,7 +183,7 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
         Password for data download. (default=None)
     mangle_file_dates : bool
         If True, file dates are shifted by 5 minutes. (default=False)
-    test_list_remote_kwrd : any or NoneType
+    test_list_remote_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -194,8 +194,8 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_list_remote_kwrd = ',
-                         str(test_list_remote_kwrd))))
+    logger.info(''.join(('test_list_remote_kwarg = ',
+                         str(test_list_remote_kwarg))))
 
     # Determine the appropriate date range for the fake files
     if start is None:
@@ -214,7 +214,7 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
 
 def download(date_array, tag, inst_id, data_path=None, user=None,
-             password=None, test_download_kwrd=None):
+             password=None, test_download_kwarg=None):
     """Simple pass function for pysat compatibility for test instruments.
 
     This routine is invoked by pysat and is not intended for direct use by the
@@ -239,7 +239,7 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
         error if user not supplied. (default=None)
     password : string or NoneType
         Password for data download. (default=None)
-    test_download_kwrd : any or NoneType
+    test_download_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Raises
@@ -254,7 +254,7 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_download_kwrd = ', str(test_download_kwrd))))
+    logger.info(''.join(('test_download_kwarg = ', str(test_download_kwarg))))
 
     if tag == 'no_download':
         warnings.warn('This simulates an instrument without download support')

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -96,7 +96,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     ----------
     tag : str or NoneType
         pysat instrument tag (default=None)
-    inst_id : str
+    inst_id : str or NoneType
         pysat satellite ID tag (default=None)
     data_path : str or NoneType
         pysat data path (default=None)
@@ -108,7 +108,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
         through below.  Otherwise, accepts a range of files specified by the
         user.
         (default=None)
-    test_dates : dt.datetime
+    test_dates : dt.datetime or NoneType
         Pass the _test_date object through from the test instrument files
     mangle_file_dates : bool
         If True, file dates are shifted by 5 minutes. (default=False)
@@ -157,13 +157,13 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
     Parameters
     ----------
-    tag : str
+    tag : str or NoneType
         pysat instrument tag (default=None)
-    inst_id : str
+    inst_id : str or NoneType
         pysat satellite ID tag (default=None)
-    data_path : str
+    data_path : str or NoneType
         pysat data path (default=None)
-    format_str : str
+    format_str : str or NoneType
         file format string (default=None)
     start : dt.datetime or NoneType
         Starting time for file list. A None value will start 1 year before
@@ -173,13 +173,13 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
         Ending time for the file list.  A None value will stop 2 years 1 month
         after test_date
         (default=None)
-    test_dates : dt.datetime
+    test_dates : dt.datetime or NoneType
         Pass the _test_date object through from the test instrument files
-    user : string
+    user : string or NoneType
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
         error if user not supplied. (default=None)
-    password : string
+    password : string or NoneType
         Password for data download. (default=None)
     mangle_file_dates : bool
         If True, file dates are shifted by 5 minutes. (default=False)
@@ -231,13 +231,13 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
     inst_id : string
         Instrument ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
-    data_path : string
+    data_path : string or NoneType
         Path to directory to download data to. (default=None)
-    user : string
+    user : string or NoneType
         User string input used for download. Provided by user and passed via
-        pysat. If an account is required for dowloads this routine here must
+        pysat. If an account is required for downloads this routine here must
         error if user not supplied. (default=None)
-    password : string
+    password : string or NoneType
         Password for data download. (default=None)
     test_download_kwrd : any or NoneType
         Testing keyword (default=None)

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -151,7 +151,8 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
 def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
                       start=None, stop=None, test_dates=None, user=None,
-                      password=None, test_list_remote_kwrd=None):
+                      password=None, mangle_file_dates=False,
+                      test_list_remote_kwrd=None):
     """Produce a fake list of files spanning three years and one month to
     simulate new data files on a remote server
 
@@ -181,6 +182,8 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
         error if user not supplied. (default=None)
     password : string
         Password for data download. (default=None)
+    mangle_file_dates : bool
+        If True, file dates are shifted by 5 minutes. (default=False)
     test_list_remote_kwrd : any or NoneType
         Testing keyword (default=None)
 
@@ -207,6 +210,7 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
     return list_files(tag=tag, inst_id=inst_id, data_path=data_path,
                       format_str=format_str, file_date_range=file_date_range,
+                      mangle_file_dates=mangle_file_dates,
                       test_dates=test_dates)
 
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -47,7 +47,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, malformed_index=False,
-         num_samples=None, test_load_kwrd=None):
+         num_samples=None, test_load_kwarg=None):
     """ Loads the test files
 
     Parameters
@@ -72,7 +72,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         If True, time index will be non-unique and non-monotonic (default=False)
     num_samples : int
         Number of samples per day
-    test_load_kwrd : any or NoneType
+    test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -85,7 +85,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_load_kwrd = ', str(test_load_kwrd))))
+    logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
     # create an artificial satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -34,7 +34,7 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         num_samples=None, test_load_kwrd=None):
+         num_samples=None, test_load_kwarg=None):
     """ Loads the test files
 
     Parameters
@@ -50,7 +50,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         (default=False)
     num_samples : int
         Number of samples
-    test_load_kwrd : any or NoneType
+    test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -63,7 +63,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_load_kwrd = ', str(test_load_kwrd))))
+    logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
     # create an artifical satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -40,7 +40,7 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         num_samples=None, test_load_kwrd=None):
+         num_samples=None, test_load_kwarg=None):
     """ Loads the test files
 
     Parameters
@@ -55,7 +55,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         If True, the time index will be non-unique and non-monotonic.
     num_samples : int
         Number of samples
-    test_load_kwrd : any or NoneType
+    test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -68,7 +68,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_load_kwrd = ', str(test_load_kwrd))))
+    logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
     # create an artifical satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -41,7 +41,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, malformed_index=False,
-         num_samples=None, test_load_kwrd=None):
+         num_samples=None, test_load_kwarg=None):
     """ Loads the test files
 
     Parameters
@@ -62,7 +62,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         If True, time index will be non-unique and non-monotonic.
     num_samples : int
         Number of samples
-    test_load_kwrd : any or NoneType
+    test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -75,7 +75,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_load_kwrd = ', str(test_load_kwrd))))
+    logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
     # create an artifical satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -34,7 +34,7 @@ clean = mm_test.clean
 preprocess = mm_test.preprocess
 
 
-def load(fnames, tag=None, inst_id=None, num_samples=None, test_load_kwrd=None):
+def load(fnames, tag=None, inst_id=None, num_samples=None, test_load_kwarg=None):
     """ Loads the test files
 
     Parameters
@@ -47,7 +47,7 @@ def load(fnames, tag=None, inst_id=None, num_samples=None, test_load_kwrd=None):
         Instrument satellite ID (accepts '')
     num_samples : int
         Number of samples
-    test_load_kwrd : any or NoneType
+    test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
     Returns
@@ -60,7 +60,7 @@ def load(fnames, tag=None, inst_id=None, num_samples=None, test_load_kwrd=None):
     """
 
     # Support keyword testing
-    logger.info(''.join(('test_load_kwrd = ', str(test_load_kwrd))))
+    logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
     if num_samples is None:
         # Default to 1 day at a frequency of 900S

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -34,7 +34,8 @@ clean = mm_test.clean
 preprocess = mm_test.preprocess
 
 
-def load(fnames, tag=None, inst_id=None, num_samples=None, test_load_kwarg=None):
+def load(fnames, tag=None, inst_id=None, num_samples=None,
+         test_load_kwarg=None):
     """ Loads the test files
 
     Parameters

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -243,7 +243,7 @@ class TestBasics():
         """Test that equality is false if self missing attributes"""
         self.out = self.testInst.files.copy()
         self.out.hi_there = 'hi'
-        assert  self.testInst.files != self.out
+        assert self.testInst.files != self.out
 
     def test_inequality_different_data(self):
         """Test that equality is false if different data"""

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -227,7 +227,7 @@ class TestBasics():
         self.out = self.testInst.files.copy()
         assert self.out == self.testInst.files
 
-    def test_equality_with_copy(self):
+    def test_equality_with_copy_with_data(self):
         """Test that copy is the same as original, loaded inst.data"""
         self.testInst.load(date=self.start)
         self.out = self.testInst.files.copy()

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -201,17 +201,29 @@ class TestBasics():
         self.out = self.testInst.files.__repr__()
         assert isinstance(self.out, str)
         assert self.out.find("pysat.Files(") >= 0
+        return
 
     def test_eval_repr(self):
         """Test eval of repr recreates object"""
+        # Evaluate __repr__ string
         self.out = eval(self.testInst.files.__repr__())
+
+        # Confirm new Instrument equal to original
         assert self.out == self.testInst.files
+        return
 
     def test_eval_repr_and_copy(self):
         """Test eval of repr consistent with object copy"""
+        # Evaluate __repr__ string
         self.out = eval(self.testInst.files.__repr__())
+
+        # Get copy of original object
         second_out = self.testInst.files.copy()
+
+        # Confirm new object equal to copy
         assert self.out == second_out
+
+        return
 
     def test_basic_str(self):
         """Check for lines from each decision point in str"""
@@ -223,45 +235,66 @@ class TestBasics():
 
         # Test no files
         assert self.out.find('Date Range') > 0
+        return
 
     def test_equality_with_copy(self):
         """Test that copy is the same as original"""
+        # Create copy
         self.out = self.testInst.files.copy()
+
+        # Confirm equal to original
         assert self.out == self.testInst.files
+        return
 
     def test_equality_with_copy_with_data(self):
         """Test that copy is the same as original, loaded inst.data"""
+        # Load data
         self.testInst.load(date=self.start)
+
+        # Make copy
         self.out = self.testInst.files.copy()
+
+        # Test for equality
         assert self.out == self.testInst.files
+        return
 
     def test_inequality_modified_object(self):
         """Test that equality is false if other missing attributes"""
+        # Copy files class
         self.out = self.testInst.files.copy()
+
+        # Remove attribute
         del self.out.start_date
+
+        # Confirm not equal
         assert self.testInst.files != self.out
+        return
 
     def test_inequality_reduced_object(self):
         """Test that equality is false if self missing attributes"""
         self.out = self.testInst.files.copy()
         self.out.hi_there = 'hi'
         assert self.testInst.files != self.out
+        return
 
     def test_inequality_different_data(self):
         """Test that equality is false if different data"""
         self.out = self.testInst.files.copy()
         self.out.files = pds.Series()
         assert self.out != self.testInst.files
+        return
 
     def test_inequality_different_type(self):
         """Test that equality is false if different type"""
         assert self.testInst.files != self.testInst
+        return
 
     def test_from_os_requires_data_path(self):
         """Check that path required for from_os"""
         with pytest.raises(ValueError) as war:
             self.testInst.files.from_os()
         assert str(war).find('Must supply instrument') > 0
+        return
 
     def test_year_doy_files_directly_call_from_os(self):
         """Check that Files.from_os generates file list"""

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -217,8 +217,10 @@ class TestBasics():
         """Check for lines from each decision point in str"""
         self.out = self.testInst.files.__str__()
         assert isinstance(self.out, str)
+
         # Test basic file output
         assert self.out.find('Number of files') > 0
+
         # Test no files
         assert self.out.find('Date Range') > 0
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -227,6 +227,24 @@ class TestBasics():
         self.out = self.testInst.files.copy()
         assert self.out == self.testInst.files
 
+    def test_equality_with_copy(self):
+        """Test that copy is the same as original, loaded inst.data"""
+        self.testInst.load(date=self.start)
+        self.out = self.testInst.files.copy()
+        assert self.out == self.testInst.files
+
+    def test_inequality_modified_object(self):
+        """Test that equality is false if other missing attributes"""
+        self.out = self.testInst.files.copy()
+        del self.out.start_date
+        assert self.testInst.files != self.out
+
+    def test_inequality_reduced_object(self):
+        """Test that equality is false if self missing attributes"""
+        self.out = self.testInst.files.copy()
+        self.out.hi_there = 'hi'
+        assert  self.testInst.files != self.out
+
     def test_inequality_different_data(self):
         """Test that equality is false if different data"""
         self.out = self.testInst.files.copy()

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -20,11 +20,11 @@ from pysat.utils.time import filter_datetime_input
 xarray_epoch_name = 'time'
 
 testing_kwargs = {'test_init_kwarg': True, 'test_clean_kwarg': False,
-                 'test_preprocess_kwarg': 'test_phrase',
-                 'test_load_kwarg': 'bright_light',
-                 'test_list_files_kwarg': 'sleep_tight',
-                 'test_list_remote_kwarg': 'one_eye_open',
-                 'test_download_kwarg': 'exit_night'}
+                  'test_preprocess_kwarg': 'test_phrase',
+                  'test_load_kwarg': 'bright_light',
+                  'test_list_files_kwarg': 'sleep_tight',
+                  'test_list_remote_kwarg': 'one_eye_open',
+                  'test_download_kwarg': 'exit_night'}
 
 
 # -----------------------------------------------------------------------------

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2578,31 +2578,6 @@ class TestBasicsXarray(TestBasics):
 # Repeat tests above with 2d data
 #
 # -----------------------------------------------------------------------------
-class TestBasicsXarray(TestBasics):
-    def setup(self):
-        global testing_kwrds
-        reload(pysat.instruments.pysat_testing_xarray)
-        """Runs before every method to create a clean testing setup."""
-        self.testInst = pysat.Instrument(platform='pysat',
-                                         name='testing_xarray',
-                                         num_samples=10,
-                                         clean_level='clean',
-                                         update_files=True,
-                                         **testing_kwrds)
-        self.ref_time = dt.datetime(2009, 1, 1)
-        self.ref_doy = 1
-        self.out = None
-
-    def teardown(self):
-        """Runs after every method to clean up previous testing."""
-        del self.testInst, self.out, self.ref_time, self.ref_doy
-
-
-# -----------------------------------------------------------------------------
-#
-# Repeat tests above with 2d data
-#
-# -----------------------------------------------------------------------------
 class TestBasics2D(TestBasics):
     def setup(self):
         global testing_kwrds

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -712,6 +712,7 @@ class TestBasics():
         assert inst_copy == self.testInst
         assert inst_copy.inst_module == pysat.instruments.pysat_testing
         assert self.testInst.inst_module == pysat.instruments.pysat_testing
+
         return
 
     # -------------------------------------------------------------------------

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -669,6 +669,15 @@ class TestBasics():
         assert inst_copy == self.testInst
         return
 
+    def test_copy_from_reference(self):
+        """Test .copy() if a user invokes from a weakref.proxy of Instrument"""
+        inst_copy = self.testInst.orbits.inst.copy()
+        inst_copy2 = self.testInst.files.inst_info['inst'].copy()
+        assert inst_copy == self.testInst
+        assert inst_copy == inst_copy2
+        assert inst_copy2 == self.testInst
+        return
+
     def test_copy_w_inst_module(self):
         """Test .copy() with inst_module != None"""
         # Assign module to inst_module

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -19,12 +19,12 @@ from pysat.utils.time import filter_datetime_input
 
 xarray_epoch_name = 'time'
 
-testing_kwrds = {'test_init_kwrd': True, 'test_clean_kwrd': False,
-                 'test_preprocess_kwrd': 'test_phrase',
-                 'test_load_kwrd': 'bright_light',
-                 'test_list_files_kwrd': 'sleep_tight',
-                 'test_list_remote_kwrd': 'one_eye_open',
-                 'test_download_kwrd': 'exit_night'}
+testing_kwargs = {'test_init_kwarg': True, 'test_clean_kwarg': False,
+                 'test_preprocess_kwarg': 'test_phrase',
+                 'test_load_kwarg': 'bright_light',
+                 'test_list_files_kwarg': 'sleep_tight',
+                 'test_list_remote_kwarg': 'one_eye_open',
+                 'test_download_kwarg': 'exit_night'}
 
 
 # -----------------------------------------------------------------------------
@@ -34,14 +34,14 @@ testing_kwrds = {'test_init_kwrd': True, 'test_clean_kwrd': False,
 # -----------------------------------------------------------------------------
 class TestBasics():
     def setup(self):
-        global testing_kwrds
+        global testing_kwargs
         reload(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
-                                         **testing_kwrds)
+                                         **testing_kwargs)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         self.out = None
@@ -971,12 +971,12 @@ class TestBasics():
     # test instrument initialization keyword mapping to instrument functions
     #
     # -------------------------------------------------------------------------
-    @pytest.mark.parametrize("func, kwarg, val", [('init', 'test_init_kwrd',
+    @pytest.mark.parametrize("func, kwarg, val", [('init', 'test_init_kwarg',
                                                    True),
-                                                  ('clean', 'test_clean_kwrd',
+                                                  ('clean', 'test_clean_kwarg',
                                                    False),
                                                   ('preprocess',
-                                                   'test_preprocess_kwrd',
+                                                   'test_preprocess_kwarg',
                                                    'test_phrase')])
     def test_instrument_function_keywords(self, func, kwarg, val):
         """Test if Instrument function keywords are registered by pysat"""
@@ -987,9 +987,9 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("func, kwarg", [('clean', 'test_clean_kwrd'),
+    @pytest.mark.parametrize("func, kwarg", [('clean', 'test_clean_kwarg'),
                                              ('preprocess',
-                                              'test_preprocess_kwrd')])
+                                              'test_preprocess_kwarg')])
     def test_instrument_function_keyword_liveness(self, func, kwarg):
         """Test if changed keywords are propagated by pysat to functions"""
 
@@ -1000,16 +1000,16 @@ class TestBasics():
 
         return
 
-    @pytest.mark.parametrize("func, kwarg, val", [('load', 'test_load_kwrd',
+    @pytest.mark.parametrize("func, kwarg, val", [('load', 'test_load_kwarg',
                                                    'bright_light'),
                                                   ('list_files',
-                                                   'test_list_files_kwrd',
+                                                   'test_list_files_kwarg',
                                                    'sleep_tight'),
                                                   ('list_remote_files',
-                                                   'test_list_remote_kwrd',
+                                                   'test_list_remote_kwarg',
                                                    'one_eye_open'),
                                                   ('download',
-                                                   'test_download_kwrd',
+                                                   'test_download_kwarg',
                                                    'exit_night')
                                                   ])
     def test_instrument_partial_function_keywords(self, func, kwarg, val,
@@ -1041,18 +1041,18 @@ class TestBasics():
         return
 
     @pytest.mark.parametrize("func, kwarg, cflag", [('load',
-                                                     'test_load_kwrd', False),
+                                                     'test_load_kwarg', False),
                                                     ('list_files',
-                                                     'test_list_files_kwrd',
+                                                     'test_list_files_kwarg',
                                                      False),
                                                     ('list_files',
-                                                     'test_list_files_kwrd',
+                                                     'test_list_files_kwarg',
                                                      True),
                                                     ('list_remote_files',
-                                                     'test_list_remote_kwrd',
+                                                     'test_list_remote_kwarg',
                                                      False),
                                                     ('download',
-                                                     'test_download_kwrd',
+                                                     'test_download_kwarg',
                                                      False)])
     def test_instrument_partial_keywords_liveness(self, func, kwarg, cflag,
                                                   caplog):
@@ -2599,7 +2599,7 @@ class TestBasics():
 # -----------------------------------------------------------------------------
 class TestBasicsInstModule(TestBasics):
     def setup(self):
-        global testing_kwrds
+        global testing_kwargs
         reload(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
         imod = pysat.instruments.pysat_testing
@@ -2607,7 +2607,7 @@ class TestBasicsInstModule(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
-                                         **testing_kwrds)
+                                         **testing_kwargs)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         self.out = None
@@ -2624,7 +2624,7 @@ class TestBasicsInstModule(TestBasics):
 # -----------------------------------------------------------------------------
 class TestBasicsXarray(TestBasics):
     def setup(self):
-        global testing_kwrds
+        global testing_kwargs
         reload(pysat.instruments.pysat_testing_xarray)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat',
@@ -2632,7 +2632,7 @@ class TestBasicsXarray(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
-                                         **testing_kwrds)
+                                         **testing_kwargs)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         self.out = None
@@ -2649,14 +2649,14 @@ class TestBasicsXarray(TestBasics):
 # -----------------------------------------------------------------------------
 class TestBasics2D(TestBasics):
     def setup(self):
-        global testing_kwrds
+        global testing_kwargs
         reload(pysat.instruments.pysat_testing2d)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing2d',
                                          num_samples=50,
                                          clean_level='clean',
                                          update_files=True,
-                                         **testing_kwrds)
+                                         **testing_kwargs)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         self.out = None
@@ -2673,7 +2673,7 @@ class TestBasics2D(TestBasics):
 # -----------------------------------------------------------------------------
 class TestBasics2DXarray(TestBasics):
     def setup(self):
-        global testing_kwrds
+        global testing_kwargs
         reload(pysat.instruments.pysat_testing2d_xarray)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat',
@@ -2681,7 +2681,7 @@ class TestBasics2DXarray(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
-                                         **testing_kwrds)
+                                         **testing_kwargs)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         self.out = None
@@ -2756,7 +2756,7 @@ class TestBasics2DXarray(TestBasics):
 
 class TestBasicsShiftedFileDates(TestBasics):
     def setup(self):
-        global testing_kwrds
+        global testing_kwargs
         reload(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
@@ -2765,7 +2765,7 @@ class TestBasicsShiftedFileDates(TestBasics):
                                          update_files=True,
                                          mangle_file_dates=True,
                                          strict_time_flag=True,
-                                         **testing_kwrds)
+                                         **testing_kwargs)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         self.out = None

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -614,12 +614,14 @@ class TestBasics():
         """Test equality when the same object"""
         inst_copy = self.testInst.copy()
         assert inst_copy == self.testInst
+        return
 
     def test_eq_both_with_data(self):
         """Test equality when the same object with loaded data"""
         self.testInst.load(date=self.ref_time)
         inst_copy = self.testInst.copy()
         assert inst_copy == self.testInst
+        return
 
     def test_eq_one_with_data(self):
         """Test equality when the same objects but only one with loaded data"""
@@ -627,6 +629,7 @@ class TestBasics():
         inst_copy = self.testInst.copy()
         inst_copy.data = self.testInst._null_data
         assert not (inst_copy == self.testInst)
+        return
 
     def test_eq_different_data_type(self):
         """Test equality different data type"""
@@ -639,6 +642,7 @@ class TestBasics():
             inst_copy.pandas_format = True
             inst_copy.data = pds.DataFrame()
         assert not (inst_copy == self.testInst)
+        return
 
     def test_eq_different_object(self):
         """Test equality using different pysat.Instrument objects"""
@@ -652,23 +656,29 @@ class TestBasics():
                                 num_samples=10, clean_level='clean',
                                 update_files=True)
         assert not (obj1 == obj2)
+        return
 
     def test_eq_different_type(self):
         """Test equality False when non-Instrument object"""
         assert self.testInst != np.array([])
+        return
 
     def test_inequality_modified_object(self):
         """Test that equality is false if other missing attributes"""
         self.out = self.testInst.copy()
+
         # Remove attribute
         del self.out.platform
+
         assert self.testInst != self.out
+        return
 
     def test_inequality_reduced_object(self):
         """Test that equality is false if self missing attributes"""
         self.out = self.testInst.copy()
         self.out.hi_there = 'hi'
         assert self.testInst != self.out
+        return
 
     # -------------------------------------------------------------------------
     #

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -486,19 +486,20 @@ class TestBasics():
         assert isinstance(files, pds.Series)
 
     def test_remote_file_list(self):
+        """Test remote_file_list for valid list of files"""
         stop = self.ref_time + dt.timedelta(days=30)
         self.out = self.testInst.remote_file_list(start=self.ref_time,
                                                   stop=stop)
-        assert self.out.index[0] == self.ref_time
-        assert self.out.index[-1] == stop
+        assert filter_datetime_input(self.out.index[0]) == self.ref_time
+        assert filter_datetime_input(self.out.index[-1]) == stop
 
     def test_remote_date_range(self):
         stop = self.ref_time + dt.timedelta(days=30)
         self.out = self.testInst.remote_date_range(start=self.ref_time,
                                                    stop=stop)
         assert len(self.out) == 2
-        assert self.out[0] == self.ref_time
-        assert self.out[-1] == stop
+        assert filter_datetime_input(self.out[0]) == self.ref_time
+        assert filter_datetime_input(self.out[-1]) == stop
 
     @pytest.mark.parametrize("file_bounds, non_default",
                              [(False, False), (True, False), (False, True),
@@ -2550,6 +2551,31 @@ class TestBasicsInstModule(TestBasics):
 # -----------------------------------------------------------------------------
 #
 # Repeat tests above with xarray data
+#
+# -----------------------------------------------------------------------------
+class TestBasicsXarray(TestBasics):
+    def setup(self):
+        global testing_kwrds
+        reload(pysat.instruments.pysat_testing_xarray)
+        """Runs before every method to create a clean testing setup."""
+        self.testInst = pysat.Instrument(platform='pysat',
+                                         name='testing_xarray',
+                                         num_samples=10,
+                                         clean_level='clean',
+                                         update_files=True,
+                                         **testing_kwrds)
+        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_doy = 1
+        self.out = None
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.testInst, self.out, self.ref_time, self.ref_doy
+
+
+# -----------------------------------------------------------------------------
+#
+# Repeat tests above with 2d data
 #
 # -----------------------------------------------------------------------------
 class TestBasicsXarray(TestBasics):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1837,11 +1837,9 @@ class TestBasics():
 
     def test_iterate_over_default_bounds(self):
         """Test iterating over default bounds"""
-        from pandas import DatetimeIndex
         date_range = pds.date_range(self.ref_time,
                                     self.ref_time + dt.timedelta(days=10))
         self.testInst.kwargs['list_files']['file_date_range'] = date_range
-        # self.testInst = eval(self.testInst.__repr__())
         self.testInst.files.refresh()
         self.testInst.bounds = (None, None)
         dates = []

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -657,6 +657,19 @@ class TestBasics():
         """Test equality False when non-Instrument object"""
         assert self.testInst != np.array([])
 
+    def test_inequality_modified_object(self):
+        """Test that equality is false if other missing attributes"""
+        self.out = self.testInst.copy()
+        # Remove attribute
+        del self.out.platform
+        assert self.testInst != self.out
+
+    def test_inequality_reduced_object(self):
+        """Test that equality is false if self missing attributes"""
+        self.out = self.testInst.copy()
+        self.out.hi_there = 'hi'
+        assert self.testInst != self.out
+
     # -------------------------------------------------------------------------
     #
     # Test copy method

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1016,20 +1016,15 @@ class TestBasics():
                                                   caplog):
         """Test if init keywords (partial funcs) are registered by pysat"""
         # Test for file_date_range keyword
-        saved_level = pysat.logger.level
-        pysat.logger.setLevel(1)
-        caplog.set_level(logging.INFO)
-
-        try:
+        with caplog.at_level(logging.INFO, logger='pysat'):
             # Load data to trigger some functions
             self.testInst.load(date=self.ref_time)
+
             # Refresh files to trigger other functions
             self.testInst.files.refresh()
+
             # Get remote file list
             self.testInst.download_updated_files()
-        finally:
-            # Ensure logging level reset
-            pysat.logger.setLevel(saved_level)
 
         captured = caplog.text
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1036,12 +1036,7 @@ class TestBasics():
         captured = caplog.text
 
         test_str = ''.join((kwarg, ' = ', 'live_value'))
-        if func != 'list_files':
-            assert captured.find(test_str) >= 0
-        else:
-            # list_files is not live given that method is used at the Files
-            # class.
-            assert captured.find(test_str) < 0
+        assert captured.find(test_str) >= 0
         return
 
     def test_error_undefined_input_keywords(self):
@@ -1846,7 +1841,8 @@ class TestBasics():
         date_range = pds.date_range(self.ref_time,
                                     self.ref_time + dt.timedelta(days=10))
         self.testInst.kwargs['list_files']['file_date_range'] = date_range
-        self.testInst = eval(self.testInst.__repr__())
+        # self.testInst = eval(self.testInst.__repr__())
+        self.testInst.files.refresh()
         self.testInst.bounds = (None, None)
         dates = []
         for inst in self.testInst:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1119,8 +1119,8 @@ class TestBasics():
 
         # Confirm all user provided keywords are in the supported keywords
         for func in funcs:
-            for kwrd in self.testInst.kwargs[func]:
-                assert kwrd in self.testInst.kwargs_supported[func]
+            for kwarg in self.testInst.kwargs[func]:
+                assert kwarg in self.testInst.kwargs_supported[func]
 
         return
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1071,6 +1071,25 @@ class TestBasics():
                         " 'undefined_keyword2']"))
         assert str(err).find(estr) >= 0
 
+    def test_supported_input_keywords(self):
+        """Test that supported keywords exist"""
+
+        funcs = ['load', 'init', 'list_remote_files', 'list_files', 'download',
+                 'preprocess', 'clean']
+
+        # Test instruments all have a supported keyword. Ensure keyword
+        # present for all functions.
+        for func in funcs:
+            assert func in self.testInst.kwargs_supported
+            assert len(self.testInst.kwargs_supported[func]) > 0
+
+        # Confirm all user provided keywords are in the supported keywords
+        for func in funcs:
+            for kwrd in self.testInst.kwargs[func]:
+                assert kwrd in self.testInst.kwargs_supported[func]
+
+        return
+
     # -------------------------------------------------------------------------
     #
     # Test basic data access features, both getting and setting data

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -3,7 +3,7 @@ from dateutil.relativedelta import relativedelta
 import numpy as np
 
 import pandas as pds
-from pandas import Timedelta
+from pandas import Timedelta # noqa
 import pytest
 
 import pysat

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -3,8 +3,10 @@ from dateutil.relativedelta import relativedelta
 import numpy as np
 
 import pandas as pds
-# Import below is needed for tests on __repr__
-from pandas import Timedelta # noqa
+# Orbits period is a pandas.Timedelta kwarg, and the pandas repr
+# does not include a module name. Import required to run eval
+# on Orbit representation
+from pandas import Timedelta  # noqa: F401
 import pytest
 
 import pysat

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -236,53 +236,69 @@ class TestGeneralOrbitsMLT():
                                          orbit_info={'index': 'mlt'},
                                          update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
+        return
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
         del self.testInst, self.stime
+        return
 
     def test_equality_with_copy(self):
         """Test that copy is the same as original"""
         self.out = self.testInst.orbits.copy()
         assert self.out == self.testInst.orbits
+        return
 
     def test_equality_with_data_with_copy(self):
         """Test that copy is the same as original"""
         # Load data
         self.testInst.load(date=self.stime)
+
         # Load up an orbit
         self.testInst.orbits[0]
         self.out = self.testInst.orbits.copy()
+
         assert self.out == self.testInst.orbits
+        return
 
     def test_inequality_different_data(self):
         """Test that equality is false if different data"""
         # Load data
         self.testInst.load(date=self.stime)
+
         # Load up an orbit
         self.testInst.orbits[0]
+
         # Make copy
         self.out = self.testInst.orbits.copy()
+
         # Modify data
         self.out._full_day_data = self.testInst._null_data
+
         assert self.out != self.testInst.orbits
+        return
 
     def test_inequality_modified_object(self):
         """Test that equality is false if other missing attributes"""
         self.out = self.testInst.orbits.copy()
+
         # Remove attribute
         del self.out.orbit_index
+
         assert self.testInst.orbits != self.out
+        return
 
     def test_inequality_reduced_object(self):
         """Test that equality is false if self missing attributes"""
         self.out = self.testInst.orbits.copy()
         self.out.hi_there = 'hi'
         assert self.testInst.orbits != self.out
+        return
 
     def test_inequality_different_type(self):
         """Test that equality is false if different type"""
         assert self.testInst.orbits != self.testInst
+        return
 
     def test_eval_repr(self):
         """Test eval of repr recreates object"""
@@ -292,6 +308,7 @@ class TestGeneralOrbitsMLT():
 
         self.out = eval(self.testInst.orbits.__repr__())
         assert self.out == self.testInst.orbits
+        return
 
     def test_repr_and_copy(self):
         """Test repr consistent with object copy"""
@@ -299,6 +316,7 @@ class TestGeneralOrbitsMLT():
         self.out = self.testInst.orbits.__repr__()
         second_out = self.testInst.orbits.copy().__repr__()
         assert self.out == second_out
+        return
 
     def test_load_orbits_w_empty_data(self):
         """ Test orbit loading outside of the instrument data range

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -245,11 +245,39 @@ class TestGeneralOrbitsMLT():
         self.out = self.testInst.orbits.copy()
         assert self.out == self.testInst.orbits
 
+    def test_equality_with_data_with_copy(self):
+        """Test that copy is the same as original"""
+        # Load data
+        self.testInst.load(date=self.stime)
+        # Load up an orbit
+        self.testInst.orbits[0]
+        self.out = self.testInst.orbits.copy()
+        assert self.out == self.testInst.orbits
+
     def test_inequality_different_data(self):
         """Test that equality is false if different data"""
+        # Load data
+        self.testInst.load(date=self.stime)
+        # Load up an orbit
+        self.testInst.orbits[0]
+        # Make copy
         self.out = self.testInst.orbits.copy()
+        # Modify data
         self.out._full_day_data = self.testInst._null_data
         assert self.out != self.testInst.orbits
+
+    def test_inequality_modified_object(self):
+        """Test that equality is false if other missing attributes"""
+        self.out = self.testInst.orbits.copy()
+        # Remove attribute
+        del self.out.orbit_index
+        assert self.testInst.orbits != self.out
+
+    def test_inequality_reduced_object(self):
+        """Test that equality is false if self missing attributes"""
+        self.out = self.testInst.orbits.copy()
+        self.out.hi_there = 'hi'
+        assert self.testInst.orbits != self.out
 
     def test_inequality_different_type(self):
         """Test that equality is false if different type"""

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -3,6 +3,7 @@ from dateutil.relativedelta import relativedelta
 import numpy as np
 
 import pandas as pds
+# Import below is needed for tests on __repr__
 from pandas import Timedelta # noqa
 import pytest
 

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -100,26 +100,16 @@ class TestLonSLT():
     def test_calc_solar_local_time_inconsistent_keywords(self, name, caplog):
         """Test that ref_date only works when apply_modulus=False"""
 
-        # Prep to capture logging information
-        saved_level = pysat.logger.level
-        pysat.logger.setLevel(1)
-        caplog.set_level(logging.INFO)
-
         # Instantiate instrument and load data
         self.py_inst = pysat.Instrument(platform='pysat', name=name,
                                         num_samples=1)
         self.py_inst.load(date=self.inst_time)
-
-        try:
+        with caplog.at_level(logging.INFO, logger='pysat'):
             # Apply solar local time method
             coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
                                          slt_name='slt',
                                          ref_date=self.py_inst.date,
                                          apply_modulus=True)
-        finally:
-            # Ensure logging level reset
-            pysat.logger.setLevel(saved_level)
-
         captured = caplog.text
 
         # Confirm we have the correct informational message

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -43,7 +43,7 @@ class TestLonSLT():
         """Runs after every method to clean up previous testing."""
         self.py_inst = None
         self.inst_time = dt.datetime(2009, 1, 1)
-        self.inst_2_time = dt.datetime(2009, 1, 3)
+        self.inst_time_2 = dt.datetime(2009, 1, 3)
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
@@ -140,7 +140,7 @@ class TestLonSLT():
         """
 
         self.py_inst = pysat.Instrument(platform='pysat', name=name)
-        self.py_inst.load(date=self.inst_time, end_date=self.inst_2_time)
+        self.py_inst.load(date=self.inst_time, end_date=self.inst_time_2)
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
                                      slt_name='slt', apply_modulus=False)
 

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -11,6 +11,10 @@ import datetime as dt
 import numpy as np
 import pandas as pds
 
+import pysat
+
+logger = pysat.logger
+
 
 def adjust_cyclic_data(samples, high=(2.0 * np.pi), low=0.0):
     """Adjust cyclic values such as longitude to a different scale
@@ -111,8 +115,8 @@ def calc_solar_local_time(inst, lon_name=None, slt_name='slt',
         raise ValueError('unknown longitude variable name')
 
     if ref_date is not None and apply_modulus:
-        estr = 'Keyword `ref_date` only supported if `apply_modulus`=False.'
-        raise ValueError(estr)
+        istr = 'Keyword `ref_date` only supported if `apply_modulus`=False.'
+        logger.info(istr)
 
     if ref_date is None:
         # Use date information attached to Instrument object


### PR DESCRIPTION
# Description

Addresses SLT upgrade request in #723, bug in #728, and more!

 - Adds support to disable constraining SLT values to [0, 24). Variable is continuous when loading multiple days.
 -  Fixes .copy(). Extends .copy() and __eq__ across Instrument classes. Tests added. 
 - Tests with __repr__()
 - Expands general Instrument tests to Instruments instantiated via `inst_module`
 - Condenses methods used by pysat testing instruments. Adds support for keyword tests to all.
 - I would appreciate feedback on formatting support function docstrings in testing.py
 - Updates the initialization keyword argument process. 
   - Always an entry for each Instrument function.
   - 'partial' function keywords retained;  eval(__repr__()) would otherwise lose those keywords
   - Switch all keyword treatment over to 'partial'. All keywords, user provided at instantiation or not, were listed in self.kwargs. This lead to a difference between actual user input and the string provided by __repr__. In some situations, the string from __repr__ and the string from eval(__repr__).__repr__ would have keywords in a different order, frustrating string comparisons, and would produce an underlying difference in `self.kwargs`.
   - Added `inst.kwargs_supported`. Includes all supported keyword and default values.
   
   -  I also updated code to always pass in the kwargs for each function when run (except list_files). This ensure liveness, if a user tweaks inst.kwargs it will be reflected in outputs. list_files doesn't work since files runs that method and the weakef that was in files back to Instrument is now gone.
       - Should I update `Files` to include a full reference to Instrument as done in orbits? **UPDATE** I went ahead and put this in and updated the tests. It is now 'live' as well. I have a weakref back to inst contained within files.inst_info. Switched orbits back to weakref.proxy as well. Working fine so far.
 ```
In [2]: eval("pysat.Instrument(platform='pysat', name='testing', inst_id='', clean_level='clean', pad=None, orbit_info={'index': 'mlt'}, inst_module=None, custom=[], **{'sim_multi_file_right': False, 'sim_multi_file_left': False, 'root_date': None, 'malformed_index': False, 'num_samples': None, 'test_load_kwrd': None, 'file_date_range': None, 'mangle_file_dates': False, 'test_init_kwrd': None})")                        

Out[2]: pysat.Instrument(platform='pysat', name='testing', inst_id='', clean_level='clean', pad=None, orbit_info={'index': 'mlt'}, inst_module=None, custom=[], **{'file_date_range': None, 'sim_multi_file_right': False, 'sim_multi_file_left': False, 'root_date': None, 'malformed_index': False, 'num_samples': None, 'test_load_kwrd': None, 'mangle_file_dates': False, 'test_init_kwrd': None})
```

 - I was able to remove the need for modifying file lists from within `init` for the testing instruments
 - Updated tests, and fixed some bugs with `remote_file_list` and `download` related to `mangled_file_list'
 - Removed deprecated 'modify' keywords in orbits test code
 - Added check for NoneType within `to_netcdf4`

These changes may appear unrelated however the core, the SLT upgrade, plus the inst_module bug, are combined since this branch is currently being used by some local software that needs both. The remaining expansion of commits all came up as I was working on the core stuff.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Bug-fix

# How Has This Been Tested?

UnitTests plus plots!

# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
