### PR TITLE
MAINT: Update refs to Travis CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -86,14 +86,14 @@ For merging, you should:
 
 1. Include an example for use
 2. Add a note to ``CHANGELOG.md`` about the changes
-3. Ensure that all checks passed (current checks include Scrutinizer, Travis-CI,
+3. Ensure that all checks passed (current checks include Github Actions,
    and Coveralls) [1]_
 
 .. [1] If you don't have all the necessary Python versions available locally or
        have trouble building all the testing environments, you can rely on
-       Travis to run the tests for each change you add in the pull request.
-       Because testing here will delay tests by other developers, please ensure
-       that the code passes all tests on your local system first.
+       Github Actions to run the tests for each change you add in the pull
+       request. Because testing here will delay tests by other developers,
+       please ensure that the code passes all tests on your local system first.
 
 Project Style Guidelines
 ------------------------

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -692,11 +692,11 @@ same effect, and Level 2 tests will still be run.
 FTP Access
 ^^^^^^^^^^
 
-Another thing to note about testing is that the Travis CI environment used to
+Another thing to note about testing is that the CI environment used to
 automate the tests is not compatible with FTP downloads.  For this reason,
 HTTPS access is preferred whenever possible.  However, if this is not the case,
 the `_test_download_travis` flag can be used.  This has a similar function,
-except that it skips the download tests if on Travis CI, but will run those
+except that it skips the download tests if on CI, but will run those
 tests if run locally.
 
 .. code:: python

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -88,11 +88,6 @@ if not os.path.isdir(pysat_dir) or \
     if not os.path.isfile(os.path.join(pysat_dir, 'pysat_settings.json')):
         params = _params.Parameters(path=pysat_dir, create_new=True)
 
-    # Set initial data directory if we are on Travis
-    if (os.environ.get('TRAVIS') == 'true'):
-        data_dir = '/home/travis/build/pysatData'
-        params['data_dirs'] = [data_dir]
-
     print(''.join(("\nHi there!  pysat will nominally store data in a ",
                    "'pysatData' directory which needs to be assigned. ",
                    "Please run `pysat.params['data_dirs'] = path` where path ",

--- a/pysat/tests/ci_test_class.py
+++ b/pysat/tests/ci_test_class.py
@@ -16,8 +16,7 @@ import pysat
 class CICleanSetup():
     """ Tests where local settings are altered.
 
-    These only run in CI environments such as Travis and Appveyor to avoid
-    breaking an end user's setup
+    These only run in CI environments to avoid breaking an end user's setup
 
     """
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -1014,8 +1014,8 @@ class TestFilesRaceCondition():
 
 class TestCIonly():
     """Tests where we mess with local settings.
-    These only run in CI environments such as Travis and Appveyor to avoid
-    breaking an end user's setup
+
+    These only run in CI environments to avoid breaking an end user's setup
     """
 
     # Set setup/teardown to the class defaults
@@ -1031,8 +1031,7 @@ class TestCIonly():
         assert captured.out.find("Hi there!") >= 0
 
         # Ensure the pysat 'data_dirs' param is empty list on both
-        # local systems and TravisCI. A directory is automatically set
-        # in __init__ for TravisCI.
+        # local systems and CI.
         pysat.params.data['data_dirs'] = []
 
         # Try to instantiate Instrument

--- a/pysat/tests/test_params.py
+++ b/pysat/tests/test_params.py
@@ -175,8 +175,8 @@ class TestBasics():
 
 class TestCIonly(CICleanSetup):
     """Tests where we mess with local settings.
-    These only run in CI environments such as Travis and Appveyor to avoid
-    breaking an end user's setup
+
+    These only run in CI environments to avoid breaking an end user's setup
     """
 
     # Set setup/teardown to the class defaults

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -22,7 +22,7 @@ class TestBasics():
     def test_parse_delimited_filename(self):
         """Check ability to parse list of delimited files"""
         # Note: Can be removed if future instrument that uses delimited
-        # filenames is added to routine travis end-to-end testing
+        # filenames is added to routine end-to-end testing
         fname = ''.join(('test_{year:4d}_{month:2d}_{day:2d}_{hour:2d}',
                          '_{minute:2d}_{second:2d}_{version:2s}_r02.cdf'))
         year = np.ones(6) * 2009
@@ -57,7 +57,7 @@ class TestFileDirectoryTranslations(CICleanSetup):
     def setup(self):
         """Runs before every method to create a clean testing setup."""
 
-        # Module is only required for testing installations on TravisCI
+        # Module is only required for testing installations on CI servers
         import pysatSpaceWeather
 
         # Create clean environment on the CI server


### PR DESCRIPTION
# Description

Addresses #777 

- Removes hardwired code that automatically sets the data directory on Travis.  This is now set outside the code depending on CI environment
- Scrubs docstrings for mentions of Travis to generalize to CI

## Type of change

- Maintenance fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Tested via Github Actions 

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
