### PR TITLE
STY: cleanup previous pulls in flake8 chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`
    * Streamlined unit tests for `test_orbits`
+   * Updated class declaration consistent with python 3
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`
    * Streamlined unit tests for `test_orbits`
-   * Updated class declaration consistent with python 3
+   * Updated class declaration to be consistent with python 3 standards
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -1133,8 +1133,8 @@ class TestFilesRaceCondition(object):
                          temporary_file_list=self.temporary_file_list)
         pysat.params['data_dirs'] = self.data_paths
 
-# TODO: This needs to be replaced or expanded based on the tests that
-# portalocker uses
+# TODO(jklenzing): This needs to be replaced or expanded based on the tests that
+# portalocker uses -- #871
     def test_race_condition(self):
         """Test that multiple instances of pysat instrument creation run."""
         processes = 5

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -14,8 +14,8 @@ import pytest
 
 import pysat
 import pysat.instruments.pysat_testing
-from pysat.utils import NetworkLock
 from pysat.tests.ci_test_class import CICleanSetup
+from pysat.utils import NetworkLock
 
 
 def create_dir(inst=None, temporary_file_list=False):

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -1133,8 +1133,8 @@ class TestFilesRaceCondition(object):
                          temporary_file_list=self.temporary_file_list)
         pysat.params['data_dirs'] = self.data_paths
 
-# TODO(jklenzing): This needs to be replaced or expanded based on the tests that
-# portalocker uses -- #871
+# TODO(#871): This needs to be replaced or expanded based on the tests that
+# portalocker uses
     def test_race_condition(self):
         """Test that multiple instances of pysat instrument creation run."""
         processes = 5

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -334,8 +334,8 @@ class TestBasics(object):
         return
 
     def test_year_doy_files_no_gap_in_name_directly_call_from_os(self):
-        """Test that `Files.from_os` generates file list for date w/o delimiter.
-        """
+        """Test that `Files.from_os` makes file list for date w/o delimiter."""
+
         # create a bunch of files by year and doy
         root_fname = ''.join(('pysat_testing_junk_{year:04d}{day:03d}_stuff.',
                               'pysat_testing_file'))

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -143,7 +143,7 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
     return
 
 
-class TestNoDataDir():
+class TestNoDataDir(object):
     """Test cases where data directory is not specified."""
 
     def setup(self):
@@ -171,7 +171,7 @@ class TestNoDataDir():
         return
 
 
-class TestBasics():
+class TestBasics(object):
     """Unit tests for `pysat._files`."""
 
     def setup_class(self):
@@ -560,7 +560,7 @@ class TestBasicsNoFileListStorage(TestBasics):
         return
 
 
-class TestInstWithFiles():
+class TestInstWithFiles(object):
     """Test basic file operations within an instrument."""
 
     def setup_class(self):
@@ -789,7 +789,7 @@ class TestInstWithFiles():
         return
 
 
-class TestInstWithFilesNonStandard():
+class TestInstWithFilesNonStandard(object):
     """Specialized tests for instruments with non-standard setups."""
 
     def setup_class(self):
@@ -1064,7 +1064,7 @@ def create_instrument(j):
     return 'instrument {}'.format(j)
 
 
-class TestFilesRaceCondition():
+class TestFilesRaceCondition(object):
     """Tests for multiple instances of pysat running simultaneously."""
 
     def setup_class(self):

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -21,9 +21,8 @@ from pysat.utils import testing
 logger = pysat.logger
 
 
-class TestBasics():
-    """Basic unit tests for metadata operations.
-    """
+class TestBasics(object):
+    """Basic unit tests for metadata operations."""
 
     def setup(self):
         """Set up the unit test environment for each method."""

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -65,8 +65,8 @@ class TestBasics(object):
         return
 
     def test_default_label_value_raises_error(self):
-        """Test `MetaLabels.default_values_from_attr` ValueError with bad attr.
-        """
+        """Test `MetaLabels.default_values_from_attr` errors with bad attr."""
+
         with pytest.raises(ValueError) as verr:
             self.meta.labels.default_values_from_attr('not_an_attr')
 
@@ -435,8 +435,7 @@ class TestBasics(object):
         return
 
     def test_inst_assign_from_meta_w_ho_then_update(self):
-        """Test assignment of `Instrument.meta` from separate Meta with HO data.
-        """
+        """Test assign `Instrument.meta` from separate Meta with HO data."""
         self.testInst.load(date=self.stime)
         frame = pds.DataFrame({fkey: np.arange(10) for fkey in self.frame_list},
                               columns=self.frame_list)
@@ -676,8 +675,8 @@ class TestBasics(object):
         return
 
     def test_basic_concat_w_ho_collisions_not_strict(self):
-        """Test under non-strict concat with HO metadata with multiple overlaps.
-        """
+        """Test non-strict concat with HO metadata with multiple overlaps."""
+
         self.meta['new1'] = {'units': 'hey1', 'long_name': 'crew'}
         self.meta['new2'] = {'units': 'hey', 'long_name': 'boo',
                              'description': 'boohoo'}
@@ -1037,8 +1036,8 @@ class TestBasics(object):
         return
 
     def test_multiple_input_names_null_value_preexisting_values(self):
-        """Test setting multiple input names to null with pre-existing values.
-        """
+        """Test setting multiple input names to null w/ pre-existing values."""
+
         self.meta[['test1', 'test2']] = {'units': ['degrees', 'hams'],
                                          'long_name': ['testing', 'further']}
         self.meta[['test1', 'test2']] = {}
@@ -1119,8 +1118,8 @@ class TestBasics(object):
         return
 
     def test_change_case_of_meta_labels(self):
-        """Test changing case of meta labels after initialization.
-        """
+        """Test changing case of meta labels after initialization."""
+
         self.meta_labels = {'units': ('units', str), 'name': ('long_name', str)}
         self.meta = pysat.Meta(labels=self.meta_labels)
         self.meta['new'] = {'units': 'hey', 'long_name': 'boo'}
@@ -1134,8 +1133,8 @@ class TestBasics(object):
         return
 
     def test_case_change_of_meta_labels_w_ho(self):
-        """Test changing case of meta labels after initialization with HO data.
-        """
+        """Test change case of meta labels after initialization with HO data."""
+
         # Set the initial labels
         self.meta_labels = {'units': ('units', str), 'name': ('long_Name', str)}
         self.meta = pysat.Meta(labels=self.meta_labels)
@@ -1160,8 +1159,8 @@ class TestBasics(object):
         return
 
     def test_change_Units_and_Name_case_w_ho_wrong_case(self):
-        """Test that `units` and `long_name` will error if label case is wrong.
-        """
+        """Test that `units` and `long_name` error if label case is wrong."""
+
         self.meta_labels = {'units': ('units', str), 'name': ('long_Name', str)}
         self.meta = pysat.Meta(labels=self.meta_labels)
         meta2 = pysat.Meta(labels=self.meta_labels)
@@ -1230,8 +1229,8 @@ class TestBasics(object):
         return
 
     def test_get_attribute_name_case_preservation_w_higher_order(self):
-        """Test that getting attribute names preserves the case with ho metadata.
-        """
+        """Test that get attribute names preserves the case with ho metadata."""
+
         self.meta['new'] = {'units': 'hey', 'long_name': 'boo'}
         meta2 = pysat.Meta()
         meta2['NEW21'] = {'units': 'hey2', 'long_name': 'boo2',
@@ -1249,8 +1248,8 @@ class TestBasics(object):
         return
 
     def test_get_attribute_name_case_preservation_w_higher_order_2(self):
-        """Test that getting attribute names preserves the case with ho metadata.
-        """
+        """Test that get attribute names preserves the case with ho metadata."""
+
         self.meta['new'] = {'units': 'hey', 'long_name': 'boo'}
         meta2 = pysat.Meta()
         meta2['NEW21'] = {'units': 'hey2', 'long_name': 'boo2',
@@ -1268,8 +1267,8 @@ class TestBasics(object):
         return
 
     def test_get_attribute_name_case_preservation_w_ho_reverse_order(self):
-        """Test that getting attribute names preserves the case when reversed.
-        """
+        """Test that getting attribute names preserves the case in reverse."""
+
         self.meta['new'] = {'units': 'hey', 'long_name': 'boo'}
         meta2 = pysat.Meta()
         meta2['NEW21'] = {'units': 'hey2', 'long_name': 'boo2',

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -66,7 +66,7 @@ def remove_files(inst):
     return
 
 
-class TestCIonly():
+class TestCIonly(object):
     """Tests where we mess with local settings.
 
     Note
@@ -117,7 +117,7 @@ class TestCIonly():
         return
 
 
-class TestScaleUnits():
+class TestScaleUnits(object):
     """Unit tests for `scale_units`."""
 
     def setup(self):
@@ -226,7 +226,7 @@ class TestScaleUnits():
         return
 
 
-class TestListify():
+class TestListify(object):
     """Unit tests for the `listify` function."""
 
     @pytest.mark.parametrize('iterable,nitem', [
@@ -279,7 +279,7 @@ class TestListify():
         return
 
 
-class TestLoadNetCDF4():
+class TestLoadNetCDF4(object):
     """Unit tests for `load_netcdf4`."""
 
     def setup(self):
@@ -487,7 +487,7 @@ class TestLoadNetCDF4():
         return
 
 
-class TestLoadNetCDF4XArray():
+class TestLoadNetCDF4XArray(object):
     """Unit tests for `load_netcdf4` using xarray data.
 
     Note
@@ -610,7 +610,7 @@ class TestLoadNetCDF42DPandas(TestLoadNetCDF4):
         return
 
 
-class TestFmtCols():
+class TestFmtCols(object):
     """Unit tests for `fmt_output_in_cols`."""
 
     def setup(self):
@@ -778,7 +778,7 @@ class TestAvailableInst(TestWithRegistration):
         return
 
 
-class TestNetworkLock():
+class TestNetworkLock(object):
     """Unit tests for NetworkLock class."""
 
     def setup(self):
@@ -828,7 +828,7 @@ class TestNetworkLock():
         return
 
 
-class TestGenerateInstList():
+class TestGenerateInstList(object):
     """Unit tests for `utils.generate_instrument_list`."""
 
     def setup(self):

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -6,9 +6,9 @@
 """Tests the pysat utils core functions."""
 
 import contextlib
-from io import StringIO
 from importlib import reload
 import inspect
+from io import StringIO
 import numpy as np
 import os
 import portalocker

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -14,7 +14,7 @@ import pysat
 from pysat.utils import coords
 
 
-class TestCyclicData():
+class TestCyclicData(object):
     """Unit tests for the `adjust_cyclic_data` function."""
 
     def setup(self):
@@ -48,7 +48,7 @@ class TestCyclicData():
         return
 
 
-class TestUpdateLon():
+class TestUpdateLon(object):
     """Unit tests for the `update_longitude` function."""
 
     def setup(self):
@@ -93,7 +93,7 @@ class TestUpdateLon():
         return
 
 
-class TestCalcSLT():
+class TestCalcSLT(object):
     """Unit tests for `calc_solar_local_time`.
 
     Note

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -231,8 +231,7 @@ class TestCalcSLT(object):
     @pytest.mark.parametrize("name", ["testmodel", "testing2d",
                                       "testing2d_xarray"])
     def test_lon_broadcasting_calc_solar_local_time_no_mod_ref_date(self, name):
-        """Test non modulated SLT output for a 2 day range with a ref date.
-        """
+        """Test non modulated SLT output for a 2 day range with a ref date."""
 
         # Instantiate instrument and load data
         self.py_inst = pysat.Instrument(platform='pysat', name=name)

--- a/pysat/tests/test_utils_testing.py
+++ b/pysat/tests/test_utils_testing.py
@@ -20,6 +20,7 @@ class TestTestingUtils(object):
                               ([None, False], [True, False, None])])
     def test_assert_list_contains_good(self, slist, blist):
         """Test the successful evaluation of overlapping list contents."""
+
         testing.assert_list_contains(slist, blist)
         return
 
@@ -28,8 +29,8 @@ class TestTestingUtils(object):
                               (['one', 'two'], ['three', 'one']),
                               ([None, False], [True, False, "None"])])
     def test_assert_list_contains_bad(self, slist, blist):
-        """Test raises AssertionError for lists with elements that are unique.
-        """
+        """Test raises AssertionError for lists where elements are unique."""
+
         with pytest.raises(AssertionError) as aerr:
             testing.assert_list_contains(slist, blist)
 
@@ -45,6 +46,7 @@ class TestTestingUtils(object):
                               ([np.nan, 1], [1, np.nan], {"test_nan": True})])
     def test_assert_list_equal_good(self, slist, blist, kwargs):
         """Test the evaluation of lists with unordered but identical values."""
+
         testing.assert_lists_equal(slist, blist, **kwargs)
         return
 
@@ -56,6 +58,7 @@ class TestTestingUtils(object):
                               ([None, False], [True, False, "None"])])
     def test_assert_list_equal_bad(self, slist, blist):
         """Test the evaluation of overlapping list contents."""
+
         with pytest.raises(AssertionError):
             testing.assert_lists_equal(slist, blist)
         return
@@ -66,6 +69,7 @@ class TestTestingUtils(object):
                                             (np.inf, np.inf), (10, 10)])
     def test_nan_equal_good(self, val1, val2):
         """Test successful evaluation of equivalent values."""
+
         assert testing.nan_equal(val1, val2)
         return
 
@@ -75,5 +79,6 @@ class TestTestingUtils(object):
                                             (np.inf, -np.inf), (1, 11)])
     def test_nan_equal_bad(self, val1, val2):
         """Test successful evaluation of un-equivalent values."""
+
         assert not testing.nan_equal(val1, val2)
         return

--- a/pysat/tests/test_utils_testing.py
+++ b/pysat/tests/test_utils_testing.py
@@ -11,7 +11,7 @@ import pytest
 from pysat.utils import testing
 
 
-class TestTestingUtils():
+class TestTestingUtils(object):
     """Unit tests for `pysat.utils.testing` functions."""
 
     @pytest.mark.parametrize("slist, blist",

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -10,8 +10,8 @@ import numpy as np
 
 import pytest
 
-from pysat.utils import time as pytime
 from pysat.utils import testing
+from pysat.utils import time as pytime
 
 
 class TestGetYearDay():

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -14,7 +14,7 @@ from pysat.utils import testing
 from pysat.utils import time as pytime
 
 
-class TestGetYearDay():
+class TestGetYearDay(object):
     """Unit tests for `getyrdoy`."""
 
     @pytest.mark.parametrize("date,tst_yr,tst_doy",
@@ -38,7 +38,7 @@ class TestGetYearDay():
         return
 
 
-class TestParseDate():
+class TestParseDate(object):
     """Unit tests for parse_date."""
 
     @pytest.mark.parametrize("in_args,in_kwargs,tst_date", [
@@ -71,7 +71,7 @@ class TestParseDate():
         return
 
 
-class TestCalcFreqRes():
+class TestCalcFreqRes(object):
     """Unit tests for `calc_res`, `freq_to_res`, and `calc_freq`."""
 
     def setup(self):
@@ -145,7 +145,7 @@ class TestCalcFreqRes():
         return
 
 
-class TestCreateDateRange():
+class TestCreateDateRange(object):
     """Unit tests for `create_date_range`."""
 
     @pytest.mark.parametrize("start,stop,tst_len", [
@@ -167,7 +167,7 @@ class TestCreateDateRange():
         return
 
 
-class TestCreateDatetimeIndex():
+class TestCreateDatetimeIndex(object):
     """Unit test `create_datetime_index`."""
 
     def setup(self):
@@ -218,7 +218,7 @@ class TestCreateDatetimeIndex():
         return
 
 
-class TestFilterDatetimeInput():
+class TestFilterDatetimeInput(object):
     """Unit tests for `filter_datetime_input`."""
 
     def test_filter_datetime_input_none(self):

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -184,8 +184,7 @@ class TestCreateDatetimeIndex(object):
         return
 
     def test_create_datetime_index(self):
-        """Test creation of an array of datetime objects from arrays of inputs.
-        """
+        """Test create an array of datetime objects from arrays of inputs."""
 
         dates = pytime.create_datetime_index(year=self.year, month=self.month,
                                              day=self.day, uts=self.uts)

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -7,8 +7,15 @@ of formats, loading of files, and user-supplied info
 for the pysat data directory structure.
 """
 
-from pysat.utils import coords, files, time, registry, testing
-from pysat.utils._core import scale_units, listify, load_netcdf4
-from pysat.utils._core import NetworkLock, generate_instrument_list
 from pysat.utils._core import available_instruments
 from pysat.utils._core import display_available_instruments
+from pysat.utils._core import generate_instrument_list
+from pysat.utils._core import listify
+from pysat.utils._core import load_netcdf4
+from pysat.utils._core import NetworkLock
+from pysat.utils._core import scale_units
+from pysat.utils import coords
+from pysat.utils import files
+from pysat.utils import registry
+from pysat.utils import testing
+from pysat.utils import time


### PR DESCRIPTION
# Description

Addresses #860

Updates a few styles from previous pulls now that `hacking` may be incorporated alongside `flake8-docstrings`.  Changes include 
- "new style" declaration of classes (inherit from object)
- Tightening up one-line docstrings
- import order
- Include more info on TODO comments


## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

For each modified file
```
flake8 --select=D,H --count --statistics ./pysat/tests/test_utils_testing.py
```

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* Requires: `flake8`, `flake8-docstrings`, `hacking`

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
