### PR TITLE
STY: reduce code duplication in test_instrument (2 of 2?)

### DIFF
--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -397,7 +397,7 @@ class TestBasics(object):
         """Test that correct day loads (checking down to the sec)."""
 
         self.testInst.load(self.ref_time.year, self.ref_doy)
-        assert (self.testInst.index[0] == self.ref_time)
+        self.eval_successful_load()
         return
 
     def test_basic_instrument_load_leap_year(self):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1614,10 +1614,10 @@ class TestBasics(object):
 
             check = out['expected_times'][i] + out['width']
             check -= dt.timedelta(days=1)
-            assert trange[1] > check, "End time outside of expected range"
+            assert trange[1] > check, "End time higher than expected"
 
             check = out['stops'][b_range] + dt.timedelta(days=1)
-            assert trange[1] < check, "End time outside of expected range"
+            assert trange[1] < check, "End time lower than expected"
 
             if reverse:
                 if i == 0:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -183,7 +183,7 @@ class TestBasics(object):
 
         return
 
-    def eval_iter_list(self, start, stop, dates=False):
+    def eval_iter_list(self, start, stop, dates=False, freq=None):
         """Evaluate successful generation of iter_list for `self.testInst`.
 
         Parameters
@@ -195,14 +195,21 @@ class TestBasics(object):
         dates : bool
             If True, checks each date.  If False, checks against the _iter_list
             (default=False)
+        freq : int or NoneType
+            Frequency in days.  If None, use pandas default. (default=None)
 
         """
 
-        if isinstance(start, dt.datetime):
-            out = pds.date_range(start, stop).tolist()
+        if freq:
+            kwargs = {'freq': '{:}D'.format(freq)}
         else:
-            out = pds.date_range(start[0], stop[0]).tolist()
-            out.extend(pds.date_range(start[1], stop[1]).tolist())
+            kwargs = {}
+
+        if isinstance(start, dt.datetime):
+            out = pds.date_range(start, stop, **kwargs).tolist()
+        else:
+            out = pds.date_range(start[0], stop[0], **kwargs).tolist()
+            out.extend(pds.date_range(start[1], stop[1], **kwargs).tolist())
         if dates:
             dates = []
             for inst in self.testInst:
@@ -1579,11 +1586,7 @@ class TestBasics(object):
         start = self.ref_time
         stop = self.ref_time + dt.timedelta(days=15)
         self.testInst.bounds = (start, stop, '2D')
-        dates = []
-        for inst in self.testInst:
-            dates.append(inst.date)
-        out = pds.date_range(start, stop, freq='2D').tolist()
-        assert np.all(dates == out)
+        self.eval_iter_list(start, stop, dates=True, freq=2)
         return
 
     def test_set_bounds_with_frequency_and_width(self):
@@ -2114,11 +2117,7 @@ class TestBasics(object):
         stop_date = dt.datetime(2009, 1, 3)
         self.testInst.bounds = (start, stop, 2)
 
-        dates = []
-        for inst in self.testInst:
-            dates.append(inst.date)
-        out = pds.date_range(start_date, stop_date, freq='2D').tolist()
-        assert np.all(dates == out)
+        self.eval_iter_list(start_date, stop_date, dates=True, freq=2)
         return
 
     def test_set_bounds_fname_with_frequency_and_width(self):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1687,7 +1687,6 @@ class TestBasics(object):
         """Test iterate via date with mixed step/width, excludes stop date."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-        # Verify range of loaded data.
         self.verify_exclusive_iteration(out, reverse=False)
 
         return
@@ -1714,7 +1713,6 @@ class TestBasics(object):
         """Test iterate via date with mixed step/width, includes stop date."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-        # Verify range of loaded data.
         self.verify_inclusive_iteration(out, reverse=False)
 
         return
@@ -1737,8 +1735,6 @@ class TestBasics(object):
         """Test iteration via date step/width >1, includes stop date."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-
-        # Verify range of loaded data.
         self.verify_inclusive_iteration(out, reverse=reverse)
 
         return
@@ -1763,8 +1759,6 @@ class TestBasics(object):
         """Test iteration via date step/width > 1, exclude stop date."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-
-        # Verify range of loaded data.
         self.verify_exclusive_iteration(out, reverse=reverse)
 
         return
@@ -1791,9 +1785,8 @@ class TestBasics(object):
     @pytest.mark.parametrize("reverse", [True, False])
     def test_iter_date_season_frequency_and_width_incl(self, values, reverse):
         """Test iteration via date season step/width > 1, include stop date."""
-        out = self.support_iter_evaluations(values, reverse=reverse)
 
-        # Verify range of loaded data.
+        out = self.support_iter_evaluations(values, reverse=reverse)
         self.verify_inclusive_iteration(out, reverse=reverse)
 
         return
@@ -1822,8 +1815,6 @@ class TestBasics(object):
         """Test iteration via date season step/width>1, exclude stop date."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-
-        # Verify range of loaded data.
         self.verify_exclusive_iteration(out, reverse=reverse)
 
         return
@@ -2163,7 +2154,6 @@ class TestBasics(object):
         """File iteration in bounds with step/width > 1, exclude stop bounds."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-        # verify range of loaded data
         self.verify_exclusive_iteration(out, reverse=False)
 
         return
@@ -2188,7 +2178,6 @@ class TestBasics(object):
         """File iteration in bounds with step/width > 1, include stop bounds."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-        # verify range of loaded data
         self.verify_inclusive_iteration(out, reverse=False)
 
         return
@@ -2221,7 +2210,6 @@ class TestBasics(object):
         """File season iteration with step/width > 1, exclude stop bounds."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-        # verify range of loaded data
         self.verify_exclusive_iteration(out, reverse=False)
 
         return
@@ -2262,7 +2250,6 @@ class TestBasics(object):
         """File iteration in bounds with step/width > 1, include stop bounds."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-        # verify range of loaded data
         self.verify_inclusive_iteration(out, reverse=False)
 
         return
@@ -2292,7 +2279,6 @@ class TestBasics(object):
         """Test iteration via fname step/width > 1, exclude stop file."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-        # verify range of loaded data
         self.verify_exclusive_iteration(out, reverse=reverse)
 
         return
@@ -2319,7 +2305,6 @@ class TestBasics(object):
         """Test iteration via fname step/width > 1, include stop file."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-        # verify range of loaded data
         self.verify_inclusive_iteration(out, reverse=reverse)
 
         return
@@ -2353,7 +2338,6 @@ class TestBasics(object):
         """Test iterate file season with step/width > 1, exclude stop bounds."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-        # verify range of loaded data
         self.verify_exclusive_iteration(out, reverse=reverse)
 
         return
@@ -2396,7 +2380,6 @@ class TestBasics(object):
         """Test iterate file season with step/width > 1, include stop bounds."""
 
         out = self.support_iter_evaluations(values, reverse=reverse)
-        # verify range of loaded data
         self.verify_inclusive_iteration(out, reverse=reverse)
 
         return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -135,9 +135,7 @@ class TestBasics(object):
         for start, stop in zip(starts, stops):
             tdate = stop - width + dt.timedelta(days=1)
             out.extend(pds.date_range(start, tdate, freq=step).tolist())
-        if reverse:
-            out = out[::-1]
-        assert np.all(dates == out)
+        pysat.utils.testing.assert_lists_equal(dates, out)
 
         output = {}
         output['expected_times'] = out
@@ -212,9 +210,10 @@ class TestBasics(object):
             dates = []
             for inst in self.testInst:
                 dates.append(inst.date)
-            assert np.all(dates == out)
+            pysat.utils.testing.assert_lists_equal(dates, out)
         else:
-            assert np.all(self.testInst._iter_list == out)
+            pysat.utils.testing.assert_lists_equal(self.testInst._iter_list,
+                                                   out)
         return
 
     @pytest.mark.parametrize("kwargs", [{}, {'num_samples': 30}])
@@ -2057,9 +2056,9 @@ class TestBasics(object):
         assert str(err).find(estr) >= 0
         return
 
-    @pytest.mark.parametrize("operator,step", [('next', 1), ('prev', -1)])
-    def test_iterate_over_bounds_set_by_fname_via_attr(self, operator, step):
-        """Test iterate over bounds set by fname via `.next()`."""
+    @pytest.mark.parametrize("operator", ['next', 'prev'])
+    def test_iterate_over_bounds_set_by_fname_via_attr(self, operator):
+        """Test iterate over bounds set by fname via operators."""
 
         start = '2009-01-01.nofile'
         stop = '2009-01-15.nofile'
@@ -2075,7 +2074,7 @@ class TestBasics(object):
             except StopIteration:
                 loop_next = False
         out = pds.date_range(start_d, stop_d).tolist()
-        assert np.all(dates == out[::step])
+        pysat.utils.testing.assert_lists_equal(dates, out)
         return
 
     def test_set_bounds_by_fname_season(self):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1342,17 +1342,6 @@ class TestBasics(object):
         assert (self.testInst[changed, 'doubleMLT'] == 0).all
         return
 
-    def test_setting_partial_data_by_index_and_name(self):
-        """Test setting partial data by index and name."""
-
-        self.testInst.load(self.ref_time.year, self.ref_doy)
-        self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
-        self.testInst[self.testInst.index[0:10], 'doubleMLT'] = 0
-        assert (self.testInst[10:, 'doubleMLT']
-                == 2. * self.testInst[10:, 'mlt']).all
-        assert (self.testInst[0:10, 'doubleMLT'] == 0).all
-        return
-
     def test_modifying_data_inplace(self):
         """Test modification of data inplace."""
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1651,24 +1651,29 @@ class TestBasics(object):
                 "Loaded start time is not correct"
             check = out['expected_times'][i] + out['width']
             check -= dt.timedelta(days=1)
-            assert trange[1] > check
+            assert trange[1] > check, "End time lower than expected"
 
             if not reverse:
-                assert trange[1] < out['stops'][b_range]
+                assert trange[1] < out['stops'][b_range], \
+                    "End time higher than expected"
             else:
                 check = out['stops'][b_range] + dt.timedelta(days=1)
-                assert trange[1] < check
+                assert trange[1] < check, "End time higher than expected"
                 if i == 0:
                     # check first load is before end of bounds
                     check = out['stops'][b_range] - out['width']
                     check += dt.timedelta(days=1)
-                    assert trange[0] < check
-                    assert trange[1] < out['stops'][b_range]
+                    assert trange[0] < check, "Start time higher than expected"
+                    assert trange[1] < out['stops'][b_range], \
+                        "End time higher than expected"
                 elif i == len(out['observed_times']) - 1:
                     # last load at start of bounds
-                    assert trange[0] == out['starts'][b_range]
-                    assert trange[1] > out['starts'][b_range]
-                    assert trange[1] < out['starts'][b_range] + out['width']
+                    assert trange[0] == out['starts'][b_range], \
+                        "Loaded start time is not correct"
+                    assert trange[1] > out['starts'][b_range], \
+                        "End time lower than expected"
+                    assert trange[1] < out['starts'][b_range] + out['width'], \
+                        "End time higher than expected"
 
         return
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -208,8 +208,6 @@ class TestBasics(object):
             out = list()
             for (istart, istop) in zip(start, stop):
                 out.extend(pds.date_range(istart, istop, **kwargs).tolist())
-
-            out.extend(pds.date_range(start[1], stop[1], **kwargs).tolist())
         if dates:
             dates = []
             for inst in self.testInst:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -1977,8 +1977,6 @@ class TestBasics(object):
         """Test iterate over season, step/width > 1, exclude stop bounds."""
 
         out = self.support_iter_evaluations(values, for_loop=True)
-
-        # Verify range of loaded data.
         self.verify_exclusive_iteration(out, reverse=False)
 
         return
@@ -2007,7 +2005,6 @@ class TestBasics(object):
 
         out = self.support_iter_evaluations(values, for_loop=True)
 
-        # Verify range of loaded data.
         self.verify_inclusive_iteration(out, reverse=False)
 
         return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2510,7 +2510,7 @@ class TestBasicsInstModule(TestBasics):
                                          clean_level='clean',
                                          update_files=True,
                                          **self.testing_kwargs)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = imod._test_dates['']['']
         self.ref_doy = 1
         self.out = None
         return
@@ -2540,7 +2540,8 @@ class TestBasicsXarray(TestBasics):
                                          clean_level='clean',
                                          update_files=True,
                                          **self.testing_kwargs)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = \
+            pysat.instruments.pysat_testing_xarray._test_dates['']['']
         self.ref_doy = 1
         self.out = None
         return
@@ -2564,7 +2565,7 @@ class TestBasics2D(TestBasics):
                                          clean_level='clean',
                                          update_files=True,
                                          **self.testing_kwargs)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = pysat.instruments.pysat_testing2d._test_dates['']['']
         self.ref_doy = 1
         self.out = None
         return
@@ -2594,7 +2595,8 @@ class TestBasics2DXarray(TestBasics):
                                          clean_level='clean',
                                          update_files=True,
                                          **self.testing_kwargs)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = \
+            pysat.instruments.pysat_testing2d_xarray._test_dates['']['']
         self.ref_doy = 1
         self.out = None
         return
@@ -2684,7 +2686,7 @@ class TestBasicsShiftedFileDates(TestBasics):
                                          mangle_file_dates=True,
                                          strict_time_flag=True,
                                          **self.testing_kwargs)
-        self.ref_time = dt.datetime(2009, 1, 1)
+        self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.ref_doy = 1
         self.out = None
         return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2142,18 +2142,15 @@ class TestBasics(object):
     @pytest.mark.parametrize("values", [('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-03.nofile',
-                                         dt.datetime(2009, 1, 3),
-                                         2, 2),
+                                         dt.datetime(2009, 1, 3), 2, 2),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         2, 3),
+                                         dt.datetime(2009, 1, 4), 2, 3),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-05.nofile',
-                                         dt.datetime(2009, 1, 5),
-                                         3, 1)])
+                                         dt.datetime(2009, 1, 5), 3, 1)])
     def test_iterate_bounds_fname_with_frequency_and_width(self, values):
         """File iteration in bounds with step/width > 1, exclude stop bounds."""
 
@@ -2166,23 +2163,19 @@ class TestBasics(object):
     @pytest.mark.parametrize("values", [('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         2, 2),
+                                         dt.datetime(2009, 1, 4), 2, 2),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         3, 1),
+                                         dt.datetime(2009, 1, 4), 3, 1),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-04.nofile',
-                                         dt.datetime(2009, 1, 4),
-                                         1, 4),
+                                         dt.datetime(2009, 1, 4), 1, 4),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-05.nofile',
-                                         dt.datetime(2009, 1, 5),
-                                         2, 3)])
+                                         dt.datetime(2009, 1, 5), 2, 3)])
     def test_iterate_bounds_fname_with_frequency_and_width_incl(self, values):
         """File iteration in bounds with step/width > 1, include stop bounds."""
 
@@ -2299,23 +2292,19 @@ class TestBasics(object):
     @pytest.mark.parametrize("values", [('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 10),
-                                         2, 2),
+                                         dt.datetime(2009, 1, 10), 2, 2),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-09.nofile',
-                                         dt.datetime(2009, 1, 9),
-                                         4, 1),
+                                         dt.datetime(2009, 1, 9), 4, 1),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         1, 3),
+                                         dt.datetime(2009, 1, 11), 1, 3),
                                         ('2009-01-01.nofile',
                                          dt.datetime(2009, 1, 1),
                                          '2009-01-11.nofile',
-                                         dt.datetime(2009, 1, 11),
-                                         1, 11),
+                                         dt.datetime(2009, 1, 11), 1, 11),
                                         ])
     @pytest.mark.parametrize("reverse", [True, False])
     def test_iter_fname_with_frequency_and_width_incl(self, values, reverse):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -135,6 +135,8 @@ class TestBasics(object):
         for start, stop in zip(starts, stops):
             tdate = stop - width + dt.timedelta(days=1)
             out.extend(pds.date_range(start, tdate, freq=step).tolist())
+        if reverse:
+            out = out[::-1]
         pysat.utils.testing.assert_lists_equal(dates, out)
 
         output = {}


### PR DESCRIPTION
# Description

Addresses #532

- Added options to evaluation functions to improve utility across the unit tests.
- Consistent use of `reverse` kwarg in functions to improve parametrize usage.
- Regrouped multiple functions under @pytest.mark.parametrize
- Minor style changes for consistency
- Removed a duplicate test missed in #890.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Via `pytest -vs pysat/tests/test_instrument.py::TestBasics` to compare number of tests run before and after changes

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [na] Add a note to ``CHANGELOG.md``, summarizing the changes -- Changes fall under #890 changelog

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
