### PR TITLE
Meta reorg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Update minimum numpy in CI tests to 1.18 following NEP29
    * Made `InstTestClass` more portable to streamline user implementation of the
      standard end-to-end instrument tests.
+   * Separated MetaLabels tests from Meta test class
+   * Organized and reduced duplication in the Meta test class
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1269,11 +1269,11 @@ class Meta(object):
                         # Use naming convention: new_name = 'pysat_attr_' + key
                         inst.__setattr__(key, adict[key])
                     else:
-                        rerr = ''.join(('Attribute ', key, 'attached to the '
-                                        'Meta object can not be transferred ',
-                                        'as it already exists in the ',
-                                        'Instrument object.'))
-                        raise RuntimeError(rerr)
+                        aerr = ''.join(('Attribute ', key.__repr__(),
+                                        ' attached to the Meta object cannot be'
+                                        ' transferred as it already exists in ',
+                                        'the Instrument object.'))
+                        raise AttributeError(aerr)
         return
 
     def add_epoch_metadata(self, epoch_name):

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -541,14 +541,17 @@ class Meta(object):
                     new_name = match_name(self.attr_case_name, key[1],
                                           self.data.columns)
                     return self.data.loc[new_index, new_name]
-                except KeyError:
-                    # This may instead be a child variable
+                except KeyError as kerr:
+                    # This may instead be a child variable, check for children
+                    if self[new_index].children is None:
+                        raise kerr
+
                     try:
                         new_child_index = match_name(
                             self.attr_case_name, key[1],
                             self[new_index].children.data.index)
                         return self.ho_data[new_index].data.loc[new_child_index]
-                    except AttributeError:
+                    except AttributeError as aerr:
                         raise NotImplementedError(
                             ''.join(['Cannot retrieve child meta data ',
                                      'from multiple parents']))

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -3,6 +3,7 @@
 # Full author list can be found in .zenodo.json file
 # DOI:10.5281/zenodo.1199703
 # ----------------------------------------------------------------------------
+"""Classes for storing and managing meta data."""
 
 from copy import deepcopy
 import numpy as np
@@ -75,42 +76,45 @@ class Meta(object):
     --------
     ::
 
-        # instantiate Meta object, default values for attribute labels are used
+        # Instantiate Meta object, default values for attribute labels are used
         meta = pysat.Meta()
-        # set a couple base units
-        # note that other base parameters not set below will
-        # be assigned a default value
-        meta['name'] = {'long_name': string, 'units': string}
-        # update 'units' to new value
-        meta['name'] = {'units': string}
-        # update 'long_name' to new value
-        meta['name'] = {'long_name': string}
-        # attach new info with partial information, 'long_name' set to 'name2'
-        meta['name2'] = {'units': string}
-        # units are set to '' by default
-        meta['name3'] = {'long_name': string}
 
-        # assigning custom meta parameters
-        meta['name4'] = {'units': string, 'long_name': string
-                         'custom1': string, 'custom2': value}
-        meta['name5'] = {'custom1': string, 'custom3': value}
+        # Set several variable units. Note that other base parameters are not
+        # set below, and so will be assigned a default value
+        meta['var_name'] = {meta.labels.name: 'Variable Name',
+                            meta.labels.units: 'MegaUnits'}
 
-        # assign multiple variables at once
-        meta[['name1', 'name2']] = {'long_name': [string1, string2],
-                                    'units': [string1, string2],
-                                    'custom10': [string1, string2]}
+        # Update only 'units' to new value.  You can use the value of
+        # `meta.labels.units` instead of the class attribute, as was done in
+        # the above example.
+        meta['var_name'] = {'units': 'MU'}
 
-        # assiging metadata for n-Dimensional variables
+        # Custom meta data variables may be assigned using the same method.
+        # This example uses non-standard meta data variables 'scale', 'PI',
+        # and 'axis_multiplier'.  You can include or not include any of the
+        # standard meta data information.
+        meta['var_name'] = {'units': 'MU', 'long_name': 'Variable Name',
+                            'scale': 'linear', 'axis_multiplier': 1e4}
+        meta['var_name'] = {'PI': 'Dr. R. Song'}
+
+        # Meta data may be assigned to multiple variables at once
+        meta[['var_name1', 'var_name2']] = {'long_name': ['Name1', 'Name2'],
+                                            'units': ['Units1', 'Units2'],
+                                            'scale': ['linear', 'linear']}
+
+        # Sometimes n-Dimensional (nD) variables require multi-dimensional
+        # meta data structures.
         meta2 = pysat.Meta()
-        meta2['name41'] = {'long_name': string, 'units': string}
-        meta2['name42'] = {'long_name': string, 'units': string}
-        meta['name4'] = {'meta': meta2}
+        meta2['var_name41'] = {'long_name': 'name1of4', 'units': 'Units1'}
+        meta2['var_name42'] = {'long_name': 'name2of4', 'units': 'Units2'}
+        meta['var_name4'] = {'meta': meta2}
 
-        # or
-        meta['name4'] = meta2
-        meta['name4'].children['name41']
+        # An alternative method to acheive the same result is:
+        meta['var_name4'] = meta2
+        meta['var_name4'].children['name41']
+        meta['var_name4'].children['name42']
 
-        # mixture of 1D and higher dimensional data
+        # You may, of course, have a mixture of 1D and nD data
         meta = pysat.Meta()
         meta['dm'] = {'units': 'hey', 'long_name': 'boo'}
         meta['rpa'] = {'units': 'crazy', 'long_name': 'boo_whoo'}
@@ -119,17 +123,21 @@ class Meta(object):
                                       'units': [None, 'boo'],
                                       'long_name': [None, 'boohoo']}
 
-        # assign from another Meta object
+        # Meta data may be assigned from another Meta object using dict-like
+        # assignments
+        key1 = 'var_name'
+        key2 = 'var_name4'
         meta[key1] = meta2[key2]
 
-        # access fill info for a variable, presuming default label
-        meta[key1, 'fill']
+        # When accessing one meta data value for any data variable, first use
+        # the data variable and then the meta data label.
+        meta['var_name', 'fill']
 
-        # access same info, even if 'fill' not used to label fill values
-        meta[key1, meta.fill_label]
+        # A more robust method is to use the available Meta variable attributes
+        # in the attached MetaLabels class object.
+        meta[key1, meta.labels.fill_val]
 
-
-        # change a label used by Meta object
+        # You may change a label used by Meta object to have a different value
         meta.labels.fill_val = '_FillValue'
 
         # Note that the fill label is intended for use when interacting

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -543,7 +543,8 @@ class Meta(object):
                     return self.data.loc[new_index, new_name]
                 except KeyError as kerr:
                     # This may instead be a child variable, check for children
-                    if self[new_index].children is None:
+                    if(hasattr(self[new_index], 'children')
+                       and self[new_index].children is None):
                         raise kerr
 
                     try:

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1138,6 +1138,11 @@ class Meta(object):
         mdata : Meta
             Concatenated object
 
+        Raises
+        ------
+        KeyError
+            If there are duplicate keys and the `strict` flag is True.
+
         Note
         ----
         Uses units and name label of self if other_meta is different
@@ -1150,14 +1155,8 @@ class Meta(object):
         if strict:
             for key in other_meta.keys():
                 if key in mdata:
-                    raise RuntimeError(''.join(('Duplicated keys (variable ',
-                                                'names) across Meta ',
-                                                'objects in keys().')))
-            for key in other_meta.keys_nD():
-                if key in mdata:
-                    raise RuntimeError(''.join(('Duplicated keys (variable ',
-                                                'names) across Meta '
-                                                'objects in keys_nD().')))
+                    raise KeyError(''.join(('Duplicated keys (variable names) ',
+                                            'in Meta.keys().')))
 
         # Make sure labels between the two objects are the same
         other_meta_updated = other_meta.copy()

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1217,6 +1217,11 @@ class Meta(object):
             If True, produces an error if the Instrument object already
             has an attribute with the same name to be copied (default=False).
 
+        Raises
+        ------
+        ValueError
+            If `inst` type is not pysat.Instrument.
+
         Note
         ----
         pysat's load_netCDF and similar routines are only able to attach
@@ -1227,6 +1232,12 @@ class Meta(object):
         Will not transfer names that conflict with pysat default attributes.
 
         """
+
+        # Test the instrument parameter for type
+        if not isinstance(inst, pysat.Instrument):
+            raise ValueError("".join(["Can't transfer Meta attributes to ",
+                                      "non-Instrument object of type ",
+                                      str(type(inst))]))
 
         # Save the base Instrument attributes
         banned = inst._base_attr

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -185,9 +185,9 @@ class Meta(object):
                 # Make sure defaults are taken care of for required metadata
                 self.accept_default_labels(self)
             else:
-                raise ValueError(''.join(('Input must be a pandas DataFrame',
-                                          'type. See other constructors for',
-                                          ' alternate inputs.')))
+                raise ValueError(''.join(('Input must be a pandas DataFrame ',
+                                          'type. See other constructors for ',
+                                          'alternate inputs.')))
         else:
             columns = [getattr(self.labels, mlab)
                        for mlab in self.labels.label_type.keys()]
@@ -1524,7 +1524,7 @@ class MetaLabels(object):
                                         use_names_default=True)
 
     def __repr__(self):
-        """Print MetaData instantiation parameters.
+        """Print MetaLabels instantiation parameters.
 
         Returns
         -------
@@ -1539,7 +1539,7 @@ class MetaLabels(object):
         return out_str
 
     def __str__(self):
-        """Print Meta instance, variables, and attributes.
+        """Print MetaLabels instance, variables, and attributes.
 
         Returns
         -------

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -536,9 +536,22 @@ class Meta(object):
                 # If tuple length is 2, index, column
                 new_index = match_name(self.var_case_name, key[0],
                                        self.data.index)
-                new_name = match_name(self.attr_case_name, key[1],
-                                      self.data.columns)
-                return self.data.loc[new_index, new_name]
+                try:
+                    # Assume this is a label name
+                    new_name = match_name(self.attr_case_name, key[1],
+                                          self.data.columns)
+                    return self.data.loc[new_index, new_name]
+                except KeyError:
+                    # This may instead be a child variable
+                    try:
+                        new_child_index = match_name(
+                            self.attr_case_name, key[1],
+                            self[new_index].children.data.index)
+                        return self.ho_data[new_index].data.loc[new_child_index]
+                    except AttributeError:
+                        raise NotImplementedError(
+                            ''.join(['Cannot retrieve child meta data ',
+                                     'from multiple parents']))
 
             elif len(key) == 3:
                 # If tuple length is 3, index, child_index, column

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1648,10 +1648,11 @@ class TestMeta(object):
         self.meta[self.dval] = cmeta
 
         # Test the meta method using different input variations
-        assert self.meta.hasattr_case_neutral(label.upper())
-        assert self.meta.hasattr_case_neutral(label.lower())
-        assert self.meta.hasattr_case_neutral(label.capitalize())
-        assert self.meta.hasattr_case_neutral(label)
+        assert self.meta[self.dval].children.hasattr_case_neutral(label.upper())
+        assert self.meta[self.dval].children.hasattr_case_neutral(label.lower())
+        assert self.meta[self.dval].children.hasattr_case_neutral(
+            label.capitalize())
+        assert self.meta[self.dval].children.hasattr_case_neutral(label)
         return
 
 
@@ -1667,8 +1668,8 @@ class TestMetaImmutable(TestMeta):
 
         self.meta_labels = {'units': ('Units', str),
                             'name': ('Long_Name', str),
-                            'desc': ('Description', str),
-                            'notes': ('Note', str),
+                            'desc': ('Desc', str),
+                            'notes': ('Notes', str),
                             'min_val': ('Minimum', np.float64),
                             'max_val': ('Maximum', np.float64),
                             'fill_val': ('Fill_Value', np.float64)}

--- a/pysat/tests/test_meta_labels.py
+++ b/pysat/tests/test_meta_labels.py
@@ -6,36 +6,27 @@
 """Tests the pysat MetaLabels object."""
 
 import logging
+import numpy as np
 import pytest
 
 import pysat
 
 
 class TestMetaLabels(object):
-    """Basic unit tests for the MetaLabels class."""
+    """Unit and integration tests for the MetaLabels class."""
 
-    
     def setup(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument('pysat', 'testing')
-        self.stime = pysat.instruments.pysat_testing._test_dates['']['']
-        self.meta_labels = self.testInst.meta.labels
+        testInst = pysat.Instrument('pysat', 'testing')
+        self.meta_labels = testInst.meta.labels
+        self.meta = pysat.Meta()
 
-        self.label_dict = {'units': ('Units', str),
-                           'name': ('Long_Name', str)}
-        self.dval = None
-        self.default_name = ['long_name']
-        self.default_nan = ['fill', 'value_min', 'value_max']
-        self.default_val = {'notes': '', 'units': '', 'desc': ''}
-        self.frame_list = ['dummy_frame1', 'dummy_frame2']
         return
 
     def teardown(self):
         """Clean up the unit test environment after each method."""
-        del self.testInst, self.meta, self.stime, self.meta_labels
-        del self.default_name, self.default_nan, self.default_val, self.dval
-        del self.frame_list
+        del self.meta, self.meta_labels
         return
 
     # -----------------------

--- a/pysat/tests/test_meta_labels.py
+++ b/pysat/tests/test_meta_labels.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python
+# Full license can be found in License.md
+# Full author list can be found in .zenodo.json file
+# DOI:10.5281/zenodo.1199703
+# ----------------------------------------------------------------------------
+"""Tests the pysat MetaLabels object."""
+
+import logging
+import pytest
+
+import pysat
+
+
+class TestMetaLabels(object):
+    """Basic unit tests for the MetaLabels class."""
+
+    
+    def setup(self):
+        """Set up the unit test environment for each method."""
+
+        self.testInst = pysat.Instrument('pysat', 'testing')
+        self.stime = pysat.instruments.pysat_testing._test_dates['']['']
+        self.meta_labels = self.testInst.meta.labels
+
+        self.label_dict = {'units': ('Units', str),
+                           'name': ('Long_Name', str)}
+        self.dval = None
+        self.default_name = ['long_name']
+        self.default_nan = ['fill', 'value_min', 'value_max']
+        self.default_val = {'notes': '', 'units': '', 'desc': ''}
+        self.frame_list = ['dummy_frame1', 'dummy_frame2']
+        return
+
+    def teardown(self):
+        """Clean up the unit test environment after each method."""
+        del self.testInst, self.meta, self.stime, self.meta_labels
+        del self.default_name, self.default_nan, self.default_val, self.dval
+        del self.frame_list
+        return
+
+    # -----------------------
+    # Test the Error messages
+
+    def test_default_label_value_raises_error(self):
+        """Test `MetaLabels.default_values_from_attr` errors with bad attr."""
+
+        with pytest.raises(ValueError) as verr:
+            self.meta_labels.default_values_from_attr('not_an_attr')
+
+        assert verr.match("unknown label attribute")
+        return
+
+    # -------------------------
+    # Test the logging messages
+
+    @pytest.mark.parametrize("in_val", [1., 1, {}, None, []])
+    def test_default_value_from_type_unexpected_input(self, in_val, caplog):
+        """Test `MetaLabels.default_values_from_type` with unexpected input."""
+
+        with caplog.at_level(logging.INFO, logger='pysat'):
+            self.meta_labels.default_values_from_type(in_val)
+
+            # Test for expected string
+            captured = caplog.text
+            test_str = 'No type match found for '
+            assert captured.find(test_str) >= 0
+
+        return
+
+    # ---------------------------
+    # Test the class magic methods
+
+    def test_repr(self):
+        """Test the `MetaLabels.__repr__` method."""
+
+        out = self.meta_labels.__repr__()
+        assert isinstance(out, str)
+        assert out.find('pysat.MetaLabels(') >= 0
+        return
+
+    # -----------------------------
+    # Test the class public methods
+
+    @pytest.mark.parametrize("in_val",
+                             [float, np.float16, np.float32, np.float64])
+    def test_default_value_from_type_float_inputs(self, in_val):
+        """Test `MetaLabels.default_values_from_type` with float inputs."""
+
+        out = self.meta.labels.default_values_from_type(in_val)
+        assert np.isnan(out)
+
+        return
+
+    @pytest.mark.parametrize("in_val, comp_val",
+                             [(int, -1), (np.int8, -1), (np.int16, -1),
+                              (np.int32, -1), (np.int64, -1), (str, '')])
+    def test_default_value_from_type_int_inputs(self, in_val, comp_val):
+        """Test `MetaLabels.default_values_from_type` with int inputs."""
+
+        out = self.meta.labels.default_values_from_type(in_val)
+        assert out == comp_val
+
+        return

--- a/pysat/tests/test_meta_labels.py
+++ b/pysat/tests/test_meta_labels.py
@@ -101,3 +101,47 @@ class TestMetaLabels(object):
         assert out == comp_val
 
         return
+
+    # ----------------------------------------
+    # Test the integration with the Meta class
+
+    def test_change_case_of_meta_labels(self):
+        """Test changing case of meta labels after initialization."""
+
+        self.meta_labels = {'units': ('units', str), 'name': ('long_name', str)}
+        self.meta = pysat.Meta(labels=self.meta_labels)
+        self.meta['new'] = {'units': 'hey', 'long_name': 'boo'}
+        self.meta['new2'] = {'units': 'hey2', 'long_name': 'boo2'}
+        self.meta.labels.units = 'Units'
+        self.meta.labels.name = 'Long_Name'
+        assert (self.meta['new'].Units == 'hey')
+        assert (self.meta['new'].Long_Name == 'boo')
+        assert (self.meta['new2'].Units == 'hey2')
+        assert (self.meta['new2'].Long_Name == 'boo2')
+        return
+
+    def test_case_change_of_meta_labels_w_ho(self):
+        """Test change case of meta labels after initialization with HO data."""
+
+        # Set the initial labels
+        self.meta_labels = {'units': ('units', str), 'name': ('long_Name', str)}
+        self.meta = pysat.Meta(labels=self.meta_labels)
+        meta2 = pysat.Meta(labels=self.meta_labels)
+
+        # Set meta data values
+        meta2['new21'] = {'units': 'hey2', 'long_name': 'boo2'}
+        self.meta['new'] = {'units': 'hey', 'long_name': 'boo'}
+        self.meta['new2'] = meta2
+
+        # Change the label name
+        self.meta.labels.units = 'Units'
+        self.meta.labels.name = 'Long_Name'
+
+        # Evaluate the results in the main data
+        assert (self.meta['new'].Units == 'hey')
+        assert (self.meta['new'].Long_Name == 'boo')
+
+        # Evaluate the results in the higher order data
+        assert (self.meta['new2'].children['new21'].Units == 'hey2')
+        assert (self.meta['new2'].children['new21'].Long_Name == 'boo2')
+        return


### PR DESCRIPTION
# Description

Reorganizes, reduces duplication, and fixes errors in the Meta test class by:
- Improving HO data slicing (addresses #911),
- Separating mutable-only tests into their own class,
- Moving immutable-only tests into the immutable class,
- Separating MetaLabels tests into their own class,
- Combining similar tests using parametrize,
- Identifying tests that may be able to be deleted, and
- Adding unit tests for missing areas.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Ran existing and new unit/integration tests locally.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
