### PR TITLE
DEP/TST: deprecation of `_test_download_travis`, test setting of instrument test attrs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added `start_time` keyword for test instruments
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
+   * Removed `_test_download_travis` as a standard attribute for
+     `pysat.Instrument`
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Standardized Instrument instantiation to always define `inst_module`
    * Extended testing options for `pysat.utils.testing` functions
    * Added `start_time` keyword for test instruments
+   * Added `_test_download_ci` as a standard attribute for `pysat.Instrument`
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Removed `_test_download_travis` as a standard attribute for
-     `pysat.Instrument`
+     `pysat.Instrument`.  The function is replaced by `_test_download_ci`
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -735,9 +735,9 @@ FTP Access
 Another thing to note about testing is that the CI environment used to
 automate the tests is not compatible with FTP downloads.  For this reason,
 HTTPS access is preferred whenever possible.  However, if this is not the case,
-the :py:attr:`_test_download_ci` flag can be used.  This has a similar function,
-except that it skips the download tests if on CI, but will run those
-tests if run locally.
+the :py:attr:`_test_download_ci` flag can be used.  This behaves similarly,
+except that it only run the download tests tests locally and will skip them if
+on a CI server.
 
 .. code:: python
 

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -736,7 +736,7 @@ Another thing to note about testing is that the CI environment used to
 automate the tests is not compatible with FTP downloads.  For this reason,
 HTTPS access is preferred whenever possible.  However, if this is not the case,
 the :py:attr:`_test_download_ci` flag can be used.  This behaves similarly,
-except that it only run the download tests tests locally and will skip them if
+except that it only runs the download tests locally and will skip them if
 on a CI server.
 
 .. code:: python

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -735,8 +735,8 @@ FTP Access
 Another thing to note about testing is that the CI environment used to
 automate the tests is not compatible with FTP downloads.  For this reason,
 HTTPS access is preferred whenever possible.  However, if this is not the case,
-the :py:attr:`_test_download_travis` flag can be used.  This has a similar
-function, except that it skips the download tests if on CI, but will run those
+the :py:attr:`_test_download_ci` flag can be used.  This has a similar function,
+except that it skips the download tests if on CI, but will run those
 tests if run locally.
 
 .. code:: python
@@ -748,7 +748,7 @@ tests if run locally.
    inst_ids = {'': ['Level_1', 'Level_2']}
    _test_dates = {'': {'Level_1': dt.datetime(2020, 1, 1),
                        'Level_2': dt.datetime(2020, 1, 1)}}
-   _test_download_travis = {'': {'Level_1': False}}
+   _test_download_ci = {'': {'Level_1': False}}
 
 Note that here we use the streamlined flag definition and only call out the
 tag that is False.  The other is True by default.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1158,7 +1158,7 @@ class Instrument(object):
         inst_attrs = {'directory_format': None, 'file_format': None,
                       'multi_file_day': False, 'orbit_info': None,
                       'pandas_format': True}
-        test_attrs = {'_test_download': True, '_test_download_travis': True,
+        test_attrs = {'_test_download': True, '_test_download_ci': True,
                       '_password_req': False}
 
         # Set method defaults
@@ -1305,6 +1305,24 @@ class Instrument(object):
                     missing.append(iattr)
             else:
                 missing.append(iattr)
+
+        # Check and see if this instrument has deprecated _test_download_travis
+        # TODO(#807): Remove this check once _test_download_travis is removed.
+        if hasattr(self.inst_module, '_test_download_travis'):
+            local_attr = getattr(self.inst_module, '_test_download_travis')
+
+            # Test to see that this attribute is set for the desired
+            # inst_id and tag
+            if self.inst_id in local_attr.keys():
+                if self.tag in local_attr[self.inst_id].keys():
+                    # Update the test attribute value
+                    setattr(self, '_test_download_ci',
+                            local_attr[self.inst_id][self.tag])
+                    warnings.warn(" ".join(["`_test_download_travis` has been",
+                                            "deprecated and will be replaced",
+                                            "by `_test_download_ci` in",
+                                            "3.2.0+"]),
+                                  DeprecationWarning, stacklevel=2)
 
         if len(missing) > 0:
             logger.debug(''.join(['These Instrument test attributes kept their',

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1147,7 +1147,7 @@ class Instrument(object):
             directory_format, file_format, multi_file_day, orbit_info, and
             pandas_format
         test attributes
-            _download_test, _download_test_travis, and _password_req
+            _test_download, _test_download_ci, and _password_req
 
         """
         # Declare the standard Instrument methods and attributes

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -105,8 +105,8 @@ _test_dates = {'': {'': dt.datetime(2019, 1, 1),
 # If not set, defaults to True
 _test_download = {'': {'': False, 'tag_string': True}}
 
-# For instruments using FTP for download, set _test_download_ci to False
-# These tests will still download locally but be skipped on CI
+# For instruments using FTP for download, set `_test_download_ci` to False.
+# These tests will still download locally but be skipped on CI.
 # If not set, defaults to True
 _test_download_ci = {'': {'': False, 'tag_string': False}}
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -105,10 +105,10 @@ _test_dates = {'': {'': dt.datetime(2019, 1, 1),
 # If not set, defaults to True
 _test_download = {'': {'': False, 'tag_string': True}}
 
-# For instruments using FTP for download, set _test_download_travis to False
-# These tests will still download locally but be skipped on Travis CI
+# For instruments using FTP for download, set _test_download_ci to False
+# These tests will still download locally but be skipped on CI
 # If not set, defaults to True
-_test_download_travis = {'': {'': False, 'tag_string': False}}
+_test_download_ci = {'': {'': False, 'tag_string': False}}
 
 # For instruments requiring a user passwrod, set _password_req to True
 # These instruments will not be downloaded as part of tests to preserve password

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2994,17 +2994,14 @@ class TestDeprecation(object):
         warnings.simplefilter("always", DeprecationWarning)
         self.in_kwargs = {"platform": 'pysat', "name": 'testing',
                           "clean_level": 'clean'}
-        self.warn_msgs = ["".join(["`pysat.Instrument.download` kwarg `freq` ",
-                                   "has been deprecated and will be removed ",
-                                   "in pysat 3.2.0+"])]
-        self.warn_msgs = np.array(self.warn_msgs)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
     def teardown(self):
         """Clean up the unit test environment after each method."""
 
-        del self.in_kwargs, self.warn_msgs, self.ref_time
+        reload(pysat.instruments.pysat_testing)
+        del self.in_kwargs, self.ref_time
         return
 
     def test_download_freq_kwarg(self):
@@ -3015,10 +3012,48 @@ class TestDeprecation(object):
             tinst = pysat.Instrument(**self.in_kwargs)
             tinst.download(start=self.ref_time, freq='D')
 
+        self.warn_msgs = ["".join(["`pysat.Instrument.download` kwarg `freq` ",
+                                   "has been deprecated and will be removed ",
+                                   "in pysat 3.2.0+"])]
+        self.warn_msgs = np.array(self.warn_msgs)
+
         # Ensure the minimum number of warnings were raised
         assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
+        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(
+            war, self.warn_msgs)
+
+        for i, good in enumerate(found_msgs):
+            assert good, "didn't find warning about: {:}".format(
+                self.warn_msgs[i])
+
+        return
+
+    def test_download_travis_attr(self):
+        """Test deprecation of instrument attribute `_test_download_travis`."""
+
+        inst_module = pysat.instruments.pysat_testing
+        # Add deprecated attribute.
+        inst_module._test_download_travis = {'': {'': False}}
+
+        self.warn_msgs = [" ".join(["`_test_download_travis` has been",
+                                    "deprecated and will be replaced",
+                                    "by `_test_download_ci` in",
+                                    "3.2.0+"])]
+        self.warn_msgs = np.array(self.warn_msgs)
+
+        # Catch the warnings.
+        with warnings.catch_warnings(record=True) as war:
+            tinst = pysat.Instrument(inst_module=inst_module)
+
+        # Ensure attributes set properly.
+        assert tinst._test_download_ci is False
+
+        # Ensure the minimum number of warnings were raised.
+        assert len(war) >= len(self.warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present.
         found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(
             war, self.warn_msgs)
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -279,7 +279,7 @@ class TestBasics(object):
         inst_module = getattr(pysat.instruments,
                               '_'.join((self.testInst.platform,
                                         self.testInst.name)))
-        # Change settings
+        # Update settings for this test
         setattr(inst_module, attr, {'': {'': setting}})
         self.testInst = pysat.Instrument(inst_module=inst_module)
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -270,6 +270,22 @@ class TestBasics(object):
         assert str(err).find(estr) >= 0
         return
 
+    @pytest.mark.parametrize('attr', ['_test_download', '_test_download_ci',
+                                      '_password_req'])
+    @pytest.mark.parametrize('setting', [True, False])
+    def test_basic_instrument_download_kwargs(self, attr, setting):
+        """Check that download flags are appropriately set."""
+
+        inst_module = getattr(pysat.instruments,
+                              '_'.join((self.testInst.platform,
+                                        self.testInst.name)))
+        # Change settings
+        setattr(inst_module, attr, {'': {'': setting}})
+        self.testInst = pysat.Instrument(inst_module=inst_module)
+
+        assert getattr(self.testInst, attr) is setting
+        return
+
     def test_basic_instrument_load_yr_no_doy(self):
         """Ensure doy required if yr present."""
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -583,11 +583,11 @@ def generate_instrument_list(inst_loc, user_info=None):
                                             tag=tag,
                                             inst_id=inst_id,
                                             temporary_file_list=True)
-                    travis_skip = ((os.environ.get('TRAVIS') == 'true')
-                                   and not inst._test_download_travis)
-                    if inst._test_download:
-                        if not travis_skip:
-                            instrument_download.append(inst_dict)
+                    # Flag to skip tests on CI environment
+                    ci_skip = ((os.environ.get('CI') == 'true')
+                               and not inst._test_download_ci)
+                    if inst._test_download and not ci_skip:
+                        instrument_download.append(inst_dict)
                     elif not inst._password_req:
                         # We don't want to test download for this combo, but
                         # we do want to test the download warnings for

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -583,7 +583,7 @@ def generate_instrument_list(inst_loc, user_info=None):
                                             tag=tag,
                                             inst_id=inst_id,
                                             temporary_file_list=True)
-                    # Flag to skip tests on CI environment
+                    # Set flag to skip tests on a CI environment
                     ci_skip = ((os.environ.get('CI') == 'true')
                                and not inst._test_download_ci)
                     if inst._test_download and not ci_skip:


### PR DESCRIPTION
# Description

Addresses #807

- Deprecates `_test_download_travis` attribute and replaces it with `_test_download_ci`.  
- Adds test for deprecation warnings
- Adds unit test for setting the custom test attrs (`_test_download`, `_test_download_ci`, and `_password_req`) via the instrument module.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Tested via pytest.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
