### PR TITLE
Add deprecation warning for download kwarg ,`freq`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Extended Constellation unit tests
    * Standardized Instrument instantiation to always define `inst_module`
    * Extended testing options for `pysat.utils.testing` functions
+* Deprecations
+   * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -670,7 +670,7 @@ class Instrument(object):
         return output_str
 
     def __getitem__(self, key):
-        """Convenience notation for accessing data.
+        """Access data in `pysat.Instrument` object.
 
         Parameters
         ----------
@@ -736,7 +736,7 @@ class Instrument(object):
             return self.__getitem_xarray__(key)
 
     def __getitem_xarray__(self, key):
-        """Convenience notation for accessing data.
+        """Access data in `pysat.Instrument` object with `xarray.Dataset`.
 
         Parameters
         ----------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3201,7 +3201,7 @@ class Instrument(object):
             del kwargs['freq']
         else:
             freq = 'D'
-        
+
         # Make sure directories are there, otherwise create them
         try:
             os.makedirs(self.files.data_path)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -567,7 +567,7 @@ class Instrument(object):
         return test_data
 
     def __repr__(self):
-        """ Print the basic Instrument properties"""
+        """Print the basic Instrument properties."""
 
         # Create string for custom attached methods
         cstr = '['
@@ -606,7 +606,7 @@ class Instrument(object):
         return out_str
 
     def __str__(self):
-        """ Descriptively print the basic Instrument properties"""
+        """Descriptively print the basic Instrument properties."""
 
         # Get the basic Instrument properties
         output_str = 'pysat Instrument object\n'
@@ -670,8 +670,7 @@ class Instrument(object):
         return output_str
 
     def __getitem__(self, key):
-        """
-        Convenience notation for accessing data; inst['name'] is inst.data.name
+        """Convenience notation for accessing data.
 
         Parameters
         ----------
@@ -681,6 +680,8 @@ class Instrument(object):
 
         Note
         ----
+        inst['name'] is inst.data.name.
+
         See pandas or xarray .loc and .iloc documentation for more details
 
         Examples
@@ -735,8 +736,7 @@ class Instrument(object):
             return self.__getitem_xarray__(key)
 
     def __getitem_xarray__(self, key):
-        """
-        Convenience notation for accessing data; inst['name'] is inst.data.name
+        """Convenience notation for accessing data.
 
         Parameters
         ----------
@@ -751,6 +751,8 @@ class Instrument(object):
 
         Note
         ----
+        inst['name'] is inst.data.name
+
         See xarray .loc and .iloc documentation for more details
 
         Examples
@@ -994,7 +996,7 @@ class Instrument(object):
         return
 
     def __iter__(self):
-        """Iterates instrument object by loading subsequent days or files.
+        """Load data for subsequent days or files.
 
         Note
         ----
@@ -1059,7 +1061,7 @@ class Instrument(object):
     # Define all hidden methods
 
     def _empty(self, data=None):
-        """Boolean flag reflecting lack of data
+        """Determine whether or not data has been loaded.
 
         Parameters
         ----------
@@ -1086,7 +1088,7 @@ class Instrument(object):
                 return True
 
     def _index(self, data=None):
-        """Returns time index of loaded data
+        """Retrieve the time index for the loaded data.
 
         Parameters
         ----------
@@ -1113,12 +1115,11 @@ class Instrument(object):
                 return pds.Index([])
 
     def _pass_method(*args, **kwargs):
-        """ Default method for updatable Instrument methods
-        """
+        """Empty default method for updatable Instrument methods."""
         pass
 
     def _assign_attrs(self, by_name=False):
-        """Assign all external instrument attributes to the Instrument object
+        """Assign all external instrument attributes to the Instrument object.
 
         Parameters
         ----------
@@ -1310,8 +1311,7 @@ class Instrument(object):
         return
 
     def _load_data(self, date=None, fid=None, inc=None, load_kwargs=None):
-        """
-        Load data for an instrument on given date or fid, depending upon input.
+        """Load data for an instrument on given date or filename index.
 
         Parameters
         ----------
@@ -1422,7 +1422,7 @@ class Instrument(object):
         return data, mdata
 
     def _load_next(self):
-        """Load the next days data (or file) without incrementing the date
+        """Load the next days data (or file) without incrementing the date.
 
         Returns
         -------
@@ -1448,7 +1448,7 @@ class Instrument(object):
             return self._load_data(fid=next_id, inc=self.load_step)
 
     def _load_prev(self):
-        """Load the previous days data (or file) without decrementing the date
+        """Load the previous days data (or file) without decrementing the date.
 
         Returns
         -------
@@ -1475,7 +1475,7 @@ class Instrument(object):
             return self._load_data(fid=prev_id, inc=self.load_step)
 
     def _set_load_parameters(self, date=None, fid=None):
-        """ Set the necesssary load attributes
+        """Set the necesssary load attributes.
 
         Parameters
         ----------
@@ -1502,7 +1502,7 @@ class Instrument(object):
             self._load_by_date = False
 
     def _get_var_type_code(self, coltype):
-        """Determines the two-character type code for a given variable type
+        """Determine the two-character type code for a given variable type.
 
         Parameters
         ----------
@@ -1542,7 +1542,7 @@ class Instrument(object):
                 raise TypeError('Unknown Variable Type' + str(coltype))
 
     def _get_data_info(self, data):
-        """Support file writing by determining data type and other options
+        """Support file writing by determining data type and other options.
 
         Parameters
         ----------
@@ -1937,12 +1937,12 @@ class Instrument(object):
 
     @property
     def index(self):
-        """Returns time index of loaded data."""
+        """Time index of the loaded data."""
         return self._index()
 
     @property
     def variables(self):
-        """Returns list of variables within loaded data."""
+        """List of variables for the loaded data."""
 
         if self.pandas_format:
             return self.data.columns
@@ -1950,7 +1950,7 @@ class Instrument(object):
             return list(self.data.variables.keys())
 
     def copy(self):
-        """Deep copy of the entire Instrument object.
+        """Create a deep copy of the entire Instrument object.
 
         Returns
         -------
@@ -1998,7 +1998,7 @@ class Instrument(object):
         return inst_copy
 
     def concat_data(self, new_data, prepend=False, **kwargs):
-        """Concats new_data to self.data for xarray or pandas as needed
+        """Concatonate data to self.data for xarray or pandas as needed.
 
         Parameters
         ----------
@@ -2107,7 +2107,7 @@ class Instrument(object):
         return
 
     def custom_apply_all(self):
-        """ Apply all of the custom functions to the satellite data object.
+        """Apply all of the custom functions to the satellite data object.
 
         Raises
         ------
@@ -2140,15 +2140,14 @@ class Instrument(object):
         return
 
     def custom_clear(self):
-        """Clear the custom function list.
-        """
+        """Clear the custom function list."""
         self.custom_functions = []
         self.custom_args = []
         self.custom_kwargs = []
         return
 
     def today(self):
-        """Returns today's date (UTC), with no hour, minute, second, etc.
+        """Get today's date (UTC), with no hour, minute, second, etc.
 
         Returns
         -------
@@ -2159,7 +2158,7 @@ class Instrument(object):
         return utils.time.today()
 
     def tomorrow(self):
-        """Returns tomorrow's date (UTC), with no hour, minute, second, etc.
+        """Get tomorrow's date (UTC), with no hour, minute, second, etc.
 
         Returns
         -------
@@ -2171,7 +2170,7 @@ class Instrument(object):
         return self.today() + dt.timedelta(days=1)
 
     def yesterday(self):
-        """Returns yesterday's date (UTC), with no hour, minute, second, etc.
+        """Get yesterday's date (UTC), with no hour, minute, second, etc.
 
         Returns
         -------
@@ -2183,7 +2182,7 @@ class Instrument(object):
         return self.today() - dt.timedelta(days=1)
 
     def next(self, verifyPad=False):
-        """Manually iterate through the data loaded in Instrument object.
+        """Iterate forward through the data loaded in Instrument object.
 
         Bounds of iteration and iteration type (day/file) are set by
         `bounds` attribute.
@@ -2271,7 +2270,7 @@ class Instrument(object):
         return
 
     def prev(self, verifyPad=False):
-        """Manually iterate backwards through the data in Instrument object.
+        """Iterate backwards through the data in Instrument object.
 
         Bounds of iteration and iteration type (day/file)
         are set by `bounds` attribute.
@@ -2353,7 +2352,7 @@ class Instrument(object):
         return
 
     def rename(self, var_names, lowercase_data_labels=False):
-        """Renames variable within both data and metadata.
+        """Rename variable within both data and metadata.
 
         Parameters
         ----------
@@ -2524,7 +2523,7 @@ class Instrument(object):
         return
 
     def generic_meta_translator(self, input_meta):
-        """Translates the metadata contained in an object into a dictionary
+        """Convert the metadata contained in an object into a dictionary.
 
         Parameters
         ----------
@@ -2592,7 +2591,7 @@ class Instrument(object):
     def load(self, yr=None, doy=None, end_yr=None, end_doy=None, date=None,
              end_date=None, fname=None, stop_fname=None, verifyPad=False,
              **kwargs):
-        """Load instrument data into Instrument.data object.
+        """Load the instrument data and metadata.
 
         Parameters
         ----------
@@ -3031,7 +3030,7 @@ class Instrument(object):
         return
 
     def remote_file_list(self, start=None, stop=None, **kwargs):
-        """List remote files for chosen instrument
+        """Retrieve a time-series of remote files for chosen instrument.
 
         Parameters
         ----------
@@ -3048,7 +3047,7 @@ class Instrument(object):
 
         Returns
         -------
-        Series
+        pds.Series
             pandas Series of filenames indexed by date and time
 
         Note
@@ -3075,7 +3074,7 @@ class Instrument(object):
         return self._list_remote_files_rtn(self.tag, self.inst_id, **kwargs)
 
     def remote_date_range(self, start=None, stop=None, **kwargs):
-        """Returns fist and last date for remote data
+        """Determine first and last available dates for remote data.
 
         Parameters
         ----------
@@ -3107,8 +3106,7 @@ class Instrument(object):
         return [files.index[0], files.index[-1]]
 
     def download_updated_files(self, **kwargs):
-        """Grabs a list of remote files, compares to local, then downloads new
-        files.
+        """Download new files after comparing available remote and local files.
 
         Parameters
         ----------
@@ -3155,9 +3153,13 @@ class Instrument(object):
         # Download date for dates in new_dates (also includes new names)
         self.download(date_array=new_dates, **kwargs)
 
-    def download(self, start=None, stop=None, freq='D', date_array=None,
+    def download(self, start=None, stop=None, date_array=None,
                  **kwargs):
         """Download data for given Instrument object from start to stop.
+
+        .. deprecated:: 3.2.0
+           `freq`, which sets the step size for downloads, will be removed in
+            the 3.2.0+ release.
 
         Parameters
         ----------
@@ -3167,9 +3169,6 @@ class Instrument(object):
         stop : pandas.datetime or NoneType
             Stop date (inclusive) to download data, or tomorrow if None is
             provided (default=None)
-        freq : str
-            Stepsize between dates for season, as described in
-            pandas.DatetimeIndex (e.g., 'D' for daily, 'M' monthly)
         date_array : list-like
             Sequence of dates to download date for. Takes precedence over
             start and stop inputs
@@ -3190,6 +3189,14 @@ class Instrument(object):
         pandas.DatetimeIndex
 
         """
+        # Test for deprecated kwargs
+        if 'freq' in kwargs.keys():
+            warnings.warn("".join(["`pysat.Instrument.download` kwarg `freq` ",
+                                   "has been deprecated and will be removed ",
+                                   "in pysat 3.2.0+. Use `date_array` for ",
+                                   "non-daily frequencies instead."]),
+                          DeprecationWarning, stacklevel=2)
+        
         # Make sure directories are there, otherwise create them
         try:
             os.makedirs(self.files.data_path)
@@ -3221,6 +3228,7 @@ class Instrument(object):
         if date_array is None:
             # Create range of dates for downloading data.  Make sure dates are
             # whole days
+            freq = kwargs['freq'] if 'freq' in kwargs.keys() else 'D'
             start = utils.time.filter_datetime_input(start)
             stop = utils.time.filter_datetime_input(stop)
             date_array = utils.time.create_date_range(start, stop, freq=freq)
@@ -3287,7 +3295,7 @@ class Instrument(object):
                    zlib=False, complevel=4, shuffle=True,
                    preserve_meta_case=False, export_nan=None,
                    unlimited_time=True):
-        """Stores loaded data into a netCDF4 file.
+        """Store loaded data into a netCDF4 file.
 
         Parameters
         ----------
@@ -3817,13 +3825,14 @@ class Instrument(object):
 
 # Hidden variable to store pysat reserved keywords. Defined here, since these
 # values are used by both the Instrument class and a function defined below.
+# In release 3.2.0+ `freq` will be removed.
 _reserved_keywords = ['fnames', 'inst_id', 'tag', 'date_array',
                       'data_path', 'format_str', 'supported_tags',
                       'start', 'stop', 'freq']
 
 
 def _kwargs_keys_to_func_name(kwargs_key):
-    """ Convert from self.kwargs key name to the function/method name
+    """Convert from self.kwargs key name to the function/method name.
 
     Parameters
     ----------
@@ -3842,7 +3851,7 @@ def _kwargs_keys_to_func_name(kwargs_key):
 
 
 def _get_supported_keywords(local_func):
-    """Return a dict of supported keywords
+    """Get a dict of supported keywords.
 
     Parameters
     ----------
@@ -3914,16 +3923,12 @@ def _get_supported_keywords(local_func):
 
 
 def _pass_func(*args, **kwargs):
-    """ Default function for updateable Instrument methods
-    """
+    """Empty, default function for updateable Instrument methods."""
     pass
 
 
 def _check_load_arguments_none(args, raise_error=False):
     """Ensure all arguments are None.
-
-    Used to support .load method checks that arguments that should be
-    None are None, while also keeping the .load method readable.
 
     Parameters
     ----------
@@ -3933,15 +3938,21 @@ def _check_load_arguments_none(args, raise_error=False):
         A flag that if True, will raise a ValueError if any one value in `args`
         is not None (default=False)
 
+    Returns
+    -------
+    all_none : bool
+        Flag that is True if all `args` values are None and False otherwise
+
     Raises
     ------
     ValueError
         If any one value in `args` is not None and `raise_error` is True
 
-    Returns
-    -------
-    all_none : bool
-        Flag that is True if all `args` values are None and False otherwise
+    Note
+    ----
+    Used to support .load method checks that arguments that should be
+    None are None, while also keeping the .load method readable.
+
 
     """
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3169,13 +3169,14 @@ class Instrument(object):
         stop : pandas.datetime or NoneType
             Stop date (inclusive) to download data, or tomorrow if None is
             provided (default=None)
-        date_array : list-like
+        date_array : list-like or NoneType
             Sequence of dates to download date for. Takes precedence over
-            start and stop inputs
+            start and stop inputs (default=None)
         **kwargs : dict
             Dictionary of keywords that may be options for specific instruments.
             The keyword arguments 'user' and 'password' are expected for remote
-            databases requiring sign in or registration.
+            databases requiring sign in or registration. 'freq' temporarily
+            ingested through this input option.
 
         Note
         ----
@@ -3196,6 +3197,10 @@ class Instrument(object):
                                    "in pysat 3.2.0+. Use `date_array` for ",
                                    "non-daily frequencies instead."]),
                           DeprecationWarning, stacklevel=2)
+            freq = kwargs['freq']
+            del kwargs['freq']
+        else:
+            freq = 'D'
         
         # Make sure directories are there, otherwise create them
         try:
@@ -3228,7 +3233,6 @@ class Instrument(object):
         if date_array is None:
             # Create range of dates for downloading data.  Make sure dates are
             # whole days
-            freq = kwargs['freq'] if 'freq' in kwargs.keys() else 'D'
             start = utils.time.filter_datetime_input(start)
             stop = utils.time.filter_datetime_input(stop)
             date_array = utils.time.create_date_range(start, stop, freq=freq)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -3450,16 +3450,17 @@ class TestDeprecation():
         """Run before every method to create a clean testing setup."""
 
         warnings.simplefilter("always", DeprecationWarning)
-        self.in_kwargs = {"platform": 'pysat', "name": 'testing', "tag": '',
-                          "sat_id": '', "clean_level": 'clean'}
+        self.in_kwargs = {"platform": 'pysat', "name": 'testing',
+                          "clean_level": 'clean'}
         self.warn_msgs = ["".join(["`pysat.Instrument.download` kwarg `freq` ",
                                    "has been deprecated and will be removed ",
                                    "in pysat 3.2.0+"])]
         self.warn_msgs = np.array(self.warn_msgs)
+        self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
 
     def teardown(self):
         """Runs after every method to clean up previous testing."""
-        del self.in_kwargs, self.warn_msgs
+        del self.in_kwargs, self.warn_msgs, self.ref_time
 
     def test_download_freq_kwarg(self):
         """Test deprecation of download kwarg `freq`."""
@@ -3467,7 +3468,7 @@ class TestDeprecation():
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
             tinst = pysat.Instrument(**self.in_kwargs)
-            tinst.download(freq='D')
+            tinst.download(start=self.ref_time, freq='D')
 
         # Ensure the minimum number of warnings were raised
         assert len(war) >= len(self.warn_msgs)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -4,6 +4,7 @@ import datetime as dt
 from importlib import reload
 import logging
 import numpy as np
+import warnings
 
 import pandas as pds
 import pytest
@@ -3440,3 +3441,43 @@ class TestInstListGeneration():
         assert not hasattr(self.test_library.pysat_testing, '_test_dates')
         inst_list = generate_instrument_list(self.test_library)
         assert 'pysat_testing' in inst_list['names']
+
+
+class TestDeprecation():
+    """Unit test for deprecation warnings."""
+
+    def setup(self):
+        """Run before every method to create a clean testing setup."""
+
+        warnings.simplefilter("always", DeprecationWarning)
+        self.in_kwargs = {"platform": 'pysat', "name": 'testing', "tag": '',
+                          "sat_id": '', "clean_level": 'clean'}
+        self.warn_msgs = ["".join(["`pysat.Instrument.download` kwarg `freq` ",
+                                   "has been deprecated and will be removed ",
+                                   "in pysat 3.2.0+"])]
+        self.warn_msgs = np.array(self.warn_msgs)
+
+    def teardown(self):
+        """Runs after every method to clean up previous testing."""
+        del self.in_kwargs, self.warn_msgs
+
+    def test_download_freq_kwarg(self):
+        """Test deprecation of download kwarg `freq`."""
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            tinst = pysat.Instrument(**self.in_kwargs)
+            tinst.download(freq='D')
+
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(self.warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(
+            war, self.warn_msgs)
+
+        for i, good in enumerate(found_msgs):
+            assert good, "didn't find warning about: {:}".format(
+                self.warn_msgs[i])
+
+        return


### PR DESCRIPTION
# Description

Addresses the 3.1.0 Milestone portion of #788 by adding a deprecation warning to the download `freq` kwarg.

## Type of change

- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?
Added a unit test.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [n/a] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
