### PR TITLE
DEP: use of numeric sat_id to specify number of points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
       - the pysatMadrigal: jro_isr, dmsp_ivm
       - the pysatSpaceWeather: sw_dst, sw_f107, sw_kp
       - the pysatModels: ucar_tiegcm
-   - Test instruments
-     - The usage of a numeric string for `sat_id` to specify number of points
+   - The usage of a numeric string for `sat_id` to specify number of points
+     in test instruments
    - SpaceWeather, Incubator (DEMETER), and Madrigal instrument method
 - Documentation
    - Updated docstrings with deprecation notes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
      `manual_org`, and `_filter_datetime_input`)
    - pysat.instruments.methods.general.list_files kwarg
      `fake_montly_files_from_daily`
+   - pysat.instruments.methods.testing.generate_times kwarg
+     `sat_id`
    - Constellation class kwarg `name`
    - Custom class
    - functions from `_files` class
@@ -21,6 +23,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
       - the pysatMadrigal: jro_isr, dmsp_ivm
       - the pysatSpaceWeather: sw_dst, sw_f107, sw_kp
       - the pysatModels: ucar_tiegcm
+   - Test instruments
+     - The usage of a numeric string for `sat_id` to specify number of points
    - SpaceWeather, Incubator (DEMETER), and Madrigal instrument method
 - Documentation
    - Updated docstrings with deprecation notes

--- a/pysat/constellations/test_diff_same.py
+++ b/pysat/constellations/test_diff_same.py
@@ -7,8 +7,8 @@ test instruments
 
 inst1 = pysat.Instrument('pysat', 'testing',
                          clean_level='clean',
-                         sat_id='6000')
+                         num_samples=6000)
 inst2 = pysat.Instrument('pysat', 'testing',
                          clean_level='clean',
-                         sat_id='6000')
+                         num_samples=6000)
 instruments = [inst1, inst2]

--- a/pysat/constellations/test_diff_similar.py
+++ b/pysat/constellations/test_diff_similar.py
@@ -8,8 +8,8 @@ instruments
 inst1 = pysat.Instrument('pysat', 'testing',
                          clean_level='clean',
                          tag='mlt_offset',
-                         sat_id='6000')
+                         num_samples=6000)
 inst2 = pysat.Instrument('pysat', 'testing',
                          clean_level='clean',
-                         sat_id='6000')
+                         num_samples=6000)
 instruments = [inst1, inst2]

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -130,6 +130,11 @@ def generate_fake_data(t0, num_array, period=5820, data_range=[0.0, 24.0],
 def generate_times(fnames, sat_id, freq='1S', num=None):
     """Construct list of times for simulated instruments
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num` keyword as an integer)
+
     Parameters
     ----------
     fnames : (list)
@@ -143,11 +148,6 @@ def generate_times(fnames, sat_id, freq='1S', num=None):
         [default : '1S']
     num : int or NoneType
         Number of times to generate
-
-    .. deprecated:: 2.3.0
-      The ability to use a numeric string as `sat_id` to specify the number
-      of data points has been removed from pysat in the 3.0.0 release and
-      will be replaced by the `num` keyword as an integer)
 
     Outputs
     -------

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -127,7 +127,7 @@ def generate_fake_data(t0, num_array, period=5820, data_range=[0.0, 24.0],
     return data
 
 
-def generate_times(fnames, sat_id, freq='1S'):
+def generate_times(fnames, sat_id, freq='1S', num=None):
     """Construct list of times for simulated instruments
 
     Parameters
@@ -168,8 +168,8 @@ def generate_times(fnames, sat_id, freq='1S'):
     # Create one day of data at desired frequency
     index = pds.date_range(start=date, end=date+pds.DateOffset(seconds=86399),
                            freq=freq)
-    # Allow numeric string to select first set of data
     try:
+        # Allow numeric string to select first set of data
         index = index[0:int(sat_id)]
         warnings.warn(' '.join(["The ability to use a numeric string as",
                                 "`sat_id` to specify the number of data points",
@@ -179,7 +179,9 @@ def generate_times(fnames, sat_id, freq='1S'):
                       DeprecationWarning, stacklevel=2)
     except ValueError:
         # non-integer sat_id produces ValueError
-        pass
+        # Check if manual number if passed through
+        if isinstance(num, int):
+            index = index[0:num]
 
     uts = index.hour * 3600 + index.minute * 60 + index.second
 

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -141,6 +141,8 @@ def generate_times(fnames, sat_id, freq='1S', num=None):
     freq : string
         Frequency of temporal output, compatible with pandas.date_range
         [default : '1S']
+    num : int or NoneType
+        Number of times to generate
 
     .. deprecated:: 2.3.0
       The ability to use a numeric string as `sat_id` to specify the number

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -142,6 +142,11 @@ def generate_times(fnames, sat_id, freq='1S'):
         Frequency of temporal output, compatible with pandas.date_range
         [default : '1S']
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num` keyword as an integer)
+
     Outputs
     -------
     uts : (array)

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os
+import warnings
 
 import pandas as pds
 
@@ -165,6 +166,12 @@ def generate_times(fnames, sat_id, freq='1S'):
     # Allow numeric string to select first set of data
     try:
         index = index[0:int(sat_id)]
+        warnings.warn(' '.join(["The ability to use a numeric string as",
+                                "`sat_id` to specify the number of data points",
+                                "has been removed from pysat in the 3.0.0",
+                                "release and will be replaced by the",
+                                "`num_samples` keyword"]),
+                      DeprecationWarning, stacklevel=2)
     except ValueError:
         # non-integer sat_id produces ValueError
         pass

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -88,7 +88,7 @@ def default(self):
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, file_date_range=None,
-         malformed_index=False, mangle_file_dates=False):
+         malformed_index=False, mangle_file_dates=False, num_samples=None):
     """ Loads the test files
 
     Parameters
@@ -118,6 +118,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     mangle_file_dates : bool
         If True, the loaded file list time index is shifted by 5-minutes.
         This shift is actually performed by the init function.
+    num_samples : int
+        Number of samples per day (default=None)
 
     .. deprecated:: 2.3.0
       The ability to use a numeric string as `sat_id` to specify the number
@@ -136,7 +138,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     # create an artifical satellite data set
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
-    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='1S')
+    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='1S',
+                                              num=num_samples)
 
     # Specify the date tag locally and determine the desired date range
     pds_offset = pds.DateOffset(hours=12)

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -119,6 +119,11 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         If True, the loaded file list time index is shifted by 5-minutes.
         This shift is actually performed by the init function.
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Returns
     -------
     data : (pds.DataFrame)

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -91,6 +91,11 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          malformed_index=False, mangle_file_dates=False, num_samples=None):
     """ Loads the test files
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Parameters
     ----------
     fnames : list
@@ -120,11 +125,6 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         This shift is actually performed by the init function.
     num_samples : int
         Number of samples per day (default=None)
-
-    .. deprecated:: 2.3.0
-      The ability to use a numeric string as `sat_id` to specify the number
-      of data points has been removed from pysat in the 3.0.0 release and
-      will be replaced by the `num_samples` keyword)
 
     Returns
     -------

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -50,7 +50,8 @@ def default(inst):
     pass
 
 
-def load(fnames, tag=None, sat_id=None, malformed_index=False):
+def load(fnames, tag=None, sat_id=None, malformed_index=False,
+         num_samples=None):
     """ Loads the test files
 
     Parameters
@@ -65,6 +66,8 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic.
         (default=False)
+    num_samples : int
+        Number of samples per day (default=None)
 
     .. deprecated:: 2.3.0
       The ability to use a numeric string as `sat_id` to specify the number
@@ -84,7 +87,8 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
     # Using 100s frequency for compatibility with seasonal analysis unit tests
-    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='100S')
+    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='100S',
+                                              num=num_samples)
     # seed DataFrame with UT array
     data = pysat.DataFrame(uts, columns=['uts'])
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -66,6 +66,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
         If True, the time index will be non-unique and non-monotonic.
         (default=False)
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Returns
     -------
     data : pds.DataFrame

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -54,6 +54,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False,
          num_samples=None):
     """ Loads the test files
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Parameters
     ----------
     fnames : list
@@ -68,11 +73,6 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False,
         (default=False)
     num_samples : int
         Number of samples per day (default=None)
-
-    .. deprecated:: 2.3.0
-      The ability to use a numeric string as `sat_id` to specify the number
-      of data points has been removed from pysat in the 3.0.0 release and
-      will be replaced by the `num_samples` keyword)
 
     Returns
     -------

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -52,7 +52,8 @@ def default(inst):
     pass
 
 
-def load(fnames, tag=None, sat_id=None, malformed_index=False):
+def load(fnames, tag=None, sat_id=None, malformed_index=False,
+         num_samples=None):
     """ Loads the test files
 
     Parameters
@@ -66,6 +67,8 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
         specifies the number of data points to include in the test instrument)
     malformed_index : bool False
         If True, the time index will be non-unique and non-monotonic.
+    num_samples : int
+        Number of samples per day (default=None)
 
     .. deprecated:: 2.3.0
       The ability to use a numeric string as `sat_id` to specify the number
@@ -85,7 +88,8 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
     # Using 100s frequency for compatibility with seasonal analysis unit tests
-    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='100S')
+    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='100S',
+                                              num=num_samples)
 
     if malformed_index:
         index = index.tolist()

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -56,6 +56,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False,
          num_samples=None):
     """ Loads the test files
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Parameters
     ----------
     fnames : list
@@ -69,11 +74,6 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False,
         If True, the time index will be non-unique and non-monotonic.
     num_samples : int
         Number of samples per day (default=None)
-
-    .. deprecated:: 2.3.0
-      The ability to use a numeric string as `sat_id` to specify the number
-      of data points has been removed from pysat in the 3.0.0 release and
-      will be replaced by the `num_samples` keyword)
 
     Returns
     -------

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -67,6 +67,11 @@ def load(fnames, tag=None, sat_id=None, malformed_index=False):
     malformed_index : bool False
         If True, the time index will be non-unique and non-monotonic.
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Returns
     -------
     data : xr.Dataset

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -59,6 +59,11 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
          **kwargs):
     """ Loads the test files
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Parameters
     ----------
     fnames : list
@@ -81,11 +86,6 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     kwargs : dict
         Additional unspecified keywords supplied to pysat.Instrument upon
         instantiation are passed here.
-
-    .. deprecated:: 2.3.0
-      The ability to use a numeric string as `sat_id` to specify the number
-      of data points has been removed from pysat in the 3.0.0 release and
-      will be replaced by the `num_samples` keyword)
 
     Returns
     -------

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -80,6 +80,11 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         Additional unspecified keywords supplied to pysat.Instrument upon
         instantiation are passed here.
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Returns
     -------
     data : (xr.Dataset)

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -55,7 +55,7 @@ def default(inst):
 
 
 def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
-         sim_multi_file_left=False, malformed_index=False,
+         sim_multi_file_left=False, malformed_index=False, num_samples=None,
          **kwargs):
     """ Loads the test files
 
@@ -76,6 +76,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
         root_date (default=False)
     malformed_index : boolean
         If True, time index will be non-unique and non-monotonic.
+    num_samples : int
+        Number of samples per day (default=None)
     kwargs : dict
         Additional unspecified keywords supplied to pysat.Instrument upon
         instantiation are passed here.
@@ -97,7 +99,8 @@ def load(fnames, tag=None, sat_id=None, sim_multi_file_right=False,
     # create an artifical satellite data set
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
-    uts, index, date = mm_test.generate_times(fnames, sat_id=sat_id, freq='1S')
+    uts, index, date = mm_test.generate_times(fnames, sat_id=sat_id, freq='1S',
+                                              num=num_samples)
 
     if sim_multi_file_right:
         root_date = pysat.datetime(2009, 1, 1, 12)

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -51,6 +51,10 @@ def load(fnames, tag=None, sat_id=None):
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
 
     Returns
     -------

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -39,6 +39,11 @@ def init(self):
 def load(fnames, tag=None, sat_id=None, num_samples=None):
     """ Loads the test files
 
+    .. deprecated:: 2.3.0
+      The ability to use a numeric string as `sat_id` to specify the number
+      of data points has been removed from pysat in the 3.0.0 release and
+      will be replaced by the `num_samples` keyword)
+
     Parameters
     ----------
     fnames : list
@@ -50,11 +55,6 @@ def load(fnames, tag=None, sat_id=None, num_samples=None):
         specifies the number of data points to include in the test instrument)
     num_samples : int
         Number of samples per day (default=None)
-
-    .. deprecated:: 2.3.0
-      The ability to use a numeric string as `sat_id` to specify the number
-      of data points has been removed from pysat in the 3.0.0 release and
-      will be replaced by the `num_samples` keyword)
 
     Returns
     -------

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -6,9 +6,7 @@ from __future__ import print_function
 from __future__ import absolute_import
 import functools
 import numpy as np
-import os
 
-import pandas as pds
 import xarray as xr
 
 import pysat
@@ -38,7 +36,7 @@ def init(self):
     self.new_thing = True
 
 
-def load(fnames, tag=None, sat_id=None):
+def load(fnames, tag=None, sat_id=None, num_samples=None):
     """ Loads the test files
 
     Parameters
@@ -50,6 +48,8 @@ def load(fnames, tag=None, sat_id=None):
     sat_id : str or NoneType
         Instrument satellite ID (accepts '' or a number (i.e., '10'), which
         specifies the number of data points to include in the test instrument)
+    num_samples : int
+        Number of samples per day (default=None)
 
     .. deprecated:: 2.3.0
       The ability to use a numeric string as `sat_id` to specify the number
@@ -66,7 +66,8 @@ def load(fnames, tag=None, sat_id=None):
     """
 
     # create an artifical satellite data set
-    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='900S')
+    uts, index, date = mm_test.generate_times(fnames, sat_id, freq='900S',
+                                              num=num_samples)
 
     # Define range of simulated 3D model
     latitude = np.linspace(-50, 50, 21)

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -264,7 +264,7 @@ class TestDataMod:
         warnings.filterwarnings('ignore', category=DeprecationWarning)
         self.testConst = \
             pysat.Constellation([pysat.Instrument('pysat', 'testing',
-                                                  sat_id='10',
+                                                  num_samples=10,
                                                   clean_level='clean')])
 
     def teardown(self):
@@ -297,7 +297,8 @@ class TestDeprecation():
         warnings.simplefilter("always")
 
         self.instruments = [pysat.Instrument(platform='pysat', name='testing',
-                                             sat_id='10', clean_level='clean')
+                                             num_samples=10,
+                                             clean_level='clean')
                             for i in range(2)]
         self.in_kwargs = {"name": 'single_test',
                           'instruments': self.instruments}

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -29,7 +29,7 @@ class TestBasics():
         re_load(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         sat_id='10',
+                                         num_samples=10,
                                          clean_level='clean',
                                          update_files=True)
 
@@ -56,7 +56,7 @@ class TestBasics():
     def test_basic_instrument_bad_keyword(self):
         """Checks for error when instantiating with bad load_rtn keywords"""
         testInst = pysat.Instrument(platform='pysat', name='testing',
-                                    sat_id='10',
+                                    num_samples=10,
                                     clean_level='clean',
                                     unsupported_keyword_yeah=True)
 
@@ -71,7 +71,7 @@ class TestBasics():
     @raises(Exception)
     def test_basic_instrument_load_by_file_and_multifile(self):
         testInst = pysat.Instrument(platform='pysat', name='testing',
-                                    sat_id='10',
+                                    num_samples=10,
                                     clean_level='clean',
                                     update_files=True,
                                     multi_file_day=True)
@@ -342,7 +342,7 @@ class TestBasics():
                       'kind': 'local time',
                       'period': np.timedelta64(97, 'm')}
         testInst = pysat.Instrument(platform='pysat', name='testing',
-                                    sat_id='10',
+                                    num_samples=10,
                                     clean_level='clean',
                                     update_files=True,
                                     orbit_info=orbit_info)
@@ -890,7 +890,7 @@ class TestBasicsXarray(TestBasics):
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat',
                                          name='testing_xarray',
-                                         sat_id='10',
+                                         num_samples=10,
                                          clean_level='clean',
                                          update_files=True)
 
@@ -910,7 +910,7 @@ class TestBasicsShiftedFileDates(TestBasics):
         re_load(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         sat_id='10',
+                                         num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
                                          mangle_file_dates=True,
@@ -934,7 +934,7 @@ class TestMalformedIndex():
         re_load(pysat.instruments.pysat_testing)
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         sat_id='10',
+                                         num_samples=10,
                                          clean_level='clean',
                                          malformed_index=True,
                                          update_files=True,
@@ -966,7 +966,7 @@ class TestMalformedIndexXarray(TestMalformedIndex):
         """Runs before every method to create a clean testing setup."""
         self.testInst = pysat.Instrument(platform='pysat',
                                          name='testing_xarray',
-                                         sat_id='10',
+                                         num_samples=10,
                                          clean_level='clean',
                                          malformed_index=True,
                                          update_files=True,

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -398,6 +398,7 @@ class TestInstrumentDeprectaion():
     def setup(self):
         """Runs before every method to create a clean testing setup"""
         warnings.filterwarnings('always', category=DeprecationWarning)
+        self.warn_msgs = ["The ability to use a numeric string as"]
 
     def teardown(self):
         """Runs after every method to clean up previous testing"""
@@ -409,5 +410,13 @@ class TestInstrumentDeprectaion():
         with warnings.catch_warnings(record=True) as war:
             uts, index, date = mm_test.generate_times(fnames, '100', freq='1S')
 
-        assert len(war) == 1
-        assert war[0].category == DeprecationWarning
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(self.warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(
+            war, self.warn_msgs)
+
+        for i, good in enumerate(found_msgs):
+            assert good, "didn't find warning about: {:}".format(
+                self.warn_msgs[i])

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -405,7 +405,7 @@ class TestInstrumentDeprectaion():
     def test_deprecated_season_date_range(self):
         """Tests that deprecation of season_date_range is working"""
 
-        fnames = ['fake_name.txt']
+        fnames = ['2009-01-01.nofile']
         with warnings.catch_warnings(record=True) as war:
             uts, index, date = mm_test.generate_times(fnames, '100', freq='1S')
 

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -12,6 +12,7 @@ import tempfile
 
 import pysat
 import pysat.instruments.pysat_testing
+from pysat.instruments.methods import testing as mm_test
 
 # modules in the list below have deprecation warnings
 dep_list = ['cosmic_gps', 'dmsp_ivm', 'jro_isr', 'sw_dst', 'sw_kp', 'sw_f107',
@@ -391,15 +392,22 @@ class TestInstrumentQualifier():
                                         inst.name, inst.tag, inst.sat_id,
                                         'was not successful.')))
 
-    # Optional support
 
-    # directory_format string
+class TestInstrumentDeprectaion():
 
-    # multiple file days
+    def setup(self):
+        """Runs before every method to create a clean testing setup"""
+        warnings.filterwarnings('always', category=DeprecationWarning)
 
-    # orbit information
+    def teardown(self):
+        """Runs after every method to clean up previous testing"""
 
-        # self.directory_format = None
-        # self.file_format = None
-        # self.multi_file_day = False
-        # self.orbit_info = None
+    def test_deprecated_season_date_range(self):
+        """Tests that deprecation of season_date_range is working"""
+
+        fnames = ['fake_name.txt']
+        with warnings.catch_warnings(record=True) as war:
+            uts, index, date = mm_test.generate_times(fnames, '100', freq='1S')
+
+        assert len(war) == 1
+        assert war[0].category == DeprecationWarning

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -26,7 +26,7 @@ class TestRemoveLeadText():
         """Runs before every method to create a clean testing setup."""
         # Load a test instrument
         warnings.filterwarnings('ignore', category=DeprecationWarning)
-        self.testInst = pysat.Instrument('pysat', 'testing', sat_id='12',
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12,
                                          clean_level='clean')
         self.testInst.load(2009, 1)
         self.Npts = len(self.testInst['uts'])
@@ -79,7 +79,7 @@ class TestRemoveLeadTextXarray(TestRemoveLeadText):
         # Load a test instrument
         warnings.filterwarnings('ignore', category=DeprecationWarning)
         self.testInst = pysat.Instrument('pysat', 'testing2d_xarray',
-                                         sat_id='12',
+                                         num_samples=12,
                                          clean_level='clean')
         self.testInst.load(2009, 1)
         self.Npts = len(self.testInst['uts'])

--- a/pysat/tests/test_omni_hro.py
+++ b/pysat/tests/test_omni_hro.py
@@ -15,7 +15,7 @@ class TestOMNICustom():
         warnings.filterwarnings('ignore', category=DeprecationWarning)
 
         # Load a test instrument
-        self.testInst = pysat.Instrument('pysat', 'testing', sat_id='12',
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12,
                                          tag='1min', clean_level='clean')
         self.testInst.load(2009, 1)
 

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -244,7 +244,7 @@ class TestBasicNetCDF4():
 
         self.testInst = pysat.Instrument(platform='pysat',
                                          name='testing',
-                                         sat_id='100',
+                                         num_samples=100,
                                          clean_level='clean')
         self.testInst.pandas_format = True
 
@@ -494,7 +494,7 @@ class TestBasicNetCDF4xarray():
 
         self.testInst = pysat.Instrument(platform='pysat',
                                          name='testing2d_xarray',
-                                         sat_id='100',
+                                         num_samples=100,
                                          clean_level='clean')
         self.testInst.pandas_format = False
 


### PR DESCRIPTION
# Description

Addresses #686
Complements #735.  Moves those warnings here as part of 2.3.0.

I've included notes in the docs throughout the instruments for usage.  Let me know if these should be done differently.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

testing via travis CI

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
