### PR TITLE
BUG: restore coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,3 +55,8 @@ jobs:
 
     - name: Test with pytest
       run: pytest --cov=pysat/
+
+    - name: Publish results to coveralls
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: coveralls --rcfile=setup.cfg --service=github


### PR DESCRIPTION
# Description

Addresses #817 

Somewhere in the primordial windows test branch, coveralls tests were removed during debugging.  This restores them to the develop branch.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Looking at the results on coveralls:
https://coveralls.io/github/pysat/pysat?branch=bug/coveralls

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
