### PR TITLE
STY/ENH: Testing Instruments -- metadata and start_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`
    * Streamlined unit tests for `test_orbits`
+   * Moved metadata generation for test instruments to `methods.testing`
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Extended Constellation unit tests
    * Standardized Instrument instantiation to always define `inst_module`
    * Extended testing options for `pysat.utils.testing` functions
+   * Added `start_time` keyword for test instruments
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -77,6 +77,8 @@ def preprocess(self, test_preprocess_kwarg=None):
 
     Parameters
     ----------
+    self : pysat.Instrument
+        This object
     test_preprocess_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -85,6 +87,102 @@ def preprocess(self, test_preprocess_kwarg=None):
     self.test_preprocess_kwarg = test_preprocess_kwarg
 
     return
+
+
+def initialize_test_meta(epoch_name, data_keys):
+    """Initialize meta data for test instruments.
+
+    This routine should be applied to test instruments at the end of the load
+    routine.
+
+    Parameters
+    ----------
+    epoch_name : str
+        The variable name of the instrument epoch.
+    data : pds.DataFrame or xr.Dataset
+        The dataset keys from the instrument.
+
+    """
+    # create standard metadata for all parameters
+    meta = pysat.Meta()
+    meta[epoch_name] = {'long_name': 'Datetime Index'}
+    meta['uts'] = {'units': 's', 'long_name': 'Universal Time',
+                   'desc': 'Number of seconds since mindight UT',
+                   'value_min': 0.0, 'value_max': 86400.0}
+    meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time',
+                   'value_min': 0.0, 'value_max': 24.0}
+    meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time',
+                   'value_min': 0.0, 'value_max': 24.0}
+    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude',
+                         'value_min': 0.0, 'value_max': 360.0}
+    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude',
+                        'value_min': -90.0, 'value_max': 90.0}
+    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
+    meta['orbit_num'] = {'units': '', 'long_name': 'Orbit Number',
+                         'desc': 'Orbit Number', 'value_min': 0.0,
+                         'value_max': 25000.0,
+                         'notes': ''.join(['Number of orbits since the start ',
+                                           'of the mission. For this ',
+                                           'simulation we use the number of ',
+                                           '5820 second periods since the ',
+                                           'start, 2008-01-01.'])}
+
+    # Set profile metadata
+    profile_meta = pysat.Meta()
+    profile_meta['density'] = {'long_name': 'profiles'}
+    profile_meta['dummy_str'] = {'long_name': 'profiles'}
+    profile_meta['dummy_ustr'] = {'long_name': 'profiles'}
+    meta['profiles'] = {'meta': profile_meta, 'long_name': 'profiles'}
+
+    # Set variable profile metadata
+    variable_profile_meta = pysat.Meta()
+    variable_profile_meta['variable_profiles'] = {'long_name': 'series'}
+    meta['variable_profiles'] = {'meta': variable_profile_meta,
+                                 'long_name': 'series'}
+
+    # Set series profile metadata
+    series_profile_meta = pysat.Meta()
+    series_profile_meta['series_profiles'] = {'long_name': 'series'}
+    meta['series_profiles'] = {'meta': series_profile_meta,
+                               'long_name': 'series'}
+    meta['profiles'] = {'meta': profile_meta, 'long_name': 'profiles'}
+
+    # Set altitude profile metadata
+    alt_profile_meta = pysat.Meta()
+    alt_profile_meta['density'] = {'long_name': 'profiles'}
+    alt_profile_meta['fraction'] = {'long_name': 'profiles'}
+    meta['alt_profiles'] = {'meta': alt_profile_meta, 'long_name': 'profiles'}
+
+    # Set image metadata
+    image_meta = pysat.Meta()
+    image_meta['density'] = {'long_name': 'profiles'}
+    image_meta['fraction'] = {'long_name': 'profiles'}
+    meta['images'] = {'meta': image_meta, 'long_name': 'profiles'}
+    meta['x'] = {'long_name': 'x-value of image pixel',
+                 'notes': 'Dummy Variable'}
+    meta['y'] = {'long_name': 'y-value of image pixel',
+                 'notes': 'Dummy Variable'}
+    meta['z'] = {'long_name': 'z-value of profile height',
+                 'notes': 'Dummy Variable'}
+    meta['image_lat'] = {'long_name': 'Latitude of image pixel',
+                         'notes': 'Dummy Variable'}
+    meta['image_lon'] = {'long_name': 'Longitude of image pixel',
+                         'notes': 'Dummy Variable'}
+    meta['profile_height'] = {'long_name': 'profile height'}
+    meta['variable_profile_height'] = {'long_name': 'Variable Profile Height'}
+
+    # Set any dummy variable metadata present in instrument keys
+    for var in data_keys:
+        if var.find('dummy') >= 0:
+            meta[var] = {'units': 'none', 'long_name': var,
+                         'notes': 'Dummy variable'}
+
+    # Drop unused meta data for desired instrument.
+    for var in meta.keys():
+        if var not in data_keys:
+            meta.drop(var)
+
+    return meta
 
 
 def list_files(tag=None, inst_id=None, data_path=None, format_str=None,

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -103,7 +103,7 @@ def initialize_test_meta(epoch_name, data_keys):
         The dataset keys from the instrument.
 
     """
-    # create standard metadata for all parameters
+    # Create standard metadata for all parameters
     meta = pysat.Meta()
     meta[epoch_name] = {'long_name': 'Datetime Index'}
     meta['uts'] = {'units': 's', 'long_name': 'Universal Time',

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -181,6 +181,8 @@ def initialize_test_meta(epoch_name, data_keys):
     for var in meta.keys():
         if var not in data_keys:
             meta.drop(var)
+            if var in meta.keys_nD():
+                meta.ho_data.pop(var)
 
     return meta
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -22,7 +22,7 @@ tags = {'': 'Regular testing data set',
         'no_download': 'simulate an instrument without download support',
         'non_strict': 'simulate an instrument without strict_time_flag',
         'user_password': 'simulates an instrument that requires a password',
-        'default_meta': 'simulates an instrument using the default meta'}
+        'default_meta': 'simulates an instrument using the default metadata'}
 
 # dictionary of satellite IDs, list of corresponding tags
 # a numeric string can be used in inst_id to change the number of points per day
@@ -45,7 +45,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, malformed_index=False,
-         start_time=None, num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=86400, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -74,7 +74,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         (default=None)
     num_samples : int
         Maximum number of times to generate.  Data points will not go beyond the
-        current day.
+        current day. (default=86400)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -94,9 +94,6 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
 
-    if num_samples is None:
-        # Default to 1 day at a frequency of 1S
-        num_samples = 86400
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='1S',
                                                start_time=start_time)
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -167,47 +167,8 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     data.index = index
     data.index.name = 'Epoch'
 
-    # Set the meta data
-    meta = pysat.Meta()
-    meta['uts'] = {'units': 's', 'long_name': 'Universal Time', 'custom': False}
-    meta['Epoch'] = {'units': 'Milliseconds since 1970-1-1',
-                     'Bin_Location': 0.5,
-                     'notes': 'UTC time at middle of geophysical measurement.',
-                     'desc': 'UTC seconds'}
-    meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time',
-                   'desc': 'Magnetic Local Time',
-                   'value_min': 0.0, 'value_max': 24.0,
-                   'notes': ''.join(['Magnetic Local Time is the solar local ',
-                                     'time of thefield line at the location ',
-                                     'where the field crosses the magnetic ',
-                                     'equator. In this case we just simulate ',
-                                     '0-24 with a consistent orbital period ',
-                                     'and an offset with SLT.']),
-                   'scale': 'linear'}
-    meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time',
-                   'desc': 'Solar Local Time', 'value_min': 0.0,
-                   'value_max': 24.0,
-                   'notes': ''.join(['Solar Local Time is the local time ',
-                                     '(zenith angle of sun) of the given ',
-                                     'location. Overhead noon, +/- 90 is 6, ',
-                                     '18 SLT .'])}
-    meta['orbit_num'] = {'units': '', 'long_name': 'Orbit Number',
-                         'desc': 'Orbit Number', 'value_min': 0.0,
-                         'value_max': 25000.0,
-                         'notes': ''.join(['Number of orbits since the start ',
-                                           'of the mission. For this ',
-                                           'simulation we use the number of ',
-                                           '5820 second periods since the ',
-                                           'start, 2008-01-01.'])}
-    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
-    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
-    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
-    if tag != 'default_meta':
-        for var in data.keys():
-            if var.find('dummy') >= 0:
-                meta[var] = {'units': 'none',
-                             'notes': 'Dummy variable for testing'}
-
+    # Set the meta data.
+    meta = mm_test.initialize_test_meta('Epoch', data.keys())
     return data, meta
 
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -45,7 +45,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, malformed_index=False,
-         num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=None, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -68,8 +68,13 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         (default=None)
     malformed_index : boolean
         If True, time index will be non-unique and non-monotonic (default=False)
+    start_time : dt.timedelta or NoneType
+        Offset time of start time since midnight UT. If None, instrument data
+        will begin at midnight.
+        (default=None)
     num_samples : int
-        Number of samples per day
+        Maximum number of times to generate.  Data points will not go beyond the
+        current day.
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -92,8 +97,8 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     if num_samples is None:
         # Default to 1 day at a frequency of 1S
         num_samples = 86400
-    uts, index, dates = mm_test.generate_times(fnames, num_samples,
-                                               freq='1S')
+    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='1S',
+                                               start_time=start_time)
 
     # Specify the date tag locally and determine the desired date range
     pds_offset = dt.timedelta(hours=12)

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -22,7 +22,7 @@ tags = {'': 'Regular testing data set',
         'no_download': 'simulate an instrument without download support',
         'non_strict': 'simulate an instrument without strict_time_flag',
         'user_password': 'simulates an instrument that requires a password',
-        'default_meta': 'simulates an instrument using the defualt meta'}
+        'default_meta': 'simulates an instrument using the default meta'}
 
 # dictionary of satellite IDs, list of corresponding tags
 # a numeric string can be used in inst_id to change the number of points per day

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -174,7 +174,11 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
 
     # Set the meta data.
     meta = mm_test.initialize_test_meta('Epoch', data.keys())
-    return data, meta
+
+    if tag == 'default_meta':
+        return data, pysat.Meta()
+    else:
+        return data, meta
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -32,7 +32,7 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         start_time=None, num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=864, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -52,7 +52,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         (default=None)
     num_samples : int
         Maximum number of times to generate.  Data points will not go beyond the
-        current day.
+        current day. (default=864)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -78,7 +78,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     # Using 100s frequency for compatibility with seasonal analysis unit tests
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',
                                                start_time=start_time)
-    # seed DataFrame with UT array
+    # Seed the DataFrame with a UT array
     data = pds.DataFrame(np.mod(uts, 86400.), columns=['uts'])
 
     # need to create simple orbits here. Have start of first orbit

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -32,7 +32,7 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=None, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -46,8 +46,13 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic.
         (default=False)
+    start_time : dt.timedelta or NoneType
+        Offset time of start time since midnight UT. If None, instrument data
+        will begin at midnight.
+        (default=None)
     num_samples : int
-        Number of samples
+        Maximum number of times to generate.  Data points will not go beyond the
+        current day.
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -71,8 +76,8 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         num_samples = 864
 
     # Using 100s frequency for compatibility with seasonal analysis unit tests
-    uts, index, dates = mm_test.generate_times(fnames, num_samples,
-                                               freq='100S')
+    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',
+                                               start_time=start_time)
     # seed DataFrame with UT array
     data = pds.DataFrame(np.mod(uts, 86400.), columns=['uts'])
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -71,9 +71,6 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     # create an artifical satellite data set
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
-    if num_samples is None:
-        # Default to 1 day at a frequency of 100S
-        num_samples = 864
 
     # Using 100s frequency for compatibility with seasonal analysis unit tests
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -156,28 +156,8 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     data['alt_profiles'] = pds.Series(alt_profiles, index=data.index)
     data['series_profiles'] = pds.Series(series_profiles, index=data.index)
 
-    # create very limited metadata
-    meta = pysat.Meta()
-    meta['uts'] = {'units': 's', 'long_name': 'Universal Time'}
-    meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time'}
-    meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time'}
-    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
-    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
-    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
-    series_profile_meta = pysat.Meta()
-    series_profile_meta['series_profiles'] = {'long_name': 'series'}
-    meta['series_profiles'] = {'meta': series_profile_meta,
-                               'long_name': 'series'}
-    profile_meta = pysat.Meta()
-    profile_meta['density'] = {'long_name': 'profiles'}
-    profile_meta['dummy_str'] = {'long_name': 'profiles'}
-    profile_meta['dummy_ustr'] = {'long_name': 'profiles'}
-    meta['profiles'] = {'meta': profile_meta, 'long_name': 'profiles'}
-    alt_profile_meta = pysat.Meta()
-    alt_profile_meta['density'] = {'long_name': 'profiles'}
-    alt_profile_meta['fraction'] = {'long_name': 'profiles'}
-    meta['alt_profiles'] = {'meta': alt_profile_meta, 'long_name': 'profiles'}
-
+    # Set the meta data.
+    meta = mm_test.initialize_test_meta('epoch', data.keys())
     return data, meta
 
 

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -77,9 +77,6 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
 
-    if num_samples is None:
-        # Default to 1 day at a frequency of 100S
-        num_samples = 864
     # Using 100s frequency for compatibility with seasonal analysis unit tests
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',
                                                start_time=start_time)

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -38,7 +38,7 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=None, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -51,8 +51,13 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         Instrument satellite ID (accepts '')
     malformed_index : bool False
         If True, the time index will be non-unique and non-monotonic.
+    start_time : dt.timedelta or NoneType
+        Offset time of start time since midnight UT. If None, instrument data
+        will begin at midnight.
+        (default=None)
     num_samples : int
-        Number of samples
+        Maximum number of times to generate.  Data points will not go beyond the
+        current day.
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -76,8 +81,8 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         # Default to 1 day at a frequency of 100S
         num_samples = 864
     # Using 100s frequency for compatibility with seasonal analysis unit tests
-    uts, index, dates = mm_test.generate_times(fnames, num_samples,
-                                               freq='100S')
+    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',
+                                               start_time=start_time)
 
     if malformed_index:
         index = index.tolist()
@@ -85,7 +90,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         index[0:3], index[3:6] = index[3:6], index[0:3]
         # non unique
         index[6:9] = [index[6]] * 3
-    data = xr.Dataset({'uts': ((epoch_name), index)},
+    data = xr.Dataset({'uts': ((epoch_name), uts)},
                       coords={epoch_name: index})
 
     # need to create simple orbits here. Have start of first orbit

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -169,45 +169,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
                                 np.arange(17)[np.newaxis, np.newaxis,
                                               :] * np.ones((num, 17, 17)))
 
-    # create very limited metadata
-    meta = pysat.Meta()
-    meta[epoch_name] = {'long_name': 'Datetime Index'}
-    meta['uts'] = {'units': 's', 'long_name': 'Universal Time'}
-    meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time'}
-    meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time'}
-    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
-    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
-    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
-    variable_profile_meta = pysat.Meta()
-    variable_profile_meta['variable_profiles'] = {'long_name': 'series'}
-    meta['variable_profiles'] = {'meta': variable_profile_meta,
-                                 'long_name': 'series'}
-    profile_meta = pysat.Meta()
-    profile_meta['density'] = {'long_name': 'profiles'}
-    profile_meta['dummy_str'] = {'long_name': 'profiles'}
-    profile_meta['dummy_ustr'] = {'long_name': 'profiles'}
-    meta['profiles'] = {'meta': profile_meta, 'long_name': 'profiles'}
-    image_meta = pysat.Meta()
-    image_meta['density'] = {'long_name': 'profiles'}
-    image_meta['fraction'] = {'long_name': 'profiles'}
-    meta['images'] = {'meta': image_meta, 'long_name': 'profiles'}
-    for var in data.keys():
-        if var.find('dummy') >= 0:
-            meta[var] = {'units': 'none', 'long_name': var,
-                         'notes': 'Dummy variable'}
-    meta['x'] = {'long_name': 'x-value of image pixel',
-                 'notes': 'Dummy Variable'}
-    meta['y'] = {'long_name': 'y-value of image pixel',
-                 'notes': 'Dummy Variable'}
-    meta['z'] = {'long_name': 'z-value of profile height',
-                 'notes': 'Dummy Variable'}
-    meta['image_lat'] = {'long_name': 'Latitude of image pixel',
-                         'notes': 'Dummy Variable'}
-    meta['image_lon'] = {'long_name': 'Longitude of image pixel',
-                         'notes': 'Dummy Variable'}
-    meta['profile_height'] = {'long_name': 'profile height'}
-    meta['variable_profile_height'] = {'long_name': 'Variable Profile Height'}
-
+    meta = mm_test.initialize_test_meta(epoch_name, data.keys())
     return data, meta
 
 

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -38,7 +38,7 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         start_time=None, num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=864, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -57,7 +57,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         (default=None)
     num_samples : int
         Maximum number of times to generate.  Data points will not go beyond the
-        current day.
+        current day. (default=864)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -39,7 +39,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, malformed_index=False,
-         start_time=None, num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=86400, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -64,7 +64,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         (default=None)
     num_samples : int
         Maximum number of times to generate.  Data points will not go beyond the
-        current day.
+        current day. (default=86400)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -84,9 +84,6 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
 
-    if num_samples is None:
-        # Default to 1 day at a frequency of 1S
-        num_samples = 86400
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='1S',
                                                start_time=start_time)
 

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -169,47 +169,8 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
                            np.array([1] * len(data.indexes[epoch_name]),
                            dtype=np.int64))
 
-    meta = pysat.Meta()
-    meta['uts'] = {'units': 's', 'long_name': 'Universal Time',
-                   'custom': False}
-    meta[epoch_name] = {'units': 'Milliseconds since 1970-1-1',
-                        'Bin_Location': 0.5,
-                        'notes':
-                        'UTC time at middle of geophysical measurement.',
-                        'desc': 'UTC seconds', }
-    meta['mlt'] = {'units': 'hours',
-                   'long_name': 'Magnetic Local Time',
-                   'desc': 'Magnetic Local Time',
-                   'value_min': 0.,
-                   'value_max': 24.,
-                   'notes': ''.join(['Magnetic Local Time is the solar local ',
-                                     'time of the field line at the location ',
-                                     'where the field crosses the magnetic ',
-                                     'equator. In this case we just simulate ',
-                                     '0-24 with a consistent orbital period ',
-                                     'and an offset with SLT.'])}
-    meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time',
-                   'desc': 'Solar Local Time', 'value_min': 0.,
-                   'value_max': 24.,
-                   'notes': ''.join(['Solar Local Time is the local time ',
-                                     '(zenith angle of thee sun) of the given',
-                                     ' locaiton. Overhead noon, +/- 90 is 6,',
-                                     ' 18 SLT .'])}
-    meta['orbit_num'] = {'long_name': 'Orbit Number', 'desc': 'Orbit Number',
-                         'value_min': 0., 'value_max': 25000.,
-                         'notes': ''.join(['Number of orbits since the start ',
-                                           'of the mission. For this ',
-                                           'simulation we use the ',
-                                           'number of 5820 second periods ',
-                                           'since the start, 2008-01-01.'])}
-
-    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
-    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
-    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
-    for var in data.keys():
-        if var.find('dummy') >= 0:
-            meta[var] = {'units': 'none', 'notes': 'Dummy variable'}
-
+    # Set the meta data.
+    meta = mm_test.initialize_test_meta(epoch_name, data.keys())
     return data, meta
 
 

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -39,7 +39,7 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, malformed_index=False,
-         num_samples=None, test_load_kwarg=None):
+         start_time=None, num_samples=None, test_load_kwarg=None):
     """Load the test files.
 
     Parameters
@@ -58,8 +58,13 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         root_date (default=False)
     malformed_index : boolean
         If True, time index will be non-unique and non-monotonic.
+    start_time : dt.timedelta or NoneType
+        Offset time of start time since midnight UT. If None, instrument data
+        will begin at midnight.
+        (default=None)
     num_samples : int
-        Number of samples
+        Maximum number of times to generate.  Data points will not go beyond the
+        current day.
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -82,8 +87,8 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     if num_samples is None:
         # Default to 1 day at a frequency of 1S
         num_samples = 86400
-    uts, index, dates = mm_test.generate_times(fnames, num_samples,
-                                               freq='1S')
+    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='1S',
+                                               start_time=start_time)
 
     if sim_multi_file_right:
         root_date = dt.datetime(2009, 1, 1, 12)
@@ -101,7 +106,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         # Create a non-unique index
         index[6:9] = [index[6]] * 3
 
-    data = xr.Dataset({'uts': ((epoch_name), index)},
+    data = xr.Dataset({'uts': ((epoch_name), uts)},
                       coords={epoch_name: index})
     # need to create simple orbits here. Have start of first orbit
     # at 2009,1, 0 UT. 14.84 orbits per day

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -32,7 +32,7 @@ clean = mm_test.clean
 preprocess = mm_test.preprocess
 
 
-def load(fnames, tag=None, inst_id=None, num_samples=None,
+def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=None,
          test_load_kwarg=None):
     """Load the test files.
 
@@ -44,8 +44,13 @@ def load(fnames, tag=None, inst_id=None, num_samples=None,
         Instrument tag (accepts '')
     inst_id : str or NoneType
         Instrument satellite ID (accepts '')
+    start_time : dt.timedelta or NoneType
+        Offset time of start time since midnight UT. If None, instrument data
+        will begin at midnight.
+        (default=None)
     num_samples : int
-        Number of samples
+        Maximum number of times to generate.  Data points will not go beyond the
+        current day.
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 
@@ -65,8 +70,8 @@ def load(fnames, tag=None, inst_id=None, num_samples=None,
         # Default to 1 day at a frequency of 900S
         num_samples = 96
     # create an artifical satellite data set
-    uts, index, dates = mm_test.generate_times(fnames, num_samples,
-                                               freq='900S')
+    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='900S',
+                                               start_time=start_time)
 
     # Define range of simulated 3D model
     latitude = np.linspace(-50, 50, 21)

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -94,29 +94,8 @@ def load(fnames, tag=None, inst_id=None, num_samples=None,
     data['dummy2'] = (('time', 'latitude', 'longitude', 'altitude'),
                       dummy2.data)
 
-    # Set the metadata
-    meta = pysat.Meta()
-    meta['time'] = {'long_name': 'Datetime Index'}
-    meta['uts'] = {'units': 's', 'long_name': 'Universal Time',
-                   'custom': False}
-    meta['slt'] = {'units': 'hours', 'long_name': 'Solar Local Time',
-                   'desc': 'Solar Local Time', 'value_min': 0.0,
-                   'value_max': 24.0,
-                   'notes': ''.join(['Solar Local Time is the local time ',
-                                     '(zenith angle of sun) of the given ',
-                                     'locaiton. Overhead noon, +/- 90 is 6, ',
-                                     '18 SLT .'])}
-    meta['mlt'] = {'units': 'hours', 'long_name': 'Magnetic Local Time',
-                   'desc': 'Magentic Local Time', 'value_min': 0.0,
-                   'value_max': 24.0}
-    meta['longitude'] = {'units': 'degrees', 'long_name': 'Longitude'}
-    meta['latitude'] = {'units': 'degrees', 'long_name': 'Latitude'}
-    meta['altitude'] = {'units': 'km', 'long_name': 'Altitude'}
-    for var in data.keys():
-        if var.find('dummy') >= 0:
-            meta[var] = {'units': 'none', 'long_name': var,
-                         'notes': 'Dummy variable'}
-
+    # Set the meta data.
+    meta = mm_test.initialize_test_meta('time', data.keys())
     return data, meta
 
 

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -32,7 +32,7 @@ clean = mm_test.clean
 preprocess = mm_test.preprocess
 
 
-def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=None,
+def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=96,
          test_load_kwarg=None):
     """Load the test files.
 
@@ -50,7 +50,7 @@ def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=None,
         (default=None)
     num_samples : int
         Maximum number of times to generate.  Data points will not go beyond the
-        current day.
+        current day. (default=96)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
 

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -66,7 +66,7 @@ def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=96,
     # Support keyword testing
     logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
-    # create an artifical model data set
+    # Create an artificial model data set
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='900S',
                                                start_time=start_time)
 

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -66,10 +66,7 @@ def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=96,
     # Support keyword testing
     logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
-    if num_samples is None:
-        # Default to 1 day at a frequency of 900S
-        num_samples = 96
-    # create an artifical satellite data set
+    # create an artifical model data set
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='900S',
                                                start_time=start_time)
 

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -16,10 +16,10 @@ import pysat
 # e.g.,
 # import mypackage
 
-# Import the test classes from pysat
-from pysat.tests.instrument_test_class import InstTestClass
 # Need initialize_test_inst_and_date if custom tests are being added.
 from pysat.tests.instrument_test_class import initialize_test_inst_and_date
+# Import the test classes from pysat
+from pysat.tests.instrument_test_class import InstTestClass
 from pysat.utils import generate_instrument_list
 
 
@@ -71,6 +71,7 @@ class TestInstruments(InstTestClass):
     Uses class level setup and teardown so that all tests use the same
     temporary directory. We do not want to geneate a new tempdir for each test,
     as the load tests need to be the same as the download tests.
+
     """
 
     def setup_class(self):

--- a/pysat/tests/test_methods_testing.py
+++ b/pysat/tests/test_methods_testing.py
@@ -1,0 +1,63 @@
+"""Tests the `pysat.instruments.methods.testing` methods."""
+
+import datetime as dt
+from os import path
+import pandas as pds
+import pytest
+
+import pysat
+from pysat.instruments.methods import testing as mm_test
+
+
+class TestBasics(object):
+    """Unit tests for testing methods."""
+
+    def setup(self):
+        """Set up the unit test environment for each method."""
+
+        self.test_inst = pysat.Instrument('pysat', 'testing')
+        # get list of filenames.
+        self.fnames = [self.test_inst.files.files.values[0]]
+        return
+
+    def teardown(self):
+        """Clean up the unit test environment after each method."""
+
+        del self.test_inst, self.fnames
+        return
+
+    @pytest.mark.parametrize("kwarg", [0.0, 7, 'badval', {'hours': 'bad'},
+                                       dt.datetime(2009, 1, 1)])
+    def test_inst_start_time_badval(self, kwarg):
+        """Test operation of cadence keyword, including default behavior."""
+
+        with pytest.raises(ValueError) as verr:
+            mm_test.generate_times(self.fnames, 10, start_time=kwarg)
+        assert str(verr).find("start_time must be a dt.timedelta object") >= 0
+        return
+
+    @pytest.mark.parametrize("num,kwargs,output",
+                             [(10, None, [0.0, 9.0]),
+                              (10, {'start_time': dt.timedelta(hours=1)},
+                               [3600.0, 3609.0]),
+                              (10, {'start_time': dt.timedelta(hours=1),
+                                    'freq': '10s'},
+                               [3600.0, 3690.0]),
+                              (87000, {}, [0.0, 86399.0])])
+    def test_generate_times_kwargs(self, num, kwargs, output):
+        """Test use of kwargs in generate_times, including default behavior."""
+
+        if kwargs:
+            uts, index, dates = mm_test.generate_times(self.fnames, num,
+                                                       **kwargs)
+        else:
+            uts, index, dates = mm_test.generate_times(self.fnames, num)
+
+        assert uts[0] == output[0]
+        assert uts[-1] == output[1]
+        assert len(uts) == len(index)
+        assert len(dates) == 1
+        # Check that calculations are done correctly.
+        delta_time = [dt.timedelta(seconds=sec) for sec in uts]
+        assert (index.to_pydatetime() - delta_time == dates).all
+        return


### PR DESCRIPTION
# Description

Addresses #389 (partial) and #621

Moves the metadata for the test instruments to a single location.  All possible values are generated, but only the values required are passed through to the instrument.  Expanded some values of metadata to include min and max values.

Adds `start_time` to the test instruments as an optional kwarg.  If specified, the start time will be adjusted by the specified offset (as a `dt.timedelta`).
- Includes unit tests for the changes to `generate_times` as part of new test_methods_testing.py file.
- Includes integration tests for each test instrument to ensure both `start_time` and `num_samples` are passed through correctly.
  - Note that end time is not tested in the integration tests since each instrument has a different hard-wired frequency.  However, this is captured in the unit tests on the function itself.
 - Existing behavior that times will not be generated on the next day is maintained (ie, num_samples=87000 points will still only generate 86400 points at a 1-sec cadence).

Caught a bug: index was mistakenly added as 'uts' in the two orbital xarray objects.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

By loading each test instrument and inspecting metadata, and via pytest.

**Test Configuration**:
* Operating system: Mac  10.15.7
* Version number: Python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
