### PR TITLE
BUG: numpy 1.20 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Reduced code duplication throughout package
   - Reduced unused code snippets throughout
   - Ensured download start time is used
+  - Fixed a bug with usage of numpy.dtype for numpy 1.20 compatibility
 
 ## [2.2.2] - 2020-12-31
 - New Features

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1401,7 +1401,7 @@ class Instrument(object):
                      np.uint16: 'u2', np.uint8: 'u1', np.float64: 'f8',
                      np.float32: 'f4'}
 
-        if type(coltype) is np.dtype:
+        if isinstance(coltype, np.dtype):
             var_type = coltype.kind + str(coltype.itemsize)
             return var_type
         else:


### PR DESCRIPTION
# Description

Addresses #741 

Numpy dtypes are not direct instances of `np.dtype` starting with numpy 1.20.0.  This requires a change from using `type` to `isinstance` for type detection.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Locally, install numpy 1.20.  Running 
```
pytest pysat/tests/test_meta.py::TestBasics::test_nan_metadata_filtered_netcdf4_via_method
```
will detect if the routine runs correctly.  Likewise, any of the failing routines mentioned in #741.

**Test Configuration**:
* Mac OS X 10.15
* python 3.7.3
* numpy 1.20.1 and numpy 1.19.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
