### PR TITLE
BUG: assumptions in `create_datetime_index`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added `decode_timedelta=False` for loading xarray from netcdf4 (#823)
    * Closed links to open files when loading data through xarray (#887)
    * Fixed an issue in generating filenames for `pysat.Instrument._iter_list`
+   * Fixed a bug in `pysat.utils.time.create_datetime_index` (#906)
 * Maintenance
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -172,36 +172,38 @@ class TestCreateDatetimeIndex(object):
 
     def setup(self):
         """Set up the unit test environment before each method."""
-        self.year = 2012 * np.ones(4)
-        self.month = 2 * np.ones(4)
-        self.day = 28 * np.ones(4)
-        self.uts = np.arange(0, 4)
         return
 
     def teardown(self):
         """Clean up the unit test environment after each method."""
-        del self.year, self.month, self.day, self.uts
         return
 
-    def test_create_datetime_index(self):
+    @pytest.mark.parametrize("kwargs, target",
+                             [({'year': 2012 * np.ones(4),
+                                'month': 2 * np.ones(4),
+                                'day': 28 * np.ones(4),
+                                'uts': np.arange(0, 4)},
+                              [dt.datetime(2012, 2, 28),
+                               dt.datetime(2012, 2, 28, 0, 0, 3)]),
+                              ({'year': 2012 * np.ones(4),
+                                'day': 366 * np.ones(4),
+                                'uts': np.arange(0, 4)},
+                               [dt.datetime(2012, 12, 31),
+                                dt.datetime(2012, 12, 31, 0, 0, 3)]),
+                              ({'year': [2012, 2012, 2012, 2008],
+                                'day': 366 * np.ones(4),
+                                'uts': np.arange(0, 4)},
+                               [dt.datetime(2012, 12, 31),
+                                dt.datetime(2008, 12, 31, 0, 0, 3)]),
+                              ({'year': 2012 * np.ones(4)},
+                               [dt.datetime(2012, 1, 1),
+                                dt.datetime(2012, 1, 1)])])
+    def test_create_datetime_index(self, kwargs, target):
         """Test create an array of datetime objects from arrays of inputs."""
 
-        dates = pytime.create_datetime_index(year=self.year, month=self.month,
-                                             day=self.day, uts=self.uts)
+        dates = pytime.create_datetime_index(**kwargs)
 
-        testing.assert_lists_equal([dates[0], dates[-1]],
-                                   [dt.datetime(2012, 2, 28),
-                                    dt.datetime(2012, 2, 28, 0, 0, 3)])
-        return
-
-    def test_create_datetime_index_wo_month_day_uts(self):
-        """Test ability to generate missing parameters."""
-
-        dates = pytime.create_datetime_index(year=self.year)
-
-        testing.assert_lists_equal([dates[0], dates[-1]],
-                                   [dt.datetime(2012, 1, 1),
-                                    dt.datetime(2012, 1, 1)])
+        testing.assert_lists_equal([dates[0], dates[-1]], target)
         return
 
     @pytest.mark.parametrize("in_args,err_msg", [

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -294,8 +294,11 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
     df = pds.DataFrame({'year': year, 'month': month, 'day': day0})
     index = pds.DatetimeIndex(pds.to_datetime(df))
 
-    # Add days (offset by 1) and seconds to each index.
-    index += (day - 1).astype('timedelta64[D]') + uts.astype('timedelta64[s]')
+    # Add days (offset by 1) to each index.
+    index += (day - 1).astype('timedelta64[D]')
+
+    # Add seconds to each index.  Need to convert to nanoseconds first.
+    index += (1e9 * uts).astype('timedelta64[ns]')
 
     return index
 

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -278,7 +278,7 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
     # Establish default month
     if month is None:
         # If no month, assume January.  All days will be treated as day of year.
-        month = np.ones(len(year))
+        month = np.ones(shape=len(year))
 
     # Initial day is first of given month.
     day0 = np.ones(shape=len(year))
@@ -288,7 +288,7 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
         day = day0
     if uts is None:
         # If no seconds, assume start of day.
-        uts = np.zeros(len(year))
+        uts = np.zeros(shape=len(year))
 
     # Initialize all dates as first of month and convert to index.
     df = pds.DataFrame({'year': year, 'month': month, 'day': day0})

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -257,7 +257,7 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
             Array of number of days as np.int. If month=None then value
             interpreted as day of year, otherwise, day of month. (default=None)
         uts : array-like or NoneType
-            Array of UT seconds of minute as np.float64 values (default=None)
+            Array of UT seconds as np.float64 values (default=None)
 
     Returns
     -------

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -291,10 +291,12 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
         uts = np.zeros(shape=len(year))
 
     # Initialize all dates as first of month and convert to index.
+    # This method allows month-day and day of year to be used.
     df = pds.DataFrame({'year': year, 'month': month, 'day': day0})
     index = pds.DatetimeIndex(pds.to_datetime(df))
 
     # Add days (offset by 1) to each index.
+    # Day is added here in case input is in day of year format.
     index += (day - 1).astype('timedelta64[D]')
 
     # Add seconds to each index.  Need to convert to nanoseconds first.

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -281,11 +281,11 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
         month = np.ones(len(year))
 
     # Initial day is first of given month.
-    day0 = np.ones(len(year))
+    day0 = np.ones(shape=len(year))
 
     if day is None:
         # If no day, assume first of month.
-        day = np.ones(len(year))
+        day = day0
     if uts is None:
         # If no seconds, assume start of day.
         uts = np.zeros(len(year))

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -282,44 +282,29 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
     if len(year) == 0:
         raise ValueError('Length of array must be larger than 0.')
 
-    year = year.astype(int)
+    # Establish default month
     if month is None:
-        month = np.ones(len(year), dtype=int)
-    else:
-        month = month.astype(int)
+        # If no month, assume January.  All days will be treated as day of year.
+        month = np.ones(len(year))
 
-    if uts is None:
-        uts = np.zeros(len(year))
+    # Initial day is first of given month.
+    day0 = np.ones(len(year))
+
     if day is None:
+        # If no day, assume first of month.
         day = np.ones(len(year))
-    day = day.astype(int)
+    if uts is None:
+        # If no seconds, assume start of day.
+        uts = np.zeros(len(year))
 
-    # Track changes in seconds
-    uts_del = uts.copy().astype(np.float64)
+    # Initialize all dates as first of month and convert to index.
+    df = pds.DataFrame({'year': year, 'month': month, 'day': day0})
+    index = pds.DatetimeIndex(pds.to_datetime(df))
 
-    # Determine where there are changes in year and month that need to be
-    # accounted for
-    _, idx = np.unique((year * 100.0 + month), return_index=True)
+    # Add days (offset by 1) and seconds to each index.
+    index += (day - 1).astype('timedelta64[D]') + uts.astype('timedelta64[s]')
 
-    # Create another index array for faster algorithm below
-    idx2 = np.hstack((idx, len(year) + 1))
-
-    # Computes UTC seconds offset for each unique set of year and month
-    for _idx, _idx2 in zip(idx[1:], idx2[2:]):
-        temp = (dt.datetime(year[_idx], month[_idx], 1)
-                - dt.datetime(year[0], month[0], 1))
-        uts_del[_idx:_idx2] += temp.total_seconds()
-
-    # Add in UTC seconds for days, ignores existence of leap seconds
-    uts_del += (day - 1) * 86400.0
-
-    # Add in seconds since unix epoch to first day
-    uts_del += (dt.datetime(year[0], month[0], 1)
-                - dt.datetime(1970, 1, 1)).total_seconds()
-
-    # Going to use routine that defaults to nanseconds for epoch
-    uts_del *= 1E9
-    return pds.to_datetime(uts_del)
+    return index
 
 
 def filter_datetime_input(date):

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -269,13 +269,6 @@ def create_datetime_index(year=None, month=None, day=None, uts=None):
 
     """
 
-    # We need a timeseries index for storing satellite data in pandas, but
-    # creating a datetime object for everything is too slow.  Instead, we
-    # calculate the number of nanoseconds elapsed since first sample and
-    # create timeseries index from that.  This yields a factor of 20
-    # improvement compared to previous method, which itself was an order of
-    # magnitude faster than datetime.
-
     # Get list of unique year, and month
     if not hasattr(year, '__iter__'):
         raise ValueError('Must provide an iterable for all inputs.')


### PR DESCRIPTION
# Description

Addresses #906

Currently, `pysat.utils.time.create_datetime_index` assumes all incoming dates are in sequential order.  Depending on the user system, this is not always the case.  This rewrites the code to convert incoming values as `timedelta64` objects.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Testing the function:
```
import numpy as np
import pysat
year = np.array([2014, 2014, 2008])
day = np.array([1, 2, 365])
uts = np.array([0, 3600, 2700])
pysat.utils.time.create_datetime_index(year=year, day=day, uts=uts)
```
The resulting datetime index should match expectations based on the inputs.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
