### PR TITLE
Download calls that create an empty date array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - New Features
   - Added a routine for loading CSV files into a pandas DataFrame from a list
     of filenames.
-  - Added check for supported `tag` and `inst_id` at pysat.Instrument 
+  - Added check for supported `tag` and `inst_id` at pysat.Instrument
     instantiation.
   - Expanded Constellation utility by:
     - Adding common properties: `empty`, `index`, `date`, `today`, `yesterday`,
@@ -14,11 +14,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     - Improving the printed output to inform user of the Constellation contents
     - Added methods to download data and create a common time index.
    - Added utils.listify, a function that returns a list of whatever is input.
+   - Added a warning for download requests that result in an empty date range.
 - Deprecations
 - Documentation
 - Bug Fix
-  - Changed pysat.Instruments.orbits iteration to return a copy of the Instrument
-    rather than the Instrument itself. Provides robustness against garbage collection.
+  - Changed pysat.Instruments.orbits iteration to return a copy of the
+    Instrument rather than the Instrument itself. Provides robustness against
+    garbage collection.
   - Improved error messages for cases where slice of data may not exist (#761)
 - Maintenance
   - Changed pysat.Instrument from treating all support functions as partial

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -560,12 +560,25 @@ class TestBasics():
     def test_download_recent_data(self, caplog):
         with caplog.at_level(logging.INFO, logger='pysat'):
             self.testInst.download()
-        # Tells user that recent data will be downloaded
+
+        # Ensure user was told that recent data will be downloaded
         assert "most recent data by default" in caplog.text
-        # download new files
+
+        # Ensure user was notified of new files being download
         assert "Downloading data to" in caplog.text
-        # Update local file list
+
+        # Ensure user was notified of updates to the local file list
         assert "Updating pysat file list" in caplog.text
+
+    def test_download_bad_date_range(self, caplog):
+        """Test download with bad date input."""
+        with caplog.at_level(logging.WARNING, logger='pysat'):
+            self.testInst.download(start=self.ref_time,
+                                   stop=self.ref_time - dt.timedelta(days=10))
+
+        # Ensure user is warned about not calling download due to bad time input
+        assert "Requested download over an empty date range" in caplog.text
+        return
 
     # -------------------------------------------------------------------------
     #


### PR DESCRIPTION
# Description
You can enter time information into download that result in an empty date array.  This can cause uninformative errors to be raised in Instrument download routines and hide a possible user error.  This PR fixes that by warning the user that no downloads were attempted for the specified date range.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a unit test.  Also:

```
import datetime as dt
import pysat
inst = pysat.Instrument('your', 'fav', 'inst', 'here')
inst.download(dt.datetime(2009, 1, 1), dt.datetime(2008, 1, 1))
```

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant: found using pysatSpaceWeather Prelim F10.7 data.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
