### PR TITLE
TST: add integration test for `file_date_range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`
    * Streamlined unit tests for `test_orbits`
    * Moved metadata generation for test instruments to `methods.testing`
+   * Added integration tests for test instrument kwargs
    * Updated class declaration to be consistent with python 3 standards
 
 [3.0.1] - 2021-07-28

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -7,6 +7,7 @@ Imports test methods from pysat.tests.instrument_test_class
 """
 
 import datetime as dt
+import pandas as pds
 import tempfile
 
 import pytest
@@ -129,4 +130,18 @@ class TestInstruments(InstTestClass):
         self.test_inst.load(date=date)
 
         assert len(self.test_inst['uts']) == num
+        return
+
+    @pytest.mark.parametrize("inst_dict", [x for x in instruments['download']])
+    def test_inst_file_date_range(self, inst_dict):
+        """Test operation of file_date_range keyword."""
+
+        file_date_range = pds.date_range(dt.datetime(2021, 1, 1),
+                                         dt.datetime(2021, 12, 31))
+        _, date = initialize_test_inst_and_date(inst_dict)
+        self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
+                                          file_date_range=file_date_range)
+        file_list = self.test_inst.files.files
+
+        assert all(file_date_range == file_list.index)
         return


### PR DESCRIPTION
# Description

Addresses #631

I missed that this kwarg was added in a previous pull, solving the issue.  Adding an integration test to test the incorporation into the test instruments.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via pyest

**Test Configuration**:
* Operating system: Mac 10.15.7
* Version number: Python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
