### PR TITLE
STY: usage of caplog and capsys in unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Moved metadata generation for test instruments to `methods.testing`
    * Added integration tests for test instrument kwargs
    * Updated class declaration to be consistent with python 3 standards
+   * Update usage of caplog and capsys in unit tests
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -6,7 +6,6 @@
 """Unit tests for the `constellation` class and methods."""
 
 import datetime as dt
-from io import StringIO
 import logging
 import pandas as pds
 import pytest
@@ -51,29 +50,24 @@ class TestConstellationInitReg(TestWithRegistration):
         assert str(verr).find("no registered packages match input") >= 0
         return
 
-    def test_some_bad_construct_constellation(self):
+    def test_some_bad_construct_constellation(self, caplog):
         """Test partial load and log warning if some inputs are unregistered."""
-
-        # Initialize logging
-        log_capture = StringIO()
-        pysat.logger.addHandler(logging.StreamHandler(log_capture))
-        pysat.logger.setLevel(logging.WARNING)
 
         # Register fake Instrument modules
         pysat.utils.registry.register(self.module_names)
 
         # Load the Constellation and capture log output
-        const = pysat.Constellation(platforms=['Executor', 'platname1'],
-                                    tags=[''])
-        log_out = log_capture.getvalue()
+        with caplog.at_level(logging.WARNING, logger='pysat'):
+            const = pysat.Constellation(platforms=['Executor', 'platname1'],
+                                        tags=[''])
 
         # Test the partial Constellation initialization
         assert len(const.instruments) == 2
 
         # Test the log warning
-        assert log_out.find("unable to load some platforms") >= 0
+        assert caplog.text.find("unable to load some platforms") >= 0
 
-        del log_capture, log_out, const
+        del const
         return
 
 

--- a/pysat/tests/test_custom.py
+++ b/pysat/tests/test_custom.py
@@ -1,7 +1,6 @@
 """Unit tests for the `custom_attach` methods."""
 
 import copy
-from io import StringIO
 import logging
 import pytest
 
@@ -45,23 +44,21 @@ class TestLogging(object):
                                          clean_level='clean',
                                          update_files=False)
         self.out = ''
-        self.log_capture = StringIO()
-        pysat.logger.addHandler(logging.StreamHandler(self.log_capture))
-        pysat.logger.setLevel(logging.WARNING)
         return
 
     def teardown(self):
         """Clean up the unit test environment after each method."""
 
-        del self.testInst, self.out, self.log_capture
+        del self.testInst, self.out
         return
 
-    def test_custom_pos_warning(self):
+    def test_custom_pos_warning(self, caplog):
         """Test for logging warning if inappropriate position specified."""
 
-        self.testInst.custom_attach(lambda inst: inst.data['mlt'] * 2.0,
-                                    at_pos=3)
-        self.out = self.log_capture.getvalue()
+        with caplog.at_level(logging.WARNING, logger='pysat'):
+            self.testInst.custom_attach(lambda inst: inst.data['mlt'] * 2.0,
+                                        at_pos=3)
+        self.out = caplog.text
 
         assert self.out.find(
             "unknown position specified, including function at end") >= 0

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -8,7 +8,6 @@
 import contextlib
 from importlib import reload
 import inspect
-from io import StringIO
 import numpy as np
 import os
 import portalocker
@@ -737,31 +736,27 @@ class TestAvailableInst(TestWithRegistration):
     @pytest.mark.parametrize("inst_flag, plat_flag",
                              [(None, None), (False, False), (True, True)])
     def test_display_available_instruments(self, inst_loc, inst_flag,
-                                           plat_flag):
+                                           plat_flag, capsys):
         """Test display_available_instruments options."""
         # If using the pysat registry, make sure there is something registered
         if inst_loc is None:
             pysat.utils.registry.register(self.module_names)
 
-        # Initialize the STDOUT stream
-        new_stdout = StringIO()
+        pysat.utils.display_available_instruments(
+            inst_loc, show_inst_mod=inst_flag, show_platform_name=plat_flag)
 
-        with contextlib.redirect_stdout(new_stdout):
-            pysat.utils.display_available_instruments(
-                inst_loc, show_inst_mod=inst_flag, show_platform_name=plat_flag)
-
-        out = new_stdout.getvalue()
-        assert out.find("Description") > 0
+        captured = capsys.readouterr()
+        assert captured.out.find("Description") > 0
 
         if (inst_loc is None and plat_flag is None) or plat_flag:
-            assert out.find("Platform") == 0
-            assert out.find("Name") > 0
+            assert captured.out.find("Platform") == 0
+            assert captured.out.find("Name") > 0
 
         if (inst_loc is not None and inst_flag is None) or inst_flag:
-            assert out.find("Instrument_Module") >= 0
+            assert captured.out.find("Instrument_Module") >= 0
 
         if inst_loc is not None and inst_flag in [None, True]:
-            assert out.find(inst_loc.__name__) > 0
+            assert captured.out.find(inst_loc.__name__) > 0
 
         return
 


### PR DESCRIPTION
# Description

Addresses #751

Streamlines unit tests involving standard and logger output
- Uses `capsys` in unit tests to capture standard output to terminal for tests.  
- Uses `caplog` to capture standard logger output at a given level.

## Type of change

- Style feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via pytest

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
