### PR TITLE
Defining `inst_module` the same regardless of instantiation method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added hidden Constellation methods to determine unique attribute elements
      and set Instrument attributes across all instruments
    * Extended Constellation unit tests
+   * Standardized Instrument instantiation to always define `inst_module`
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation
@@ -21,6 +22,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed noindex warning
    * Fixed redirecting links
    * Made changelog style and line length consistent
+   * Added a paragraph describing how to access Instrument sub-module
+     docstrings from an instantiated Instrument in an interactive session
 * Bug Fix
    * Fixed default MetaLabel specification in `pysat.utils.load_netcdf4`
 

--- a/docs/tutorial/tutorial_basics.rst
+++ b/docs/tutorial/tutorial_basics.rst
@@ -67,8 +67,8 @@ the `wiki <https://github.com/pysat/pysat/wiki/Pysat-Ecosystem-Status-Chart>`_.
 
 You can learn about the different Instruments in an instrument package using
 the utility :py:func:`pysat.utils.display_available_instruments`.  When
-providing an :py:class:`Instrument` sub-module as input, this will list the
-:py:class:`Instrument` module name, all possible combinations of the
+providing an :py:class:`~pysat.Instrument` sub-module as input, this will list
+the :py:class:`~pysat.Instrument` module name, all possible combinations of the
 :py:attr:`tag` and :py:attr:`inst_id` attributes, and a description of the data
 (if available). This example will use the :ref:`instruments-madrigal` package.
 
@@ -81,17 +81,26 @@ providing an :py:class:`Instrument` sub-module as input, this will list the
 
 You can see each listed instrument supports one or more data sets for analysis.
 The sub-modules are named with the convention *platform_name*.  When supplying
-an :py:class:`Instrument` sub-module as input the display utility provides the
-sub-module name instead of the :py:attr:`platform` and :py:attr:`name` because
-non-registered Instruments are instantiated using the :py:data:`inst_module`
-keyword instead of the :py:data:`platform` and :py:data:`name` keywords (jump
-to the :ref:`instantiation` section below for more information).  To use the
-:py:data:`platform` and :py:data:`name` keywords, the instrument must be
-registered.  To display the registered instruments, no input is needed.
+an :py:class:`~pysat.Instrument` sub-module as input the display utility
+provides the sub-module name instead of the :py:attr:`platform` and
+:py:attr:`name` because non-registered Instruments are instantiated using the
+:py:data:`inst_module` keyword instead of the :py:data:`platform` and
+:py:data:`name` keywords (jump to the :ref:`instantiation` section below for
+more information).  To use the :py:data:`platform` and :py:data:`name` keywords,
+the instrument must be registered.  To display the registered instruments, no
+input is needed.
 
 .. code:: python
 
     pysat.utils.display_available_instruments()
+
+
+Regardless of the :ref:`instantiation` method, the :py:func:`help` function can
+use the :py:attr:`~pysat.Instrument.inst_module` as input to access the built-in
+documentation for the :py:class:`~pysat.Instrument` sub-module in an interactive
+environment. Using :py:func:`help` on the instantiated
+:py:class:`~pysat.Instrument` will return the documentation for the general
+:py:class:`~pysat.Instrument` class.
 
 
 .. _tutorial_basics-standard:

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -94,6 +94,7 @@ class InstTestClass():
                 assert inst.name == module.name
                 assert inst.inst_id == inst_id
                 assert inst.tag == tag
+                assert inst.inst_module is not None
 
                 # Test the required class attributes
                 for iattr in self.inst_attrs:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1057,8 +1057,7 @@ class TestBasics():
         del test.load
 
         with pytest.raises(AttributeError):
-            pysat.Instrument(inst_module=test, tag='',
-                             clean_level='clean')
+            pysat.Instrument(inst_module=test, tag='', clean_level='clean')
 
     # -------------------------------------------------------------------------
     #


### PR DESCRIPTION
# Description

This pull request changes the `_assign_attrs` method to define the `inst_module` attribute consistently for all instantiation methods.  This fully addresses #324.  I also:

- Added a paragraph to the docs describing how to use `help` to access the Instrument sub-module information.
- Fixed the `tag` and `inst_id` defaults to reflect the docstring definition and removed the extra logic needed when the old defaults were used.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

```
import pysat
import pysatNASA

cindi = pysat.Instrument(platform='cnofs', name='ivm')
cindi.inst_module
<module 'pysatNASA.instruments.cnofs_ivm' from '~/Git/pysatNASA/pysatNASA/instruments/cnofs_ivm.py'>
```

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant: develop branch of pysatNASA

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
