### PR TITLE
ENH: kwargs for epoch options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added a warning evaluation utility to `pysat.utils.testing`.
    * Added the ability to only download new files if remote file listing
      capabilities are not available for the Instrument.
+   * Added kwargs for epoch units and origin in `pysat.utils.io.load_netCDF`.
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -216,7 +216,18 @@ class TestLoadNetCDF(object):
         ({'epoch_unit': 'ns', 'epoch_origin': dt.datetime(1980, 1, 6)},
          dt.timedelta(microseconds=1))])
     def test_read_netcdf4_w_epoch_kwargs(self, kwargs, target):
-        """Test success of writing and reading a netCDF4 file."""
+        """Test success of writing and reading a netCDF4 file.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Optional kwargs to input into `load_netcdf`. Allows the epoch
+            calculation to use custom origin and units.
+        target : dt.timedelta
+            Expected interpretation of 1 sec of time in loaded data when a given
+            epoch unit is specified.  Default unit for pds.to_datetime is 1 ms.
+
+        """
 
         # TODO(#947) Expand to xarray objects
         if not self.testInst.pandas_format:
@@ -249,7 +260,7 @@ class TestLoadNetCDF(object):
         # Find distance from origin
         default_uts = (self.testInst.index[0] - unix_origin).total_seconds()
         loaded_uts = (self.loaded_inst.index[0] - file_origin).total_seconds()
-        # Ratio of distances should equal ratio of step sizes
+        # Ratio of distances should equal ratio of interpreted units
         assert (default_uts / loaded_uts) == (dt.timedelta(seconds=1) / target)
         return
 

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -233,8 +233,11 @@ class TestLoadNetCDF(object):
         self.loaded_inst, meta = io.load_netcdf(outfile, **kwargs)
 
         # Check that the step size is expected
-        delta_time = (self.loaded_inst.index[1] - self.loaded_inst.index[0])
-        assert delta_time == target
+        default_delta = (self.testInst.index[1] - self.testInst.index[0])
+        loaded_delta = (self.loaded_inst.index[1] - self.loaded_inst.index[0])
+        # Ratio of step_sizes should equal ratio of interpreted units
+        assert ((default_delta / loaded_delta)
+                == (dt.timedelta(seconds=1) / target))
 
         unix_origin = dt.datetime(1970, 1, 1)
         if 'epoch_origin' in kwargs.keys():

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -694,7 +694,7 @@ class TestXarrayIO(object):
                 else:
                     assert label not in export_nan, "did not attach {:}".format(
                         repr(label))
-                    
+
                     try:
                         dval = meta.labels.default_values_from_type(type(mval))
                         assert mval == dval

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -229,9 +229,9 @@ class TestLoadNetCDF(object):
 
         """
 
-        # TODO(#947) Expand to xarray objects
+        # TODO(#947) Expand to xarray objects once functionality is updated
         if not self.testInst.pandas_format:
-            pytest.skip('Not yet implemented for xrray')
+            pytest.skip('Not yet implemented for xarray')
 
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.testInst.files.data_path,

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -218,6 +218,7 @@ class TestLoadNetCDF(object):
     def test_read_netcdf4_w_epoch_kwargs(self, kwargs, target):
         """Test success of writing and reading a netCDF4 file."""
 
+        # TODO(#947) Expand to xarray objects
         if not self.testInst.pandas_format:
             pytest.skip('Not yet implemented for xrray')
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -207,7 +207,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        The unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
         (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
@@ -217,8 +217,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
         If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
         Julian Calendar. Julian day number 0 is assigned to the day starting at
-        noon on January 1, 4713 BC.
-        (default='unix')
+        noon on January 1, 4713 BC. (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
         xarray Dataset (False). (default=False)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -207,8 +207,8 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
-        (default='ms')
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us',
+        'ns'). (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
         `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -202,7 +202,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         (default='NETCDF4')
     epoch_name : str
         Data key for epoch variable.  The epoch variable is expected to be an
-        array of interger or float values denoting time elapsed from an origin
+        array of integer or float values denoting time elapsed from an origin
         specified by `epoch_origin` with units specified by `epoch_unit`. This
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
@@ -215,9 +215,9 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         two specific strings for commonly used calendars.  These conversions are
         handled by `pandas.to_datetime`.
         If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
-        If ‘julian’, unit must be ‘D’, and origin is set to beginning of Julian
-        Calendar. Julian day number 0 is assigned to the day starting at noon on
-        January 1, 4713 BC.
+        If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
+        Julian Calendar. Julian day number 0 is assigned to the day starting at
+        noon on January 1, 4713 BC.
         (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -198,12 +198,24 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         'NETCDF3_CLASSIC', 'NETCDF3_64BIT', 'NETCDF4_CLASSIC', or 'NETCDF4'.
         (default='NETCDF4')
     epoch_name : str
-        Data key for time variable (default='Epoch')
+        Data key for epoch variable.  The epoch variable is expected to be an
+        array of interger or float values denoting time elapsed from an origin
+        specified by `epoch_origin` with units specified by `epoch_unit`. This
+        epoch variable will be converted to a `DatetimeIndex` for consistency
+        across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        Units of epoch data to convert to datetime (default='ms')
+        The unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
+        (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
-        `pandas.to_datetime`.  (default='unix')
+        `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as
+        two specific strings for commonly used calendars.  These conversions are
+        handled by `pandas.to_datetime`.
+        If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
+        If ‘julian’, unit must be ‘D’, and origin is set to beginning of Julian
+        Calendar. Julian day number 0 is assigned to the day starting at noon on
+        January 1, 4713 BC.
+        (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
         xarray Dataset (False). (default=False)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -152,7 +152,8 @@ def listify(iterable):
 
 
 def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
-                 epoch_name='Epoch', pandas_format=True, decode_timedelta=False,
+                 epoch_name='Epoch', epoch_unit='ms', epoch_origin='unix',
+                 pandas_format=True, decode_timedelta=False,
                  labels={'units': ('units', str), 'name': ('long_name', str),
                          'notes': ('notes', str), 'desc': ('desc', str),
                          'min_val': ('value_min', np.float64),
@@ -178,6 +179,11 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
         (default='NETCDF4')
     epoch_name : str
         Data key for time variable (default='Epoch')
+    epoch_unit : str
+        Units of epoch data to convert to datetime (default='ms')
+    epoch_origin : str or timestamp-convertable
+        Origin of epoch calculation, following convention for
+        `pandas.to_datetime`.  (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
         xarray Dataset (False). (default=False)
@@ -228,6 +234,8 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
     data, meta = pysat.utils.io.load_netcdf(fnames, strict_meta=strict_meta,
                                             file_format=file_format,
                                             epoch_name=epoch_name,
+                                            epoch_unit=epoch_unit,
+                                            epoch_origin=epoch_origin,
                                             pandas_format=pandas_format,
                                             decode_timedelta=decode_timedelta,
                                             labels=labels)

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -301,12 +301,24 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         'NETCDF3_CLASSIC', 'NETCDF3_64BIT', 'NETCDF4_CLASSIC', or 'NETCDF4'.
         (default='NETCDF4')
     epoch_name : str
-        Data key for time variable (default='Epoch')
+        Data key for epoch variable.  The epoch variable is expected to be an
+        array of interger or float values denoting time elapsed from an origin
+        specified by `epoch_origin` with units specified by `epoch_unit`. This
+        epoch variable will be converted to a `DatetimeIndex` for consistency
+        across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        Units of epoch data to convert to datetime (default='ms')
+        The unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
+        (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
-        `pandas.to_datetime`.  (default='unix')
+        `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as
+        two specific strings for commonly used calendars.  These conversions are
+        handled by `pandas.to_datetime`.
+        If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
+        If ‘julian’, unit must be ‘D’, and origin is set to beginning of Julian
+        Calendar. Julian day number 0 is assigned to the day starting at noon on
+        January 1, 4713 BC.
+        (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
         xarray Dataset (False). (default=False)
@@ -339,7 +351,7 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
 
     See Also
     --------
-    load_netcdf_pandas, load_netcdf_xarray
+    load_netcdf_pandas, load_netcdf_xarray, pandas.to_datetime
 
     """
     # Load data by type
@@ -384,12 +396,24 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
         'NETCDF3_CLASSIC', 'NETCDF3_64BIT', 'NETCDF4_CLASSIC', or 'NETCDF4'.
         (default='NETCDF4')
     epoch_name : str
-        Data key for time variable (default='Epoch')
+        Data key for epoch variable.  The epoch variable is expected to be an
+        array of interger or float values denoting time elapsed from an origin
+        specified by `epoch_origin` with units specified by `epoch_unit`. This
+        epoch variable will be converted to a `DatetimeIndex` for consistency
+        across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        Units of epoch data to convert to datetime (default='ms')
+        The unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
+        (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
-        `pandas.to_datetime`.  (default='unix')
+        `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as
+        two specific strings for commonly used calendars.  These conversions are
+        handled by `pandas.to_datetime`.
+        If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
+        If ‘julian’, unit must be ‘D’, and origin is set to beginning of Julian
+        Calendar. Julian day number 0 is assigned to the day starting at noon on
+        January 1, 4713 BC.
+        (default='unix')
     labels : dict
         Dict where keys are the label attribute names and the values are tuples
         that have the label values and value types in that order.

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -307,8 +307,8 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
-        (default='ms')
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us',
+        'ns'). (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
         `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as
@@ -401,8 +401,8 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
-        (default='ms')
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us',
+        'ns'). (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
         `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as
@@ -707,8 +707,9 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
                                  combine='by_coords')
 
-    # TODO(#947) Add conversion for timestamps that may have been treated incorrectly,
-    # including origin and unit.  At the moment this is only done for Pandas data.
+    # TODO(#947) Add conversion for timestamps that may have been treated
+    # incorrectly, including origin and unit.  At the moment this is only done
+    # for Pandas data.
 
     # Copy the variable attributes from the data object to the metadata
     for key in data.variables.keys():

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -302,7 +302,7 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         (default='NETCDF4')
     epoch_name : str
         Data key for epoch variable.  The epoch variable is expected to be an
-        array of interger or float values denoting time elapsed from an origin
+        array of integer or float values denoting time elapsed from an origin
         specified by `epoch_origin` with units specified by `epoch_unit`. This
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
@@ -315,9 +315,9 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         two specific strings for commonly used calendars.  These conversions are
         handled by `pandas.to_datetime`.
         If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
-        If ‘julian’, unit must be ‘D’, and origin is set to beginning of Julian
-        Calendar. Julian day number 0 is assigned to the day starting at noon on
-        January 1, 4713 BC.
+        If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
+        Julian Calendar. Julian day number 0 is assigned to the day starting at
+        noon on January 1, 4713 BC.
         (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
@@ -397,7 +397,7 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
         (default='NETCDF4')
     epoch_name : str
         Data key for epoch variable.  The epoch variable is expected to be an
-        array of interger or float values denoting time elapsed from an origin
+        array of integer or float values denoting time elapsed from an origin
         specified by `epoch_origin` with units specified by `epoch_unit`. This
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
@@ -410,9 +410,9 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
         two specific strings for commonly used calendars.  These conversions are
         handled by `pandas.to_datetime`.
         If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
-        If ‘julian’, unit must be ‘D’, and origin is set to beginning of Julian
-        Calendar. Julian day number 0 is assigned to the day starting at noon on
-        January 1, 4713 BC.
+        If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
+        Julian Calendar. Julian day number 0 is assigned to the day starting at
+        noon on January 1, 4713 BC.
         (default='unix')
     labels : dict
         Dict where keys are the label attribute names and the values are tuples

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -307,7 +307,7 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        The unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
         (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
@@ -317,8 +317,7 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
         If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
         Julian Calendar. Julian day number 0 is assigned to the day starting at
-        noon on January 1, 4713 BC.
-        (default='unix')
+        noon on January 1, 4713 BC. (default='unix')
     pandas_format : bool
         Flag specifying if data is stored in a pandas DataFrame (True) or
         xarray Dataset (False). (default=False)
@@ -402,7 +401,7 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
         epoch variable will be converted to a `DatetimeIndex` for consistency
         across pysat instruments.  (default='Epoch')
     epoch_unit : str
-        The unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us', 'ns').
         (default='ms')
     epoch_origin : str or timestamp-convertable
         Origin of epoch calculation, following convention for
@@ -412,8 +411,7 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
         If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
         If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
         Julian Calendar. Julian day number 0 is assigned to the day starting at
-        noon on January 1, 4713 BC.
-        (default='unix')
+        noon on January 1, 4713 BC. (default='unix')
     labels : dict
         Dict where keys are the label attribute names and the values are tuples
         that have the label values and value types in that order.
@@ -709,7 +707,8 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
                                  combine='by_coords')
 
-    # TODO(#947) Add conversion for timestamps, including origin and unit
+    # TODO(#947) Add conversion for timestamps that may have been treated incorrectly,
+    # including origin and unit.  At the moment this is only done for Pandas data.
 
     # Copy the variable attributes from the data object to the metadata
     for key in data.variables.keys():

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -685,6 +685,8 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
                                  combine='by_coords')
 
+    # TODO(#947) Add conversion for timestamps, including origin and unit
+
     # Copy the variable attributes from the data object to the metadata
     for key in data.variables.keys():
         meta_dict = {}


### PR DESCRIPTION
# Description

Addresses #944.  

Adds `epoch_unit` and `epoch_origin` to both `load_netCDF` functions.  Both kwargs follow the standards for `unit` and `origin` (respectively) as defined by `pandas.to_datetime`.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test by loading a `cosmic2_ivm` instrument from pysat/pysatCDAAC#32, which uses a different origin (Jan 6, 1980) and units (s) than the defaults (Jan 1, 1970; ms).  The index of the instrument should match the date loaded.

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11
* pysat/pysatCDAAC#32

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
