### PR TITLE
Fixed default `load_netcdf4` labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed noindex warning
    * Fixed redirecting links
    * Made changelog style and line length consistent
+* Bug Fix
+   * Fixed default MetaLabel specification in `pysat.utils.load_netcdf4`
 
 [3.0.1] - 2021-XX-XX
 --------------------


### PR DESCRIPTION
# Description

Addresses #847 by using the `MetaLabel` defaults.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Running unit tests and loading a netCDF file locally:

```
import pysat
fnames = ["your file"]
pandas_format = False  # Or True if it is only a time-dimension data file
data, meta = pysat.utils.load_netcdf4(fnames, pandas_format=pandas_format)
print(meta.labels)

MetaLabels:
-----------
units->units       name->long_name    notes->notes       
desc->desc         min_val->value_min max_val->value_max 
fill_val->fill
```

Previously, 'axis', 'scale', and 'plot' were also present.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
