### PR TITLE
Added  `empty_partial` property to the Constellation class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [3.1.0] - 2021-XX-XX
 --------------------
+* New Features
+   * Added the property `empty_partial` to the Constellation class
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -42,7 +42,7 @@ class Constellation(object):
         A list of pysat Instruments that make up the Constellation
     bounds : tuple
         Tuple of two datetime objects or filenames indicating bounds for loading
-        data, a tuple of NoneType objects. Users may provide as a tuple or
+        data, or a tuple of NoneType objects. Users may provide as a tuple or
         tuple of lists (useful for bounds with gaps). The attribute is always
         stored as a tuple of lists for consistency.
     empty : bool

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -40,7 +40,7 @@ class Constellation(object):
     ----------
     instruments : list
         A list of pysat Instruments that make up the Constellation
-    bounds : datetime/filename/None, datetime/filename/None)
+    bounds : tuple
         Tuple of two datetime objects or filenames indicating bounds for loading
         data, a tuple of NoneType objects. Users may provide as a tuple or
         tuple of lists (useful for bounds with gaps). The attribute is always

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -40,10 +40,16 @@ class Constellation(object):
     ----------
     instruments : list
         A list of pysat Instruments that make up the Constellation
-    bounds : (datetime/filename/None, datetime/filename/None)
-        bounds for loading data, supply array_like for a season with gaps.
-        Users may provide as a tuple or tuple of lists, but the attribute is
-        stored as a tuple of lists for consistency
+    bounds : datetime/filename/None, datetime/filename/None)
+        Tuple of two datetime objects or filenames indicating bounds for loading
+        data, a tuple of NoneType objects. Users may provide as a tuple or
+        tuple of lists (useful for bounds with gaps). The attribute is always
+        stored as a tuple of lists for consistency.
+    empty : bool
+        Flag that indicates all Instruments do not contain data when True.
+    empty_partial : bool
+        Flag that indicates at least one Instrument in the Constellation does
+        not have data when True.
 
     """
 
@@ -152,6 +158,8 @@ class Constellation(object):
             output_str += self.index[0].strftime('%d %B %Y %H:%M:%S')
             output_str += ' --- '
             output_str += self.index[-1].strftime('%d %B %Y %H:%M:%S\n')
+            output_str += '{:s} Instruments have data\n'.format(
+                'Some' if self.empty_partial else 'All')
             output_str += 'Number of variables: {:d}\n'.format(
                 len(self.variables))
 
@@ -289,6 +297,13 @@ class Constellation(object):
 
     @property
     def empty(self):
+        """Boolean flag reflecting lack of data, True if there is no Instrument
+        data in all Constellation Instrument.
+        """
+        return self._empty(all_inst=False)
+
+    @property
+    def empty_partial(self):
         """Boolean flag reflecting lack of data, True if there is no Instrument
         data in any Constellation Instrument.
         """

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -193,13 +193,15 @@ class TestConstellationFunc:
     def test_empty_flag_data_empty(self):
         """ Test the status of the empty flag for unloaded data."""
         assert self.const.empty
+        assert self.const.empty_partial
         return
 
     def test_empty_flag_data_empty_partial_load(self):
         """ Test the status of the empty flag for partially loaded data."""
         # Load only one instrument and test the status flag
         self.const.instruments[0].load(date=self.ref_time)
-        assert self.const.empty
+        assert self.const.empty_partial
+        assert not self.const.empty
         return
 
     def test_empty_flag_data_not_empty_partial_load(self):


### PR DESCRIPTION
# Description

Added an `empty_partial` flag to the Constellation class, addresses #800.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Updated unit tests

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
