### PR TITLE
BUG: Added code for missing listify input of []

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         numpy_ver: [latest]
         include:
           - python-version: 3.7
-            numpy_ver: 1.17
+            numpy_ver: 1.17.3
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Improved windows compatibility (#57, #790)
   - Fixed Instrument.load bug that prevented use of instrument specific kwargs
   - Added pytest as a package requirement (#819)
+  - Fixed pysat.utils.listify for empty list inputs (#830)
 - Maintenance
   - Changed pysat.Instrument from treating all support functions as partial
     functions to retaining the original form provided by developer

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -196,7 +196,8 @@ class TestListify():
     @pytest.mark.parametrize('iterable', ['test', ['test'], [[['test']]],
                                           [[[['test']]]],
                                           [['test', 'test']],
-                                          [['test', 'test'], ['test', 'test']]])
+                                          [['test', 'test'], ['test', 'test']],
+                                          [], [[]]])
     def test_listify_list_string_inputs(self, iterable):
         """ Test listify with various list levels of a string"""
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -136,6 +136,8 @@ def listify(iterable):
         list_iter = [arr_iter.tolist()]
     elif arr_iter.shape[0] >= 1:
         list_iter = arr_iter.flatten().tolist()
+    elif arr_iter.shape[0] == 0:
+        list_iter = arr_iter.tolist()
 
     return list_iter
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -134,10 +134,10 @@ def listify(iterable):
     arr_iter = np.asarray(iterable)
     if arr_iter.shape == ():
         list_iter = [arr_iter.tolist()]
-    elif arr_iter.shape[0] >= 1:
-        list_iter = arr_iter.flatten().tolist()
     elif arr_iter.shape[0] == 0:
         list_iter = arr_iter.tolist()
+    else:
+        list_iter = arr_iter.flatten().tolist()
 
     return list_iter
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ dask
 # netCDF 1.5.7 released after RC pull started.
 netCDF4<1.5.7
 numpy>=1.12
-pandas>=0.23
+pandas<1.2.5
 portalocker
 pytest
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask
 # Version restriction imposed due to testing failures on Windows. 
 # netCDF 1.5.7 released after RC pull started.
 netCDF4<1.5.7
-numpy>=1.12
+numpy>=1.17.03
 pandas>=0.23
 portalocker
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask
 # Version restriction imposed due to testing failures on Windows. 
 # netCDF 1.5.7 released after RC pull started.
 netCDF4<1.5.7
-numpy>=1.17.3
+numpy>=1.12
 pandas>=0.23
 portalocker
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ dask
 # Version restriction imposed due to testing failures on Windows. 
 # netCDF 1.5.7 released after RC pull started.
 netCDF4<1.5.7
-numpy>=1.17.03
+numpy>=1.17.3
 pandas>=0.23
 portalocker
 pytest


### PR DESCRIPTION
# Description

Addresses #830

Improves code coverage of `listify`. Now works on empty lists.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Expanded range of inputs of existing tests to include `[]` and `[[]]` inputs.


**Test Configuration**:
* Operating system: MacOS
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
