### PR TITLE
BUG: warn users when instantiated via `inst_module` AND `platform`/`name`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Extended testing options for `pysat.utils.testing` functions
    * Added `start_time` keyword for test instruments
    * Added `_test_download_ci` as a standard attribute for `pysat.Instrument`
-   * Added a testing model similar to TIEGCM to 
+   * Added a testing model similar to TIEGCM to
      `pysat.instruments.pysat_testmodel` as tag='pressure_levels'.
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
@@ -46,6 +46,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed an issue in generating filenames for `pysat.Instrument._iter_list`
    * Allow `tag` and `inst_id` to be specified as None (#892)
    * Fixed a bug in `pysat.utils.time.create_datetime_index` (#906)
+   * Added a warning if `inst_module` and `platform`/`name` are used to
+     instantiate an instrument (#850). In case of this, `inst_module` takes
+     priority.
 * Maintenance
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -273,6 +273,15 @@ class Instrument(object):
                 raise ValueError(' '.join(('Inputs platform and name must both',
                                            'be strings, or both None.')))
         else:
+            # Check if user supplied platform or name
+            if isinstance(platform, str) or isinstance(name, str):
+                warnings.warn(" ".join(("inst_module supplied along with",
+                                        "platform/name. Defaulting to",
+                                        "inst_module specification.",
+                                        "platform =", self.inst_module.platform,
+                                        ", name =", self.inst_module.name)),
+                              stacklevel=2)
+
             # User has provided a module, assign platform and name here
             for iattr in ['platform', 'name']:
                 if hasattr(self.inst_module, iattr):

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -10,6 +10,7 @@ import datetime as dt
 from importlib import reload
 import logging
 import numpy as np
+import warnings
 
 import pandas as pds
 import pytest
@@ -632,3 +633,29 @@ class InstPropertyTests(object):
         estr = 'Unknown Variable'
         assert str(err).find(estr) >= 0
         return
+
+    @pytest.mark.parametrize("kwargs", [{'platform': 'doctor'},
+                                        {'name': 'who'},
+                                        {'platform': 'doctor', 'name': 'who'}])
+    def test_warn_inst_module_platform_name(self, kwargs):
+        """Test that warning is raised if multiple specifications provided.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Additional specifications provided that should raise a warning.
+
+        """
+
+        with warnings.catch_warnings(record=True) as war:
+            tinst = pysat.Instrument(inst_module=self.testInst.inst_module,
+                                     **kwargs)
+
+        default_str = ' '.join(["inst_module supplied along with",
+                                "platform/name. Defaulting to"])
+        assert len(war) >= 1
+        assert war[0].category == UserWarning
+        assert default_str in str(war[0].message)
+
+        # Make sure isntrument loaded as inst_module
+        assert tinst.inst_module == self.testInst.inst_module


### PR DESCRIPTION
# Description

Addresses #850

If a user supplies both `inst_module` and `platform`/`name`, `pysat` will default to `inst_module` during instantiation.  This pull maintains that behaviour, but adds a warning so the user knows what is happening.  Warning is through if `platform` or `name` supplied just in case.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
import pysatNASA
inst = pysat.Instrument('cnofs', 'ivm', inst_module=pysatNASA.instruments.cnofs_vefi, tag='dc_b')
```
Look for warning message.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
