### PR TITLE
MAINT/BUG: numpy version cap needed for pysat 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
    - Updated docstrings with deprecation notes
 - Bug Fix
    - Closes files after download in NASA CDAWeb methods
+- Added version cap for numpy
 
 ## [2.2.2] - 2020-11-23
 - New Features

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ if sys.version_info.major == 2:
 else:
     # python 3+
     install_requires.extend(['xarray<0.15', 'pandas>=0.23, <0.25',
-                             'numpy>=1.12', 'scipy', 'matplotlib'])
+                             'numpy>=1.12, <1.20', 'scipy', 'matplotlib'])
 
 # flag, True if on readthedocs
 on_rtd = os.environ.get('READTHEDOCS') == 'True'


### PR DESCRIPTION
# Description

Addresses #730

Changes in numpy 1.20 have resulted in some incompatibilities with the supported pandas version for pysat 2.x.  Since there is no cap in pandas 0.24 (the latest supported version here), we need to add a version cap to prevent faulty setups for the final deprecated version.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via local installs with different numpy setups.


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
