### PR TITLE
Deprecation warning unit testing

### DIFF
--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2996,7 +2996,14 @@ class TestDeprecation(object):
                           "clean_level": 'clean'}
         self.warn_msgs = ["".join(["`pysat.Instrument.download` kwarg `freq` ",
                                    "has been deprecated and will be removed ",
-                                   "in pysat 3.2.0+"])]
+                                   "in pysat 3.2.0+"]),
+                          "".join(["`pysat.Instrument.",
+                                   "_filter_netcdf4_metadata` ",
+                                   "has been deprecated and will be removed ",
+                                   "in pysat 3.2.0+. Use `pysat.utils.io.",
+                                   "filter_netcdf4_metadata` instead."]),
+                          "".join(["`fname` as a kwarg has been deprecated, ",
+                                   "must supply a filename 3.2.0+"])]
         self.warn_msgs = np.array(self.warn_msgs)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         return
@@ -3007,13 +3014,21 @@ class TestDeprecation(object):
         del self.in_kwargs, self.warn_msgs, self.ref_time
         return
 
-    def test_download_freq_kwarg(self):
-        """Test deprecation of download kwarg `freq`."""
+    def test_deprecations(self):
+        """Test deprecation messages generated within `_instrument.py`"""
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as war:
             tinst = pysat.Instrument(**self.in_kwargs)
             tinst.download(start=self.ref_time, freq='D')
+            tinst.load(date=self.ref_time)
+            mdata_dict = tinst.meta._data.to_dict()
+            tinst._filter_netcdf4_metadata(mdata_dict,
+                                           coltype='str')
+            try:
+                tinst.to_netcdf4()
+            except ValueError:
+                pass
 
         # Ensure the minimum number of warnings were raised
         assert len(war) >= len(self.warn_msgs)

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -21,27 +21,6 @@ from pysat.tests.registration_test_class import TestWithRegistration
 from pysat.utils import generate_instrument_list
 
 
-def prep_dir(inst):                                                             
-    """Prepare the directory to provide netCDF export file support.             
-                                                                                
-    Parameters                                                                  
-    ----------                                                                  
-    inst : pysat.Instrument                                                     
-        Instrument class object                                                 
-                                                                                
-    Returns                                                                     
-    -------                                                                     
-    bool                                                                        
-        True if directories create, False if not                                
-                                                                                
-    """                                                                         
-    # Create data directories                                                   
-    try:                                                                        
-        os.makedirs(inst.files.data_path)                                       
-        return True                                                             
-    except OSError:                                                             
-        return False
-
 class TestCIonly(object):
     """Tests where we mess with local settings.
 
@@ -529,12 +508,12 @@ class TestGenerateInstList(object):
             assert ('user_info' not in inst.keys())
         return
 
+
 class TestDeprecation(object):
     """Unit test for deprecation warnings."""
-    
-    def setup(self):                                                            
-        """Set up the test environment."""                                      
-                                                                                
+
+    def setup(self):
+        """Set up the test environment."""
         self.warn_msgs = ["".join(["function moved to `pysat.utils.io`, ",
                                    "deprecated wrapper will be removed in ",
                                    "pysat 3.2.0+"]),
@@ -544,15 +523,15 @@ class TestDeprecation(object):
                           "".join(["`file_format` must be a string value in ",
                                    "3.2.0+, instead of None use 'NETCDF4' ",
                                    "for same behavior."])]
-        return                                                                  
-                                                                                
-    def teardown(self):                                                         
-        """Clean up the test environment."""                                    
-                                                                                
-        # Clear the attributes with data in them                                
-        del self.warn_msgs                         
-        return     
-   
+        return
+
+    def teardown(self):
+        """Clean up the test environment."""
+
+        # Clear the attributes with data in them
+        del self.warn_msgs
+        return
+
     def test_load_netcdf4(self):
         """Test deprecation warnings from load_netcdf4"""
         with warnings.catch_warnings(record=True) as war:
@@ -561,22 +540,21 @@ class TestDeprecation(object):
                 pysat.utils.load_netcdf4(fnames='anything', file_format=None)
             except FileNotFoundError:
                 pass
-    
+
             try:
                 # generate fnames positional change warning
                 pysat.utils.load_netcdf4()
             except ValueError:
                 pass
 
-        # Ensure the minimum number of warnings were raised                     
-        assert len(war) >= len(self.warn_msgs)                                  
-                                                                                
-        # Test the warning messages, ensuring each attribute is present         
-        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(       
-            war, self.warn_msgs)                                                
-                                                                                
-        for i, good in enumerate(found_msgs):                                   
-            assert good, "didn't find warning about: {:}".format(               
-                self.warn_msgs[i])                                              
-                                                                                
-        return                              
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(self.warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(
+            war, self.warn_msgs)
+
+        for i, good in enumerate(found_msgs):
+            assert good, "didn't find warning about: {:}".format(
+                self.warn_msgs[i])
+            return

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -14,11 +14,33 @@ import portalocker
 import pytest
 import shutil
 import tempfile
+import warnings
 
 import pysat
 from pysat.tests.registration_test_class import TestWithRegistration
 from pysat.utils import generate_instrument_list
 
+
+def prep_dir(inst):                                                             
+    """Prepare the directory to provide netCDF export file support.             
+                                                                                
+    Parameters                                                                  
+    ----------                                                                  
+    inst : pysat.Instrument                                                     
+        Instrument class object                                                 
+                                                                                
+    Returns                                                                     
+    -------                                                                     
+    bool                                                                        
+        True if directories create, False if not                                
+                                                                                
+    """                                                                         
+    # Create data directories                                                   
+    try:                                                                        
+        os.makedirs(inst.files.data_path)                                       
+        return True                                                             
+    except OSError:                                                             
+        return False
 
 class TestCIonly(object):
     """Tests where we mess with local settings.
@@ -506,3 +528,55 @@ class TestGenerateInstList(object):
             # `user_info` should not be in any of these
             assert ('user_info' not in inst.keys())
         return
+
+class TestDeprecation(object):
+    """Unit test for deprecation warnings."""
+    
+    def setup(self):                                                            
+        """Set up the test environment."""                                      
+                                                                                
+        self.warn_msgs = ["".join(["function moved to `pysat.utils.io`, ",
+                                   "deprecated wrapper will be removed in ",
+                                   "pysat 3.2.0+"]),
+                          "".join(["`fnames` as a kwarg has been deprecated, ",
+                                   "must supply a string or list of strings",
+                                   " in 3.2.0+"]),
+                          "".join(["`file_format` must be a string value in ",
+                                   "3.2.0+, instead of None use 'NETCDF4' ",
+                                   "for same behavior."])]
+        return                                                                  
+                                                                                
+    def teardown(self):                                                         
+        """Clean up the test environment."""                                    
+                                                                                
+        # Clear the attributes with data in them                                
+        del self.warn_msgs                         
+        return     
+   
+    def test_load_netcdf4(self):
+        """Test deprecation warnings from load_netcdf4"""
+        with warnings.catch_warnings(record=True) as war:
+            try:
+                # generate relocation warning and file_format warning
+                pysat.utils.load_netcdf4(fnames='anything', file_format=None)
+            except FileNotFoundError:
+                pass
+    
+            try:
+                # generate fnames positional change warning
+                pysat.utils.load_netcdf4()
+            except ValueError:
+                pass
+
+        # Ensure the minimum number of warnings were raised                     
+        assert len(war) >= len(self.warn_msgs)                                  
+                                                                                
+        # Test the warning messages, ensuring each attribute is present         
+        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(       
+            war, self.warn_msgs)                                                
+                                                                                
+        for i, good in enumerate(found_msgs):                                   
+            assert good, "didn't find warning about: {:}".format(               
+                self.warn_msgs[i])                                              
+                                                                                
+        return                              

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -767,7 +767,7 @@ def inst_to_netcdf(inst, fname, base_instrument=None, epoch_name='Epoch',
         base_attrb = dir(pysat.Instrument())
     else:
         warnings.warn("".join(["`base_instrument` has been deprecated and will",
-                               "be removed in 3.2.0+"]),
+                               " be removed in 3.2.0+"]),
                       DeprecationWarning, stacklevel=2)
         base_attrb = dir(base_instrument)
 


### PR DESCRIPTION
# Description

All this does is add unit tests to ensure that deprecation warnings are in fact generated when expected.
Will need some discussion on the final form for some of the tests.
The existing framework for testing deprecation warnings implied a list of all expected warnings and then a comparison.
However I am sure that what I have done here (particularly within test_instrument.py) is not what the creator of that framework had in mind.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

- local flake8 and pytest

**Test Configuration**:
* Operating system: MacOS Catalina
* Version number: Python 3.9
* conda environment

# Checklist:

- [X] Make sure you are merging into the ``develop`` (not ``main``) branch
- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
