### PR TITLE
MAINT: pysatSpaceWeather compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     functions to retaining the original form provided by developer
   - Migrates CI testing to Github Actions
   - Improved maintenance of documentation build
+  - Tests compatible with pysatSpaceWeather 0.0.4
 
 ## [3.0.0] - 2021-04-01
 - New Features

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -91,13 +91,6 @@ class TestFileDirectoryTranslations(CICleanSetup):
                                  + dt.timedelta(weeks=52)])
         self.insts_kwargs.append({'freq': 'MS'})
 
-        # Data with date mangling, 'historic' F10.7 data, single file
-        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic'))
-        test_dates = pysatSpaceWeather.instruments.sw_f107._test_dates
-        self.insts_dates.append([test_dates['']['historic'],
-                                 test_dates['']['historic']])
-        self.insts_kwargs.append({})
-
         # Download data for all instruments
         for inst, dates, kwargs in zip(self.insts, self.insts_dates,
                                        self.insts_kwargs):

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -86,8 +86,9 @@ class TestFileDirectoryTranslations(CICleanSetup):
         # Data with date mangling, regular F10.7 data, stored monthly
         self.insts.append(pysat.Instrument('sw', 'f107', tag='historic'))
         test_dates = pysatSpaceWeather.instruments.sw_f107._test_dates
-        self.insts_dates.append([test_dates[''][''],
-                                 test_dates[''][''] + dt.timedelta(weeks=52)])
+        self.insts_dates.append([test_dates['']['historic'],
+                                 test_dates['']['historic']
+                                 + dt.timedelta(weeks=52)])
         self.insts_kwargs.append({'freq': 'MS'})
 
         # Data with date mangling, 'historic' F10.7 data, single file

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -78,24 +78,23 @@ class TestFileDirectoryTranslations(CICleanSetup):
         self.insts_kwargs = []
 
         # Data by day, ACE SIS data
-        self.insts.append(pysat.Instrument('sw', 'ace', tag='historic',
-                                           inst_id='sis'))
-        test_dates = pysatSpaceWeather.instruments.sw_ace._test_dates
-        self.insts_dates.append([test_dates['sis']['historic']] * 2)
+        self.insts.append(pysat.Instrument('ace', 'sis', tag='historic'))
+        test_dates = pysatSpaceWeather.instruments.ace_sis._test_dates
+        self.insts_dates.append([test_dates['']['historic']] * 2)
         self.insts_kwargs.append({})
 
         # Data with date mangling, regular F10.7 data, stored monthly
-        self.insts.append(pysat.Instrument('sw', 'f107'))
+        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic'))
         test_dates = pysatSpaceWeather.instruments.sw_f107._test_dates
         self.insts_dates.append([test_dates[''][''],
                                  test_dates[''][''] + dt.timedelta(weeks=52)])
         self.insts_kwargs.append({'freq': 'MS'})
 
-        # Data with date mangling, 'all' F10.7 data, single file
-        self.insts.append(pysat.Instrument('sw', 'f107', tag='all'))
+        # Data with date mangling, 'historic' F10.7 data, single file
+        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic'))
         test_dates = pysatSpaceWeather.instruments.sw_f107._test_dates
-        self.insts_dates.append([test_dates['']['all'],
-                                 test_dates['']['all']])
+        self.insts_dates.append([test_dates['']['historic'],
+                                 test_dates['']['historic']])
         self.insts_kwargs.append({})
 
         # Download data for all instruments


### PR DESCRIPTION
# Description

Addresses #782

Updates unit tests to use new instrument names in pysatSpaceWeather.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested via Github Actions

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
