### PR TITLE
STY: docstrings -- test instruments

### DIFF
--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -1,9 +1,7 @@
 # -*- coding: utf-8 -*-
-"""
-pysat.instruments is a pysat module that provides
-the interface for pysat to download, load, manage,
-modify and analyze science data.  Each instrument
-is contained within a subpackage of this set.
+"""Collection of test instruments for the core pysat routines.
+
+Each instrument is contained within a subpackage of this set.
 """
 
 __all__ = ['pysat_testing', 'pysat_testing_xarray', 'pysat_testing2d',

--- a/pysat/instruments/methods/__init__.py
+++ b/pysat/instruments/methods/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
-pysat.instruments.methods is a pysat module that provides
-specific functions for instruments and classes of instruments.
+"""Provides specific functions for instruments and classes of instruments.
+
 Each set of methods is contained within a subpackage of this set.
 """
 

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""Provides generalized routines for integrating instruments into pysat.
-"""
+"""Provides generalized routines for integrating instruments into pysat."""
 
 import datetime as dt
 import numpy as np
@@ -12,7 +11,7 @@ logger = pysat.logger
 
 
 def is_daily_file_cadence(file_cadence):
-    """ Evaluate file cadence to see if it is daily or greater than daily
+    """Evaluate file cadence to see if it is daily or greater than daily.
 
     Parameters
     ----------
@@ -147,7 +146,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
 
 def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
-    """Use datetime instead of timestamp for Epoch
+    """Use datetime instead of timestamp for Epoch.
 
     Parameters
     ----------
@@ -168,7 +167,7 @@ def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
 
 
 def remove_leading_text(inst, target=None):
-    """Removes leading text on variable names
+    """Remove leading text on variable names.
 
     Parameters
     ----------
@@ -212,7 +211,7 @@ def remove_leading_text(inst, target=None):
 
 
 def filename_creator(value, format_str=None, start_date=None, stop_date=None):
-    """Creates filenames as needed to support use of generated pysat data sets
+    """Create filenames as needed to support use of generated pysat data sets.
 
     Parameters
     ----------
@@ -251,7 +250,7 @@ def filename_creator(value, format_str=None, start_date=None, stop_date=None):
 
 
 def load_csv_data(fnames, read_csv_kwargs=None):
-    """Load CSV data from a list of files into a single DataFrame
+    """Load CSV data from a list of files into a single DataFrame.
 
     Parameters
     ----------

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -1,3 +1,5 @@
+"""Standard functions for the test instruments."""
+
 import datetime as dt
 import numpy as np
 import os
@@ -18,7 +20,7 @@ with pysat.utils.NetworkLock(os.path.join(pysat.here, 'citation.txt'), 'r') as \
 
 
 def init(self, test_init_kwarg=None):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation.
 
@@ -49,7 +51,7 @@ def init(self, test_init_kwarg=None):
 
 
 def clean(self, test_clean_kwarg=None):
-    """Cleaning function
+    """Pass through when asked to clean a test instrument.
 
     Parameters
     ----------
@@ -67,7 +69,7 @@ def clean(self, test_clean_kwarg=None):
 
 # Optional method
 def preprocess(self, test_preprocess_kwarg=None):
-    """Customization method that performs standard preprocessing.
+    """Perform standard preprocessing.
 
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue). Object
@@ -88,7 +90,7 @@ def preprocess(self, test_preprocess_kwarg=None):
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
                file_date_range=None, test_dates=None, mangle_file_dates=False,
                test_list_files_kwarg=None):
-    """Produce a fake list of files spanning three years
+    """Produce a fake list of files spanning three years.
 
     Parameters
     ----------
@@ -150,8 +152,11 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
                       start=None, stop=None, test_dates=None, user=None,
                       password=None, mangle_file_dates=False,
                       test_list_remote_kwarg=None):
-    """Produce a fake list of files spanning three years and one month to
-    simulate new data files on a remote server
+    """Produce a fake list of files to simulate new files on a remote server.
+
+    Note
+    ----
+    List spans three years and one month.
 
     Parameters
     ----------
@@ -213,8 +218,10 @@ def list_remote_files(tag=None, inst_id=None, data_path=None, format_str=None,
 
 def download(date_array, tag, inst_id, data_path=None, user=None,
              password=None, test_download_kwarg=None):
-    """Simple pass function for pysat compatibility for test instruments.
+    """Pass through when asked to download for a test instrument.
 
+    Note
+    ----
     This routine is invoked by pysat and is not intended for direct use by the
     end user.
 
@@ -269,7 +276,7 @@ def download(date_array, tag, inst_id, data_path=None, user=None,
 
 def generate_fake_data(t0, num_array, period=5820, data_range=[0.0, 24.0],
                        cyclic=True):
-    """Generates fake data over a given range
+    """Generate fake data over a given range.
 
     Parameters
     ----------
@@ -307,7 +314,7 @@ def generate_fake_data(t0, num_array, period=5820, data_range=[0.0, 24.0],
 
 
 def generate_times(fnames, num, freq='1S'):
-    """Construct list of times for simulated instruments
+    """Construct list of times for simulated instruments.
 
     Parameters
     ----------
@@ -366,7 +373,7 @@ def generate_times(fnames, num, freq='1S'):
 
 
 def define_period():
-    """Define the default periods for the fake data functions
+    """Define the default periods for the fake data functions.
 
     Returns
     -------
@@ -387,7 +394,7 @@ def define_period():
 
 
 def define_range():
-    """Define the default ranges for the fake data functions
+    """Define the default ranges for the fake data functions.
 
     Returns
     -------
@@ -404,7 +411,7 @@ def define_range():
 
 
 def eval_dep_warnings(warns, check_msgs):
-    """Evaluate deprecation warnings by category and message
+    """Evaluate deprecation warnings by category and message.
 
     Parameters
     ----------

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produces fake instrument data for testing.
-"""
+"""Produces fake instrument data for testing."""
 
 import datetime as dt
 import functools
@@ -48,7 +46,7 @@ preprocess = mm_test.preprocess
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, malformed_index=False,
          num_samples=None, test_load_kwarg=None):
-    """ Loads the test files
+    """Load the test files.
 
     Parameters
     ----------

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produces fake instrument data for testing.
-"""
+"""Produces fake instrument data for testing."""
 
 import datetime as dt
 import functools
@@ -35,7 +33,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
          num_samples=None, test_load_kwarg=None):
-    """ Loads the test files
+    """Load the test files.
 
     Parameters
     ----------

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produces fake instrument data for testing.
-"""
+"""Produces fake instrument data for testing."""
 
 import datetime as dt
 import functools
@@ -41,7 +39,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
          num_samples=None, test_load_kwarg=None):
-    """ Loads the test files
+    """Load the test files.
 
     Parameters
     ----------

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produces fake instrument data for testing.
-"""
+"""Produces fake instrument data for testing."""
 
 import datetime as dt
 import functools
@@ -42,7 +40,7 @@ preprocess = mm_test.preprocess
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, malformed_index=False,
          num_samples=None, test_load_kwarg=None):
-    """ Loads the test files
+    """Load. the test files.
 
     Parameters
     ----------

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -40,7 +40,7 @@ preprocess = mm_test.preprocess
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, malformed_index=False,
          num_samples=None, test_load_kwarg=None):
-    """Load. the test files.
+    """Load the test files.
 
     Parameters
     ----------

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-"""
-Produces fake instrument data for testing.
-"""
+"""Produces fake instrument data for testing."""
 
 import datetime as dt
 import functools
@@ -36,7 +34,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, num_samples=None,
          test_load_kwarg=None):
-    """ Loads the test files
+    """Load the test files.
 
     Parameters
     ----------

--- a/pysat/instruments/templates/__init__.py
+++ b/pysat/instruments/templates/__init__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
-pysat.instruments.methods is a pysat module that provides
-specific functions for instruments and classes of instruments.
+"""Provides specific functions for instruments and classes of instruments.
+
 Each set of methods is contained within a subpackage of this set.
 """
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -143,7 +143,7 @@ def init(self):
 
 # Required method
 def clean(self):
-    """Return PLATFORM/NAME data cleaned to the specified level.
+    """Return `platform_name` data cleaned to the specified level.
 
     Cleaning level is specified in inst.clean_level and pysat
     will accept user input for several strings. The clean_level is
@@ -243,7 +243,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
 # Required function
 def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
              **kwargs):
-    """Download PLATFORM/NAME data (placeholder).
+    """Download `platform_name` data from the remote repository.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.
@@ -279,7 +279,7 @@ def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
 
 # Required function
 def load(fnames, tag=None, inst_id=None, custom_keyword=None):
-    """Load PLATFORM data into (PANDAS/XARRAY).
+    """Load `platform_name` data and meta data.
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-"""
-This is a template for a pysat.Instrument support file.
+"""Template for a pysat.Instrument support file.
+
 Modify this file as needed when adding a new Instrument to pysat.
 
 This is a good area to introduce the instrument, provide background
@@ -123,7 +123,7 @@ _password_req = {'': {'': True, 'tag_string': False}}
 
 # Required method
 def init(self):
-    """Initializes the Instrument object with instrument specific values.
+    """Initialize the Instrument object with instrument specific values.
 
     Runs once upon instantiation. Object modified in place.  Use this to set
     the acknowledgements and references.
@@ -143,7 +143,7 @@ def init(self):
 
 # Required method
 def clean(self):
-    """Method to return PLATFORM/NAME data cleaned to the specified level
+    """Return PLATFORM/NAME data cleaned to the specified level.
 
     Cleaning level is specified in inst.clean_level and pysat
     will accept user input for several strings. The clean_level is
@@ -165,7 +165,7 @@ def clean(self):
 
 # Optional method
 def preprocess(self):
-    """Customization method that performs standard preprocessing.
+    """Perform standard preprocessing.
 
     This routine is automatically applied to the Instrument object
     on every load by the pysat nanokernel (first in queue). Object
@@ -243,7 +243,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
 # Required function
 def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
              **kwargs):
-    """Placeholder for PLATFORM/NAME downloads.
+    """Download PLATFORM/NAME data (placeholder).
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.
@@ -279,7 +279,7 @@ def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
 
 # Required function
 def load(fnames, tag=None, inst_id=None, custom_keyword=None):
-    """Loads PLATFORM data into (PANDAS/XARRAY).
+    """Load PLATFORM data into (PANDAS/XARRAY).
 
     This routine is called as needed by pysat. It is not intended
     for direct user interaction.

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -1,3 +1,11 @@
+"""Unit and Integration Tests for each instrument module.
+
+Note
+----
+Imports test methods from pysat.tests.instrument_test_class
+
+"""
+
 import tempfile
 
 import pytest
@@ -53,13 +61,17 @@ for method in method_list:
 
 
 class TestInstruments(InstTestClass):
-    """Uses class level setup and teardown so that all tests use the same
+    """Main class for instrument tests.
+
+    Note
+    ----
+    Uses class level setup and teardown so that all tests use the same
     temporary directory. We do not want to geneate a new tempdir for each test,
     as the load tests need to be the same as the download tests.
     """
 
     def setup_class(self):
-        """Runs once before the tests to initialize the testing setup."""
+        """Initialize the testing setup once before all tests are run."""
         # Make sure to use a temporary directory so that the user's setup is not
         # altered
         self.tempdir = tempfile.TemporaryDirectory()
@@ -69,9 +81,13 @@ class TestInstruments(InstTestClass):
         # to point to their own subpackage location, e.g.,
         # self.inst_loc = mypackage.instruments
         self.inst_loc = pysat.instruments
+        return
 
     def teardown_class(self):
-        """Runs once to clean up testing from this class."""
+        """Clean up downloaded files and parameters from tests."""
         pysat.params['data_dirs'] = self.saved_path
         self.tempdir.cleanup()
         del self.inst_loc, self.saved_path, self.tempdir
+        return
+
+    # Custom package unit tests can be added here


### PR DESCRIPTION
# Description

Addresses #860 (partial).

Scrubs docstrings in test instruments and improves usage of returns.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

With `flake8-docstrings` installed:
```
flake8 --select=D,E,F,W --count --statistics
```

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* flake8, flake8-docstrings

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
