### PR TITLE
BUG: instantiating instrument via `eval(repr(pysat.Instrument()))`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added a warning if `inst_module` and `platform`/`name` are used to
      instantiate an instrument (#850). In case of this, `inst_module` takes
      priority.
+   * Fixed a bug when instantiating empty `pysat.Instrument()` (#851)
 * Maintenance
    * Added missing unit tests for `pysat.utils.time`
    * Added missing unit tests for `pysat.utils.file.parse_delimited_filename`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -262,8 +262,12 @@ class Instrument(object):
                 self.platform = platform.lower()
                 self.name = name.lower()
 
-                # Look to module for instrument functions and defaults
-                self._assign_attrs(by_name=True)
+                if len(self.platform) > 0:
+                    # Look to module for instrument functions and defaults
+                    self._assign_attrs(by_name=True)
+                else:
+                    # Assign defaults since string is empty
+                    self._assign_attrs()
             elif (platform is None) and (name is None):
                 # Creating "empty" Instrument object with this path
                 self.name = ''

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -256,6 +256,32 @@ class TestBasicsShiftedFileDates(TestBasics):
         return
 
 
+class TestBasicsEmpty(object):
+    """Unit tests for empty instrument objects."""
+
+    def setup(self):
+        """Set up the unit test environment for each method."""
+
+        self.testInst = pysat.Instrument()
+        return
+
+    def teardown(self):
+        """Clean up the unit test environment after each method."""
+
+        del self.testInst
+        return
+
+    def test_empty_repr_eval(self):
+        """Test that repr functions on empty `Instrument`."""
+
+        self.out = eval(repr(self.testInst))
+        assert isinstance(self.out, pysat.Instrument)
+        assert self.out.platform == ''
+        assert self.out.name == ''
+        assert self.out.inst_module is None
+        return
+
+
 class TestDeprecation(object):
     """Unit test for deprecation warnings."""
 


### PR DESCRIPTION
# Description

Addresses #851

After instantiating an empty `pysat.Instrument()`, `platform` and `name` are reset from `None` to `''`.  This creates a fault when instantiating again via methods such as `eval(repr)`.  This checks for empty strings in addition to `None` so that `_assign_attrs` is always called correctly.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
inst = pysat.Instrument()
new_inst = eval(repr(inst))
```

The two instruments should be identical.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11
* 🐈 

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
