### PR TITLE
BUG/ENH: decode_timedelta for loading into xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed default MetaLabel specification in `pysat.utils.load_netcdf4`
    * Fixed `parse_delimited_filename` output consistency and ability to handle
      leading and trailing non-parsed text in filenames (e.g., file extensions)
+   * Added `decode_timedelta=False` as default for loading xarray from netcdf4
 * Maintenance
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -315,7 +315,7 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
       instantiation are passed along to this routine.
     - When using `pysat.utils.load_netcdf4` for xarray data, pysat will
       use `decode_timedelta=False` to prevent automated conversion of data
-      to `dt.timedelta` objects if the units attribute is time-like ('hours',
+      to `np.timedelta64` objects if the units attribute is time-like ('hours',
       'minutes', etc).  This can be added as a custom keyword if timedelta
       conversion is desired.
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -312,7 +312,7 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
     Note
     ----
     - Any additional keyword arguments passed to `pysat.Instrument` upon
-      instantiation are passed along to this routine.
+      instantiation or via `load` that are defined above will be passed along to this routine.
     - When using `pysat.utils.load_netcdf4` for xarray data, pysat will
       use `decode_timedelta=False` to prevent automated conversion of data
       to `np.timedelta64` objects if the units attribute is time-like ('hours',

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -311,8 +311,13 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
 
     Note
     ----
-    Any additional keyword arguments passed to pysat.Instrument
-    upon instantiation are passed along to this routine.
+    - Any additional keyword arguments passed to `pysat.Instrument` upon
+      instantiation are passed along to this routine.
+    - When using `pysat.utils.load_netcdf4` for xarray data, pysat will
+      use `decode_timedelta=False` to prevent automated conversion of data
+      to `dt.timedelta` objects if the units attribute is time-like ('hours',
+      'minutes', etc).  This can be added as a custom keyword if timedelta
+      conversion is desired.
 
     Examples
     --------

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -312,7 +312,8 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
     Note
     ----
     - Any additional keyword arguments passed to `pysat.Instrument` upon
-      instantiation or via `load` that are defined above will be passed along to this routine.
+      instantiation or via `load` that are defined above will be passed
+      along to this routine.
     - When using `pysat.utils.load_netcdf4` for xarray data, pysat will
       use `decode_timedelta=False` to prevent automated conversion of data
       to `np.timedelta64` objects if the units attribute is time-like ('hours',

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -559,7 +559,7 @@ class TestLoadNetCDF4XArray(object):
                                                 True)])
     def test_read_netcdf4_with_time_meta_labels(self, kwargs, target):
         """Test that read_netcdf correctly interprets time labels in meta."""
-        # Write the output test data
+        # Prepare output test data
         outfile = os.path.join(self.testInst.files.data_path,
                                'pysat_test_ncdf.nc')
         self.testInst.load(date=self.stime)
@@ -567,6 +567,7 @@ class TestLoadNetCDF4XArray(object):
         self.testInst.data['uts'].attrs = {'units': 'seconds'}
         self.testInst.data['mlt'].attrs = {'units': 'minutes'}
         self.testInst.data['slt'].attrs = {'units': 'hours'}
+        # Write output test data.
         self.testInst.data.to_netcdf(outfile)
 
         # Load the written data

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -552,6 +552,29 @@ class TestLoadNetCDF4XArray(object):
 
         return
 
+    def test_read_netcdf4_with_time_meta_labels(self):
+        """Test that read_netcdf does not decode time labels in meta."""
+        # Write the output test data
+        outfile = os.path.join(self.testInst.files.data_path,
+                               'pysat_test_ncdf.nc')
+        self.testInst.load(date=self.stime)
+        # Modify the variable attributes directly before writing to file.
+        self.testInst.data['uts'].attrs = {'units': 'seconds'}
+        self.testInst.data['mlt'].attrs = {'units': 'hours'}
+        self.testInst.data['slt'].attrs = {'units': 'hr'}
+        self.testInst.data.to_netcdf(outfile)
+
+        # Load the written data
+        self.loaded_inst, meta = pysat.utils.load_netcdf4(
+            outfile, pandas_format=self.testInst.pandas_format)
+
+        # Check that labels pass through as correct type.
+        vars = ['uts', 'mlt', 'slt']
+        for var in vars:
+            assert isinstance(self.loaded_inst[var].values[0], np.float64), \
+                "Variable not loaded as a float"
+        return
+
     def test_load_netcdf4_pandas_3d_error(self):
         """Test load_netcdf4 error with a pandas 3D file."""
         # Create a bunch of files by year and doy

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -559,7 +559,7 @@ class TestLoadNetCDF4XArray(object):
                                                 True)])
     def test_read_netcdf4_with_time_meta_labels(self, kwargs, target):
         """Test that read_netcdf correctly interprets time labels in meta."""
-        # Prepare output test data
+        # Prepare output test data.
         outfile = os.path.join(self.testInst.files.data_path,
                                'pysat_test_ncdf.nc')
         self.testInst.load(date=self.stime)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -402,9 +402,10 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
         out = pds.concat(out, axis=0)
     else:
         if len(fnames) == 1:
-            out = xr.open_dataset(fnames[0])
+            out = xr.open_dataset(fnames[0], decode_timedelta=False)
         else:
-            out = xr.open_mfdataset(fnames, combine='by_coords')
+            out = xr.open_mfdataset(fnames, combine='by_coords',
+                                    decode_timedelta=False)
         for key in out.variables.keys():
             # Copy the variable attributes from the data object to the metadata
             meta_dict = {}

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -143,7 +143,7 @@ def listify(iterable):
 
 
 def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
-                 epoch_name='Epoch', pandas_format=True,
+                 epoch_name='Epoch', pandas_format=True, decode_timedelta=False,
                  labels={'units': ('units', str), 'name': ('long_name', str),
                          'notes': ('notes', str), 'desc': ('desc', str),
                          'min_val': ('value_min', np.float64),
@@ -167,6 +167,10 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
         xarray Dataset (False). (default=False)
+    decode_timedelta : bool
+        Used for xarray datasets.  If True, variables with unit attributes that
+        are 'timelike' ('hours', 'minutes', etc) are converted to
+        `dt.timedelta`. (default=False)
     labels : dict
         Dict where keys are the label attribute names and the values are tuples
         that have the label values and value types in that order.
@@ -402,10 +406,10 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
         out = pds.concat(out, axis=0)
     else:
         if len(fnames) == 1:
-            out = xr.open_dataset(fnames[0], decode_timedelta=False)
+            out = xr.open_dataset(fnames[0], decode_timedelta=decode_timedelta)
         else:
             out = xr.open_mfdataset(fnames, combine='by_coords',
-                                    decode_timedelta=False)
+                                    decode_timedelta=decode_timedelta)
         for key in out.variables.keys():
             # Copy the variable attributes from the data object to the metadata
             meta_dict = {}

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -170,7 +170,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
     decode_timedelta : bool
         Used for xarray datasets.  If True, variables with unit attributes that
         are 'timelike' ('hours', 'minutes', etc) are converted to
-        `dt.timedelta`. (default=False)
+        `np.timedelta64`. (default=False)
     labels : dict
         Dict where keys are the label attribute names and the values are tuples
         that have the label values and value types in that order.


### PR DESCRIPTION
# Description

Addresses #823

Starting in `xarray` 0.16, loading from netcdf checks for time-like units and automatically converts the data into `dt.timedelta`s.  Adding the `decode_timedelta=False` kwarg to the load statements to maintain data format as default, but users may create instruments that pass this kwarg through if desired.

Updates the instrument template with default behavior for xarray and how to modify.

Note: The unit tests in this class will be rewritten as part of #60.  The current writeup is a workaround for the inability to write to netcdf4 directly from pysat.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

New unit test captures behavior.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
