### PR TITLE
TST: add the ability to pass kwargs through standard load tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added `_test_download_ci` as a standard attribute for `pysat.Instrument`
    * Added a testing model similar to TIEGCM to
      `pysat.instruments.pysat_testmodel` as tag='pressure_levels'.
+   * Added the capability to test loading with optional kwargs through
+     `_test_load_opt`
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added a testing model similar to TIEGCM to
      `pysat.instruments.pysat_testmodel` as tag='pressure_levels'.
    * Added the capability to test loading with optional kwargs through
-     `_test_load_opt`
+     `_test_load_opt` instrument attribute
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for

--- a/docs/dependency.rst
+++ b/docs/dependency.rst
@@ -164,9 +164,18 @@ the options as a dict of kwargs with the name `_test_load_opt`:
 
 The structure of the dict should be similar to the `_test_dates` construction.
 See :ref:`rst_test-temp` for more information on structuring test attributes
-for custom instrument libraries. Note that this test only verifies that the 
-instrument can be loaded with that option.  To test for specific outcomes, see
-the following section.
+for custom instrument libraries. For multiple options, a list of dicts should
+be used.
+
+.. code:: python
+
+   _test_dates = {'': {'Level_1': dt.datetime(2020, 1, 1),
+                       'Level_2': dt.datetime(2020, 1, 1)}}
+   _test_load_opt = {'': {'Level_1': [{'myoption': True},
+                                      {'myoption': False, 'num_samples': 30}]}}
+
+Note that this test only verifies that the instrument can be loaded with that
+option.  To test for specific outcomes, see the following section.
 
 
 .. _pysat-dep-addtests:

--- a/docs/dependency.rst
+++ b/docs/dependency.rst
@@ -147,6 +147,28 @@ test methods use temporary directories to store downloaded files to avoid
 breaking a user's directory structure.
 
 
+.. _pysat-dep-options:
+
+Adding custom kwargs to load tests
+----------------------------------
+
+If an instrument in a custom library has a custom kwarg, this can be added as
+part of the standard load tests.  When writing the instrument module, simply add
+the options as a dict of kwargs with the name `_test_load_opt`:
+
+.. code:: python
+
+   _test_dates = {'': {'Level_1': dt.datetime(2020, 1, 1),
+                       'Level_2': dt.datetime(2020, 1, 1)}}
+   _test_load_opt = {'': {'Level_1': {'myoption': True}}}
+
+The structure of the dict should be similar to the `_test_dates` construction.
+See :ref:`rst_test-temp` for more information on structuring test attributes
+for custom instrument libraries. Note that this test only verifies that the 
+instrument can be loaded with that option.  To test for specific outcomes, see
+the following section.
+
+
 .. _pysat-dep-addtests:
 
 Adding custom tests in pysat

--- a/docs/dependency.rst
+++ b/docs/dependency.rst
@@ -213,14 +213,20 @@ routine, make sure to use the optional output for the custom instrument lists:
   instruments = InstLibTests.initialize_test_package(
     InstLibTests, inst_loc=customLibrary.instruments)
 
-The instruments in the custom library will be grouped into three lists:
+The instruments in the custom library will be grouped into four lists:
 
 * instruments['names']: A list of all module names to check for
   standardization
 * instruments['download']: A list of dicts containing info to initialize
-  instruments for end-to-end testing
+  instruments for end-to-end testing.  Used to access instruments on remote
+  servers.
+* instruments['load_options']: A list of dicts containing info to initialize
+  instruments for end-to-end testing.  Includes all items in
+  instruments['download'] along with alternate instruments with optional
+  kwarg inputs. Used to load data products that have already been downloaded.
 * instruments['no_download']: A list of dicts containing info to initialize
-  instruments without download support for specialized local tests
+  instruments without download support for specialized local tests.  Used for
+  limited testing since remote data access is not available.
 
 Then, the new test may be created under the ``TestInstruments`` class as before.
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -29,7 +29,7 @@ tags = {'': 'Regular testing data set',
 inst_ids = {'': [tag for tag in tags.keys()]}
 _test_dates = {'': {tag: dt.datetime(2009, 1, 1) for tag in tags.keys()}}
 _test_download = {'': {'no_download': False}}
-
+_test_load_opt = {'': {'': {'num_samples': 13}}}
 
 # Init method
 init = mm_test.init

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -36,11 +36,12 @@ def initialize_test_inst_and_date(inst_dict):
 
     """
 
+    kwargs = {} if 'kwargs' not in inst_dict.keys() else inst_dict['kwargs']
     test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
                                  tag=inst_dict['tag'],
                                  inst_id=inst_dict['inst_id'],
                                  temporary_file_list=True,
-                                 update_files=True)
+                                 update_files=True, **kwargs)
     test_dates = inst_dict['inst_module']._test_dates
     date = test_dates[inst_dict['inst_id']][inst_dict['tag']]
     return test_inst, date
@@ -144,6 +145,10 @@ class InstLibTests(object):
                 elif 'download' in mark_names:
                     mark = pytest.mark.parametrize("inst_dict",
                                                    instruments['download'])
+                    getattr(self, method).pytestmark.append(mark)
+                elif 'load_options' in mark_names:
+                    mark = pytest.mark.parametrize("inst_dict",
+                                                   instruments['load_options'])
                     getattr(self, method).pytestmark.append(mark)
                 elif 'no_download' in mark_names:
                     mark = pytest.mark.parametrize("inst_dict",
@@ -299,7 +304,7 @@ class InstLibTests(object):
         return
 
     @pytest.mark.second
-    @pytest.mark.download
+    @pytest.mark.load_options
     @pytest.mark.parametrize("clean_level", ['none', 'dirty', 'dusty', 'clean'])
     def test_load(self, clean_level, inst_dict):
         """Test that instruments load at each cleaning level.

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -36,7 +36,7 @@ def initialize_test_inst_and_date(inst_dict):
 
     """
 
-    kwargs = {} if 'kwargs' not in inst_dict.keys() else inst_dict['kwargs']
+    kwargs = inst_dict['kwargs'] if 'kwargs' in inst_dict.keys() else {}
     test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
                                  tag=inst_dict['tag'],
                                  inst_id=inst_dict['inst_id'],

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -545,6 +545,7 @@ def generate_instrument_list(inst_loc, user_info=None):
 
     instrument_names = inst_loc.__all__
     instrument_download = []
+    instrument_optional_load = []
     instrument_no_download = []
 
     # Look through list of available instrument modules in the given location
@@ -588,14 +589,28 @@ def generate_instrument_list(inst_loc, user_info=None):
                                and not inst._test_download_ci)
                     if inst._test_download and not ci_skip:
                         instrument_download.append(inst_dict)
+                        if hasattr(module, '_test_load_opt'):
+                            # Add optional load tests
+                            try:
+                                kwarg_list = module._test_load_opt[inst_id][tag]
+                                kwarg_list = pysat.utils.listify(kwarg_list)
+                                for kwargs in kwarg_list:
+                                    inst_dict['kwargs'] = kwargs
+                                    instrument_optional_load.append(inst_dict)
+                            except KeyError:
+                                # Option does not exist for tag/inst_id combo
+                                pass
+
                     elif not inst._password_req:
                         # We don't want to test download for this combo, but
                         # we do want to test the download warnings for
                         # instruments without a password requirement
                         instrument_no_download.append(inst_dict)
 
+    # load options requires all downloaded instruments plus additional options
     output = {'names': instrument_names,
               'download': instrument_download,
+              'load_options': instrument_download + instrument_optional_load,
               'no_download': instrument_no_download}
 
     return output

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,6 @@ markers =
     all_inst: tests all instruments
     download: tests for downloadable instruments
     no_download: tests for instruments without download support
-    load_options: tests for instruments with optional load kwargs
+    load_options: tests for instruments including optional load kwargs
     first: first tests to run
     second: second tests to run

--- a/setup.cfg
+++ b/setup.cfg
@@ -69,5 +69,6 @@ markers =
     all_inst: tests all instruments
     download: tests for downloadable instruments
     no_download: tests for instruments without download support
+    load_options: tests for instruments with optional load kwargs
     first: first tests to run
     second: second tests to run


### PR DESCRIPTION
# Description

Addresses #583

Modifies the instrument identification so that instruments may pass through a series of optional kwargs for `test_load`. The optional kwargs may be passed through as a dict or list of dicts describing each configuration.  Note that this only verifies that the data can be successfully loaded under this configuration, custom tests are required for testing specific outcomes.

Backwards-compatible with develop.  A new pytest mark is added (load_options).  Note that if this is unregistered in setup.cfg of downstream packages, the tests will still run and a warning will be generated asking the user to register the new mark.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Testing with local tests of pysat/pysatNASA#91. 

```
pytest -vs pysat/tests/test_instruments.py 
```

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
