### PR TITLE
STY: reduce code duplication in test_instrument (1 of 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Updated class declaration to be consistent with python 3 standards
    * Update usage of caplog and capsys in unit tests
    * Reorganized tests for the `pysat.Instrument` class into multiple files
+   * Updated unit tests for `pysat.Instrument` with pytest.mark.parametrize
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -658,34 +658,6 @@ class TestBasics(object):
         assert self.out + dt.timedelta(days=1) == self.testInst.tomorrow()
         return
 
-    @pytest.mark.parametrize("in_time, islist",
-                             [(dt.datetime.utcnow(), False),
-                              (dt.datetime(2010, 1, 1, 12, tzinfo=dt.timezone(
-                                  dt.timedelta(seconds=14400))), False),
-                              ([dt.datetime(2010, 1, 1, 12, i,
-                                            tzinfo=dt.timezone(
-                                                dt.timedelta(seconds=14400)))
-                                for i in range(3)], True)])
-    def test_filter_datetime(self, in_time, islist):
-        """Test range of allowed inputs for the Instrument datetime filter."""
-
-        # Because the input datetime is the middle of the day and the offset
-        # is four hours, the reference date and input date are the same
-        if islist:
-            self.ref_time = [dt.datetime(tt.year, tt.month, tt.day)
-                             for tt in in_time]
-            self.out = filter_datetime_input(in_time)
-        else:
-            self.ref_time = [dt.datetime(in_time.year, in_time.month,
-                                         in_time.day)]
-            self.out = [filter_datetime_input(in_time)]
-
-        # Test for the date values and timezone awareness status
-        for i, tt in enumerate(self.out):
-            assert self.out[i] == self.ref_time[i]
-            assert self.out[i].tzinfo is None or self.out[i].utcoffset() is None
-        return
-
     def test_filtered_date_attribute(self):
         """Test use of filter during date assignment."""
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1959,7 +1959,7 @@ class TestBasics(object):
                                 dt.timedelta(days=1), False],
                                'Too many input arguments.')])
     def test_set_bounds_error_message(self, new_bounds, errmsg):
-        """Test ValueError when setting bounds with mixed iterables."""
+        """Test ValueError when setting bounds with wrong inputs."""
 
         with pytest.raises(ValueError) as verr:
             self.testInst.bounds = new_bounds

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -201,6 +201,7 @@ class TestBasics(object):
             out = pds.date_range(start[0], stop[0]).tolist()
             out.extend(pds.date_range(start[1], stop[1]).tolist())
         assert np.all(self.testInst._iter_list == out)
+        return
 
     @pytest.mark.parametrize("kwargs", [{}, {'num_samples': 30}])
     def test_basic_instrument_load(self, kwargs):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -149,7 +149,7 @@ class TestBasics(object):
         Parameters
         ----------
         end_date : dt.datetime or NoneType
-            End date for loadind data.  If None, assumes self.ref_time + 1 day.
+            End date for loading data.  If None, assumes self.ref_time + 1 day.
             (default=None)
 
         """
@@ -1032,7 +1032,7 @@ class TestBasics(object):
         # No custom functions
         assert self.out.find('Custom Functions: 0') > 0
         # No orbital info
-        assert self.out.find('Orbit Settins') < 0
+        assert self.out.find('Orbit Settings') < 0
         # Files exist for test inst
         assert self.out.find('Date Range:') > 0
         # No loaded data

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -40,6 +40,7 @@ class TestBasics(object):
                                'test_list_files_kwarg': 'sleep_tight',
                                'test_list_remote_kwarg': 'one_eye_open',
                                'test_download_kwarg': 'exit_night'}
+        return
 
     def teardown_class(self):
         """Clean up class-level variables once after all methods."""

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -184,7 +184,7 @@ class TestBasics(object):
         return
 
     def eval_iter_list(self, start, stop):
-        """Evaluate successful generation of iter_lsit for `self.testInst`.
+        """Evaluate successful generation of iter_list for `self.testInst`.
 
         Parameters
         ----------
@@ -415,6 +415,7 @@ class TestBasics(object):
         """Test if correct day loads by default when first invoking `.next`."""
 
         getattr(self.testInst, operator)()
+
         # Modify ref time since iterator changes load date.
         self.ref_time = ref_time
         self.eval_successful_load()
@@ -425,7 +426,8 @@ class TestBasics(object):
         """Test Error for in new day when on a file not in iteration list."""
 
         self.testInst.load(fname=self.testInst.files[12])
-        # Set new bounds that doesn't include this date.
+
+        # Set new bounds that do not include this date.
         self.testInst.bounds = (self.testInst.files[9], self.testInst.files[20],
                                 2, 1)
         with pytest.raises(StopIteration) as err:
@@ -440,7 +442,8 @@ class TestBasics(object):
         """Test that day iterators raise Error on bad start date."""
 
         self.testInst.load(date=self.ref_time)
-        # Set new bounds that doesn't include this date.
+
+        # Set new bounds that do not include this date.
         self.testInst.bounds = (self.ref_time + dt.timedelta(days=1),
                                 self.ref_time + dt.timedelta(days=10),
                                 '2D', dt.timedelta(days=1))
@@ -1556,7 +1559,7 @@ class TestBasics(object):
         # load first data
         getattr(self.testInst, first)()
         with pytest.raises(StopIteration) as err:
-            # go back to no data
+            # Iterate to a day outside the bounds.
             getattr(self.testInst, second)()
         assert str(err).find("Outside the set date boundaries") >= 0
         return

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -228,32 +228,6 @@ class TestFilterDatetimeInput(object):
         assert out_date is None
         return
 
-    def test_filter_datetime_input_datetime(self):
-        """Test a successful `filter_datetime_input` with datetime input."""
-
-        in_date = dt.datetime(2009, 1, 1, 1, 1)
-        out_date = pytime.filter_datetime_input(in_date)
-        assert out_date == dt.datetime(2009, 1, 1)
-        return
-
-    def test_filter_datetime_input_list(self):
-        """Test a successful `filter_datetime_input` with list input."""
-
-        in_date = [dt.datetime(2009, 1, 1, 1, 1)]
-        out_date = pytime.filter_datetime_input(in_date)
-        assert len(out_date) == len(in_date)
-        assert out_date[0] == dt.datetime(2009, 1, 1)
-        return
-
-    def test_filter_datetime_input_array(self):
-        """Test a successful `filter_datetime_input` with array input."""
-
-        in_date = np.array([dt.datetime(2009, 1, 1, 1, 1)])
-        out_date = pytime.filter_datetime_input(in_date)
-        assert len(out_date) == len(in_date)
-        assert out_date[0] == dt.datetime(2009, 1, 1)
-        return
-
     @pytest.mark.parametrize("in_time, islist",
                              [(dt.datetime.utcnow(), False),
                               (dt.datetime(2010, 1, 1, 12, tzinfo=dt.timezone(

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -252,6 +252,8 @@ class TestFilterDatetimeInput(object):
 
         # Test for the date values and timezone awareness status
         for i, tt in enumerate(self.out):
-            assert self.out[i] == self.ref_time[i]
-            assert self.out[i].tzinfo is None or self.out[i].utcoffset() is None
+            assert self.out[i] == self.ref_time[i], \
+                "Filtered time has changed dates."
+            assert self.out[i].tzinfo is None or self.out[i].utcoffset() is None, \
+                "Filtered timezone is not removed."
         return

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -252,8 +252,8 @@ class TestFilterDatetimeInput(object):
 
         # Test for the date values and timezone awareness status
         for i, tt in enumerate(self.out):
-            assert self.out[i] == self.ref_time[i], \
+            assert tt == self.ref_time[i], \
                 "Filtered time has changed dates."
-            assert None in [self.out[i].tzinfo, self.out[i].utcoffset()], \
-                "Filtered timezone was not removed."
+            assert None in [tt.tzinfo, self.out[i].utcoffset()], \
+                "Filtered timezone was not removed at value {:d}.".format(i)
         return

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -254,6 +254,6 @@ class TestFilterDatetimeInput(object):
         for i, tt in enumerate(self.out):
             assert self.out[i] == self.ref_time[i], \
                 "Filtered time has changed dates."
-            assert self.out[i].tzinfo is None or self.out[i].utcoffset() is None, \
-                "Filtered timezone is not removed."
+            assert None in [self.out[i].tzinfo, self.out[i].utcoffset()], \
+                "Filtered timezone was not removed."
         return

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -253,3 +253,31 @@ class TestFilterDatetimeInput(object):
         assert len(out_date) == len(in_date)
         assert out_date[0] == dt.datetime(2009, 1, 1)
         return
+
+    @pytest.mark.parametrize("in_time, islist",
+                             [(dt.datetime.utcnow(), False),
+                              (dt.datetime(2010, 1, 1, 12, tzinfo=dt.timezone(
+                                  dt.timedelta(seconds=14400))), False),
+                              ([dt.datetime(2010, 1, 1, 12, i,
+                                            tzinfo=dt.timezone(
+                                                dt.timedelta(seconds=14400)))
+                                for i in range(3)], True)])
+    def test_filter_datetime(self, in_time, islist):
+        """Test range of allowed inputs for the Instrument datetime filter."""
+
+        # Because the input datetime is the middle of the day and the offset
+        # is four hours, the reference date and input date are the same
+        if islist:
+            self.ref_time = [dt.datetime(tt.year, tt.month, tt.day)
+                             for tt in in_time]
+            self.out = pytime.filter_datetime_input(in_time)
+        else:
+            self.ref_time = [dt.datetime(in_time.year, in_time.month,
+                                         in_time.day)]
+            self.out = [pytime.filter_datetime_input(in_time)]
+
+        # Test for the date values and timezone awareness status
+        for i, tt in enumerate(self.out):
+            assert self.out[i] == self.ref_time[i]
+            assert self.out[i].tzinfo is None or self.out[i].utcoffset() is None
+        return

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -254,6 +254,6 @@ class TestFilterDatetimeInput(object):
         for i, tt in enumerate(self.out):
             assert tt == self.ref_time[i], \
                 "Filtered time has changed dates."
-            assert None in [tt.tzinfo, self.out[i].utcoffset()], \
+            assert tt.tzinfo is None, \
                 "Filtered timezone was not removed at value {:d}.".format(i)
         return


### PR DESCRIPTION
# Description

Addresses #532 

Reduces duplicate code in test_instrument.
- Incorporates pytest.mark.parametrize
- Applies common evaluation functions
- Use class-level setup and teardown instead of global declarations
- Moves `test_filter_datetime` to test_utils_time.py since this does not require an instrument to be initialized. Deletes several existing tests there since this version repeats those but more comprehensively.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Via pytest.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.2
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
