### PR TITLE
Load kwarg tests

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2674,7 +2674,10 @@ class Instrument(object):
         """
         # Add the load kwargs from initialization those provided on input
         for lkey in self.kwargs['load'].keys():
-            kwargs[lkey] = self.kwargs['load'][lkey]
+            # Only use the initialized kwargs if a request hasn't been
+            # made to alter it in the method call
+            if lkey not in kwargs.keys():
+                kwargs[lkey] = self.kwargs['load'][lkey]
 
         # Set options used by loading routine based upon user input
         if (yr is not None) and (doy is not None):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -171,7 +171,7 @@ class TestBasics():
         # Load data by year and day of year
         self.testInst.load(self.ref_time.year, self.ref_doy)
 
-        # Test that the first loaded time
+        # Test that the loaded date range is correct
         self.eval_successful_load()
         return
 
@@ -181,7 +181,7 @@ class TestBasics():
         # Load data by year and day of year
         self.testInst.load(self.ref_time.year, self.ref_doy, num_samples=30)
 
-        # Test that the first loaded time
+        # Test that the loaded date range is correct
         self.eval_successful_load()
         return
 
@@ -194,7 +194,7 @@ class TestBasics():
         self.testInst.load(self.ref_time.year, self.ref_doy, end_date.year,
                            end_doy)
 
-        # Test that the first loaded time
+        # Test that the loaded date range is correct
         self.eval_successful_load(end_date=end_date)
         return
 


### PR DESCRIPTION
# Description

Addresses issue raised in comments to the last direct develop commit 🙈 

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Created a new unit test for loading data with custom kwargs that can now be supplied either on instantiation or during the load call.  If a load call kwarg is the same as an instantiation kwarg, the load call one will take precidence.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
