### PR TITLE
BUG: close files through xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed default MetaLabel specification in `pysat.utils.load_netcdf4`
    * Fixed `parse_delimited_filename` output consistency and ability to handle
      leading and trailing non-parsed text in filenames (e.g., file extensions)
-   * Added `decode_timedelta=False` as default for loading xarray from netcdf4
+   * Added `decode_timedelta=False` for loading xarray from netcdf4 (#823)
+   * Closed links to open files when loading data through xarray (#887)
 * Maintenance
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -410,6 +410,8 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
         else:
             out = xr.open_mfdataset(fnames, combine='by_coords',
                                     decode_timedelta=decode_timedelta)
+        # Close any open links to file through xarray.
+        out.close()
         for key in out.variables.keys():
             # Copy the variable attributes from the data object to the metadata
             meta_dict = {}

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -410,8 +410,6 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
         else:
             out = xr.open_mfdataset(fnames, combine='by_coords',
                                     decode_timedelta=decode_timedelta)
-        # Close any open links to file through xarray.
-        out.close()
         for key in out.variables.keys():
             # Copy the variable attributes from the data object to the metadata
             meta_dict = {}
@@ -432,6 +430,9 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format=None,
 
         # Remove attributes from the data object
         out.attrs = {}
+
+        # Close any open links to file through xarray.
+        out.close()
 
     return out, meta
 


### PR DESCRIPTION
# Description

Addresses #887

On some windows systems, xarray leaves a link to the file open, which can create problems in the unit test suite.  This closes the file after loading the data.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest on windows

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
