### PR TITLE
MAINT: future numpy and pandas standards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Reduced unused code snippets throughout
   - Ensured download start time is used
   - Fixed a bug with usage of numpy.dtype for numpy 1.20 compatibility
+  - Updated usage of pds.index.to_native_types() to pds.index.astype(str)
+    for pandas 2.0 compatibility (#737)
+  - Check type as float rather than np.float for future numpy compatibility
+    (#740)
+  - Verified usage of inst.loc[slice, keyword] will continue to work in
+    pandas 2.0 (#738)
 
 ## [2.2.2] - 2020-12-31
 - New Features

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -762,12 +762,13 @@ class Instrument(object):
             if isinstance(key, tuple):
                 try:
                     # Pass directly through to loc
-                    # This line raises a FutureWarning, but will be caught
-                    # by TypeError, so may not be an issue
+                    # This line raises a FutureWarning if key[0] is a slice
+                    # The future behavior is TypeError, which is already
+                    # handled correctly below
                     self.data.loc[key[0], key[1]] = new
                 except (KeyError, TypeError):
-                    # TypeError for single integer
-                    # KeyError for list, array, slice of integers
+                    # TypeError for single integer, slice (pandas 2.0)
+                    # KeyError for list, array
                     # Assume key[0] is integer (including list or slice)
                     self.data.loc[self.data.index[key[0]], key[1]] = new
                 self.meta[key[1]] = {}

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1450,7 +1450,7 @@ class Instrument(object):
             for i in np.arange(len(data)):
                 if len(data.iloc[i]) > 0:
                     data_type = type(data.iloc[i])
-                    if not isinstance(data_type, np.float):
+                    if not isinstance(data_type, float):
                         break
             datetime_flag = False
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3567,7 +3567,7 @@ class Instrument(object):
                                 (num, dims[0])).astype(coltype)
                             for i in range(num):
                                 temp_cdf_data[i, :] = \
-                                    self[key].iloc[i].index.to_native_types()
+                                    self[key].iloc[i].index.astype(str)
                             cdfkey[:, :] = temp_cdf_data.astype(coltype)
 
             # Store any non standard attributes. Compare this Instrument's


### PR DESCRIPTION
# Description

Addresses #737, #738, #740

 - Updated usage of `pds.index.to_native_types()` to `pds.index.astype(str)`
    for pandas 2.0 compatibility (#737)
  - Check type as `float` rather than `np.float` for future numpy compatibility
    (#740)
  - Verified usage of inst.loc[slice, keyword] will continue to work in
    pandas 2.0 (#738)

## Type of change

Please delete options that are not relevant.

- Maintenance fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Ran unit tests tested locally with

**Test Configuration**:
* python 3.8.2
* numpy 1.20.1
* pandas 1.2.3
* xarray 0.17.0
* netCDF4 1.5.6

Note that there are some deprecation warnings were originating from the usage of numpy in netCDF4, these issues were updated in the 1.5.6 release.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
