### PR TITLE
BUG: Allow `tag` and `inst_id` to be None, add Deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added `decode_timedelta=False` for loading xarray from netcdf4 (#823)
    * Closed links to open files when loading data through xarray (#887)
    * Fixed an issue in generating filenames for `pysat.Instrument._iter_list`
+   * Allow `tag` and `inst_id` to be specified as None (#892)
 * Maintenance
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -243,8 +243,8 @@ class Instrument(object):
         """Initialize `pysat.Instrument` object."""
 
         # Set default tag, inst_id, and Instrument module
-        self.tag = tag.lower()
-        self.inst_id = inst_id.lower()
+        self.tag = '' if tag is None else tag.lower()
+        self.inst_id = '' if inst_id is None else inst_id.lower()
         self.inst_module = inst_module
 
         if self.inst_module is None:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -242,9 +242,18 @@ class Instrument(object):
                  custom=None, **kwargs):
         """Initialize `pysat.Instrument` object."""
 
+        # Check for deprecated usage of None.
+        if None in [tag, inst_id]:
+            warnings.warn(" ".join(["The usage of None in `tag` and `inst_id`",
+                                    "has been deprecated and will be removed",
+                                    "in 3.2.0+. Please use '' instead of",
+                                    "None."]),
+                          DeprecationWarning, stacklevel=2)
+
         # Set default tag, inst_id, and Instrument module
         self.tag = '' if tag is None else tag.lower()
         self.inst_id = '' if inst_id is None else inst_id.lower()
+
         self.inst_module = inst_module
 
         if self.inst_module is None:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -2492,3 +2492,32 @@ class TestDeprecation(object):
                 self.warn_msgs[i])
 
         return
+
+    @pytest.mark.parametrize("kwargs", [{'inst_id': None}, {'tag': None}])
+    def test_inst_init_with_none(self, kwargs):
+        """Check that instantiation with None raises a DeprecationWarning.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Dictionary of optional kwargs to pass through for instrument
+            instantiation.
+
+        """
+
+        with warnings.catch_warnings(record=True) as war:
+            pysat.Instrument('pysat', 'testing', **kwargs)
+
+        warn_msgs = [" ".join(["The usage of None in `tag` and `inst_id`",
+                               "has been deprecated and will be removed",
+                               "in 3.2.0+. Please use '' instead of",
+                               "None."])]
+        # Ensure the minimum number of warnings were raised.
+        assert len(war) >= len(warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present.
+        found_msgs = pysat.instruments.methods.testing.eval_dep_warnings(
+            war, warn_msgs)
+
+        for i, good in enumerate(found_msgs):
+            assert good, "didn't find warning about: {:}".format(warn_msgs[i])


### PR DESCRIPTION
# Description

Addresses #892

If `tag` or `inst_id` are specified as None, allow these to pass through as an empty string.

EDIT: These were removed prematurely from develop.  verified that this functionality is still present in v3.0.1:
https://github.com/pysat/pysat/blob/4d12a09ea585b88d54560413e03cae9289113718/pysat/_instrument.py#L221-L223

This pull restores the functionality but adds a DeprecationWarning and appropriate tests.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
test = pysat.Instrument('pysat', 'testing', tag=None)
test = pysat.Instrument('pysat', 'testing', inst_id=None)
```
Both should instantiate successfully.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
