### PR TITLE
ENH/BUG: inst_id and tag check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New Features
   - Added a routine for loading CSV files into a pandas DataFrame from a list
     of filenames.
+  - Added check for supported `tag` and `inst_id` at pysat.Instrument 
+    instantiation.
 - Deprecations
 - Documentation
 - Bug Fix

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -231,12 +231,13 @@ class Instrument(object):
                 self.name = name.lower()
 
                 # Look to module for instrument functions and defaults
-                self._assign_attrs(by_name=True)
+                self._assign_attrs(by_name=True, tag=self.tag,
+                                   inst_id=self.inst_id)
             elif (platform is None) and (name is None):
                 # Creating "empty" Instrument object with this path
                 self.name = ''
                 self.platform = ''
-                self._assign_attrs()
+                self._assign_attrs(tag=self.tag, inst_id=self.inst_id)
             else:
                 raise ValueError(' '.join(('Inputs platform and name must both',
                                            'be strings, or both None.')))
@@ -1089,7 +1090,8 @@ class Instrument(object):
         """
         pass
 
-    def _assign_attrs(self, by_name=False, inst_module=None):
+    def _assign_attrs(self, by_name=False, inst_module=None, tag=None,
+                      inst_id=None):
         """Assign all external instrument attributes to the Instrument object
 
         Parameters
@@ -1099,6 +1101,10 @@ class Instrument(object):
             if False uses inst_module. (default=False)
         inst_module : module or NoneType
             Instrument module or None, if not specified (default=None)
+        tag : str or NoneType
+            Instrument tag string
+        inst_id : str or NoneType
+            Instrument inst_id string
 
         Raises
         ------
@@ -1192,6 +1198,20 @@ class Instrument(object):
         else:
             # No module or name info, default pass functions assigned
             return
+
+        # Check if tag and inst_id are appropriate for the module
+        if inst_id not in inst.inst_ids.keys():
+            estr = ''.join(('"', inst_id, '" is not one of the supported ',
+                            'inst_ids. Supported inst_ids are: "',
+                            '"'.join((inst.inst_ids.keys())), '".'))
+            raise ValueError(estr)
+
+        if tag not in inst.inst_ids[inst_id]:
+            tag_str = ' '.join([''.join(('"', key, '"'))
+                                for key in inst.inst_ids[inst_id]])
+            estr = ''.join(('"', tag, '" is not one of the supported tags. ',
+                            'Supported tags are: ', tag_str, '.'))
+            raise ValueError(estr)
 
         # Assign the Instrument methods
         missing = list()

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -254,7 +254,8 @@ class Instrument(object):
 
             # Look to supplied module for instrument functions and non-default
             # attribute values
-            self._assign_attrs(inst_module=self.inst_module)
+            self._assign_attrs(inst_module=self.inst_module,
+                               tag=self.tag, inst_id=self.inst_id)
 
         # More reasonable defaults for optional parameters
         self.clean_level = (clean_level.lower() if clean_level is not None

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1202,9 +1202,11 @@ class Instrument(object):
 
         # Check if tag and inst_id are appropriate for the module
         if inst_id not in inst.inst_ids.keys():
+            inst_id_str = ' '.join([''.join(('"', key, '"'))
+                                    for key in inst.inst_ids.keys()])
             estr = ''.join(('"', inst_id, '" is not one of the supported ',
-                            'inst_ids. Supported inst_ids are: "',
-                            '"'.join((inst.inst_ids.keys())), '".'))
+                            'inst_ids. Supported inst_ids are: ',
+                            inst_id_str, '.'))
             raise ValueError(estr)
 
         if tag not in inst.inst_ids[inst_id]:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1202,17 +1202,17 @@ class Instrument(object):
 
         # Check if tag and inst_id are appropriate for the module
         if inst_id not in inst.inst_ids.keys():
-            inst_id_str = ' '.join([''.join(('"', key, '"'))
-                                    for key in inst.inst_ids.keys()])
-            estr = ''.join(('"', inst_id, '" is not one of the supported ',
+            inst_id_str = ', '.join([ikey.__repr__()
+                                    for ikey in inst.inst_ids.keys()])
+            estr = ''.join(("'", inst_id, "' is not one of the supported ",
                             'inst_ids. Supported inst_ids are: ',
                             inst_id_str, '.'))
             raise ValueError(estr)
 
         if tag not in inst.inst_ids[inst_id]:
-            tag_str = ' '.join([''.join(('"', key, '"'))
-                                for key in inst.inst_ids[inst_id]])
-            estr = ''.join(('"', tag, '" is not one of the supported tags. ',
+            tag_str = ', '.join([tkey.__repr__()
+                                for tkey in inst.inst_ids[inst_id]])
+            estr = ''.join(("'", tag, "' is not one of the supported tags. ",
                             'Supported tags are: ', tag_str, '.'))
             raise ValueError(estr)
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -780,7 +780,6 @@ class TestInstWithFilesNonStandard():
         self.testInst = \
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              clean_level='clean',
-                             inst_id='hello',
                              directory_format=nonstandard_dir,
                              update_files=True, file_format=self.root_fname,
                              temporary_file_list=self.temporary_file_list)

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -771,28 +771,29 @@ class TestInstWithFilesNonStandard():
 
     def test_files_non_standard_pysat_directory(self):
         """Check that files work with a weird directory structure"""
-        # create new files and make sure that new files are captured
+        # Create new files and make sure that new files are captured
         dates = pysat.utils.time.create_date_range(self.start, self.stop,
                                                    freq='100min')
 
         nonstandard_dir = 'pysat_testing_{tag}_{inst_id}'
 
-        self.testInst = \
-            pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             clean_level='clean',
-                             directory_format=nonstandard_dir,
-                             update_files=True, file_format=self.root_fname,
-                             temporary_file_list=self.temporary_file_list)
-        # add new files
+        self.testInst = pysat.Instrument(
+            inst_module=pysat.instruments.pysat_testing,
+            clean_level='clean',
+            directory_format=nonstandard_dir,
+            update_files=True, file_format=self.root_fname,
+            temporary_file_list=self.temporary_file_list)
+
+        # Add new files
         create_dir(self.testInst)
         create_files(self.testInst, self.start, self.stop, freq='100min',
                      use_doy=False, root_fname=self.root_fname,
                      version=self.version)
 
-        # refresh file list
+        # Refresh file list
         self.testInst.files.refresh()
 
-        # get new files
+        # Get new files
         new_files = self.testInst.files.get_new()
         assert np.all(self.testInst.files.files.index == dates)
         assert np.all(new_files.index == dates)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2558,6 +2558,27 @@ class TestBasics():
         estr = 'Inputs platform and name must both'
         assert str(err).find(estr) >= 0
 
+    def test_error_bad_inst_id_instrument_object(self):
+        """Ensure instantiation with invalid inst_id errors"""
+        with pytest.raises(ValueError) as err:
+            # both name and platform should be empty
+            _ = pysat.Instrument(platform=self.testInst.platform,
+                                 name=self.testInst.name,
+                                 inst_id='invalid_inst_id')
+        estr = '"invalid_inst_id" is not one of the supported inst_ids.'
+        assert str(err).find(estr) >= 0
+
+    def test_error_bad_tag_instrument_object(self):
+        """Ensure instantiation with invalid inst_id errors"""
+        with pytest.raises(ValueError) as err:
+            # both name and platform should be empty
+            _ = pysat.Instrument(platform=self.testInst.platform,
+                                 name=self.testInst.name,
+                                 inst_id='',
+                                 tag='bad_tag')
+        estr = '"bad_tag" is not one of the supported tags.'
+        assert str(err).find(estr) >= 0
+
     def test_supplying_instrument_module_requires_name_and_platform(self):
         """Ensure instantiation via inst_module with missing name errors"""
         class Dummy:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2553,29 +2553,27 @@ class TestBasics():
     def test_incorrect_creation_empty_instrument_object(self):
         """Ensure instantiation with missing name errors"""
         with pytest.raises(ValueError) as err:
-            # both name and platform should be empty
-            _ = pysat.Instrument(platform='cnofs')
+            # Both name and platform should be empty
+            pysat.Instrument(platform='cnofs')
         estr = 'Inputs platform and name must both'
         assert str(err).find(estr) >= 0
 
     def test_error_bad_inst_id_instrument_object(self):
         """Ensure instantiation with invalid inst_id errors"""
         with pytest.raises(ValueError) as err:
-            # both name and platform should be empty
-            _ = pysat.Instrument(platform=self.testInst.platform,
-                                 name=self.testInst.name,
-                                 inst_id='invalid_inst_id')
+            pysat.Instrument(platform=self.testInst.platform,
+                             name=self.testInst.name,
+                             inst_id='invalid_inst_id')
         estr = '"invalid_inst_id" is not one of the supported inst_ids.'
         assert str(err).find(estr) >= 0
 
     def test_error_bad_tag_instrument_object(self):
         """Ensure instantiation with invalid inst_id errors"""
         with pytest.raises(ValueError) as err:
-            # both name and platform should be empty
-            _ = pysat.Instrument(platform=self.testInst.platform,
-                                 name=self.testInst.name,
-                                 inst_id='',
-                                 tag='bad_tag')
+            pysat.Instrument(platform=self.testInst.platform,
+                             name=self.testInst.name,
+                             inst_id='',
+                             tag='bad_tag')
         estr = '"bad_tag" is not one of the supported tags.'
         assert str(err).find(estr) >= 0
 
@@ -2586,7 +2584,7 @@ class TestBasics():
         Dummy.name = 'help'
 
         with pytest.raises(AttributeError) as err:
-            _ = pysat.Instrument(inst_module=Dummy)
+            pysat.Instrument(inst_module=Dummy)
         estr = 'Supplied module '
         assert str(err).find(estr) >= 0
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2564,7 +2564,7 @@ class TestBasics():
             pysat.Instrument(platform=self.testInst.platform,
                              name=self.testInst.name,
                              inst_id='invalid_inst_id')
-        estr = '"invalid_inst_id" is not one of the supported inst_ids.'
+        estr = "'invalid_inst_id' is not one of the supported inst_ids."
         assert str(err).find(estr) >= 0
 
     def test_error_bad_tag_instrument_object(self):
@@ -2574,7 +2574,7 @@ class TestBasics():
                              name=self.testInst.name,
                              inst_id='',
                              tag='bad_tag')
-        estr = '"bad_tag" is not one of the supported tags.'
+        estr = "'bad_tag' is not one of the supported tags."
         assert str(err).find(estr) >= 0
 
     def test_supplying_instrument_module_requires_name_and_platform(self):


### PR DESCRIPTION
# Description

Addresses #784, #537

Adds a check if the user supplied `tag` and `inst_id` are actually supported by the requested instrument support module.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Added a test, with error message check, when an invalid tag or inst_id provided

**Test Configuration**:
* Operating system: MacOS 10.15.4
* Version number: Python 3.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
