### PR TITLE
BUG/STY: pandas 1.3.0 compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   - Improved maintenance of documentation build
   - Added a check for use of reserved keywords at instantiation
   - Tests compatible with pysatSpaceWeather 0.0.4 (#782)
+  - Improved pandas 1.3.0 compliance
 
 ## [3.0.0] - 2021-04-01
 - New Features

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1316,24 +1316,24 @@ class TestBasics():
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[changed, 'doubleMLT'] = 0
-        assert np.all(self.testInst[fixed, 'doubleMLT']
-                      == 2. * self.testInst[fixed, 'mlt'])
-        assert np.all(self.testInst[changed, 'doubleMLT'] == 0)
+        assert (self.testInst[fixed, 'doubleMLT']
+                == 2. * self.testInst[fixed, 'mlt']).all
+        assert (self.testInst[changed, 'doubleMLT'] == 0).all
 
     def test_setting_partial_data_by_index_and_name(self):
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[self.testInst.index[0:10], 'doubleMLT'] = 0
-        assert np.all(self.testInst[10:, 'doubleMLT']
-                      == 2. * self.testInst[10:, 'mlt'])
-        assert np.all(self.testInst[0:10, 'doubleMLT'] == 0)
+        assert (self.testInst[10:, 'doubleMLT']
+                == 2. * self.testInst[10:, 'mlt']).all
+        assert (self.testInst[0:10, 'doubleMLT'] == 0).all
 
     def test_modifying_data_inplace(self):
         self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst['doubleMLT'] += 100
-        assert np.all(self.testInst['doubleMLT']
-                      == 2. * self.testInst['mlt'] + 100)
+        assert (self.testInst['doubleMLT']
+                == 2. * self.testInst['mlt'] + 100).all
 
     def test_getting_all_data_by_index(self):
         self.testInst.load(self.ref_time.year, self.ref_doy)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,8 @@
 dask
-# Version restriction imposed due to testing failures on Windows. 
 # netCDF 1.5.7 released after RC pull started.
 netCDF4<1.5.7
 numpy>=1.12
-pandas<1.2.5
+pandas
 portalocker
 pytest
 scipy


### PR DESCRIPTION
# Description

Addresses #833

Improves usage of pandas in unit tests to better comply with updates in pandas 1.3.0

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* pandas 1.3.0, numpy 1.21.0

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
