### PR TITLE
Updated Instrument rename method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added the ability to only download new files if remote file listing
      capabilities are not available for the Instrument.
    * Added a time function to calculate decimal year from datetime.
+   * Allow `Instrument.rename` to take a fuction or mapping dict as input,
+     after adapting routine to use `Meta.rename`
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -605,8 +605,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Further along the road toward windows compatibility
 * Fixed orbit number reporting in orbits.current
 * Added support for Defense Meteorological Satellite Program (DMSP) Ion Velocity
-  Meter (IVM) data. Downloads from the Madrigal database
-  (https://openmadrigal.org)
+  Meter (IVM) data. Downloads from the Madrigal database.
 * Added support for both sat_id and tag variations within filenames in the NASA
   CDAWeb template
 * Updated docummentation covering requirements for adding new instruments to

--- a/docs/instruments/pysatMadrigal.rst
+++ b/docs/instruments/pysatMadrigal.rst
@@ -5,4 +5,4 @@ pysatMadrigal
 
 `pysatMadrigal <https://github.com/pysat/pysatMadrigal>`_ provides pysat
 support for data available at the
-`Madrigal database. <http://cedar.openmadrigal.org/>`_ See the `Supported Instruments <https://pysatmadrigal.readthedocs.io/en/latest/supported_instruments.html>`_ page for more information.
+`Madrigal database. <http://cedar.openmadrigal.org/index.html>`_ See the `Supported Instruments <https://pysatmadrigal.readthedocs.io/en/latest/supported_instruments.html>`_ page for more information.

--- a/docs/tutorial/tutorial_basics.rst
+++ b/docs/tutorial/tutorial_basics.rst
@@ -183,7 +183,7 @@ and :py:data:`name` keywords.
 
 You can also specify the specific keyword arguements needed for the standard
 pysat methods.  DMSP data is hosted by the `Madrigal database
-<http://cedar.openmadrigal.org/openmadrigal/>`_, a community resource for
+<http://cedar.openmadrigal.org/index.html>`_, a community resource for
 geospace data. The proper process for downloading DMSP and other Madrigal data
 is built into the open source tool
 `madrigalWeb <http://cedar.openmadrigal.org/docs/name/rr_python.html>`_,

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2424,7 +2424,7 @@ class Instrument(object):
 
             # Case is retained within inst.meta, though data access to meta is
             # case insensitive
-            print('True meta variable name is ', inst.meta['pysat_uts'].)
+            print('True meta variable name is ', inst.meta['pysat_uts'].name)
 
             # Note that the labels in meta may be used when creating a file.
             # Thus, 'Pysat_UTS' would be found in the resulting file

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2353,47 +2353,40 @@ class Instrument(object):
 
         return
 
-    def rename(self, var_names, lowercase_data_labels=False):
-        """Rename variable within both data and metadata.
+    def rename(self, mapper, lowercase_data_labels=False):
+        """Rename variables within both data and metadata.
 
         Parameters
         ----------
-        var_names : dict or map-like
-            Existing var_names are keys, values are new var_names
+        mapper : dict or func
+            Dictionary with old names as keys and new names as variables or
+            a function to apply to all names
         lowercase_data_labels : bool
             If True, the labels applied to inst.data are forced to lowercase.
-            The supplied case in var_names is retained within inst.meta.
+            The case supplied in `mapper` is retained within inst.meta.
 
         Examples
         --------
         ::
 
-            # standard renaming
-            new_var_names = {'old_name': 'new_name',
-                         'old_name2':, 'new_name2'}
-            inst.rename(new_var_names)
+            # Standard renaming
+            new_mapper = {'old_name': 'new_name', 'old_name2':, 'new_name2'}
+            inst.rename(new_mapper)
 
 
-        If using a pandas DataFrame as the underlying data object,
-        to rename higher-order variables supply a modified dictionary.
-        Note that this rename will be invoked individually for all
-        times in the dataset.
+        If using a pandas-type Instrument with higher-order data and a
+        dictionary mapper, the upper-level data key must contain a dictionary
+        for renaming the dependent data variables.  The upper-level data key
+        cannot be renamed. Note that this rename will be invoked individually
+        for all times in the dataset.
         ::
 
-            # applies to higher-order datasets
-            # that are loaded into pandas
-            # general example
-            new_var_names = {'old_name': 'new_name',
-                             'old_name2':, 'new_name2',
-                             'col_name': {'old_ho_name': 'new_ho_name'}}
-            inst.rename(new_var_names)
-
-            # specific example
+            # Applies to higher-order datasets that are loaded into pandas
             inst = pysat.Instrument('pysat', 'testing2D')
             inst.load(2009, 1)
-            var_names = {'uts': 'pysat_uts',
-                     'profiles': {'density': 'pysat_density'}}
-            inst.rename(var_names)
+            mapper = {'uts': 'pysat_uts',
+                      'profiles': {'density': 'pysat_density'}}
+            inst.rename(mapper)
 
 
         pysat supports differing case for variable labels across the
@@ -2405,123 +2398,147 @@ class Instrument(object):
         when writing files.
         ::
 
-            # example with lowercase_data_labels
+            # Example with lowercase_data_labels
             inst = pysat.Instrument('pysat', 'testing2D')
             inst.load(2009, 1)
-            var_names = {'uts': 'Pysat_UTS',
+            mapper = {'uts': 'Pysat_UTS',
                      'profiles': {'density': 'PYSAT_density'}}
-            inst.rename(var_names, lowercase_data_labels=True)
+            inst.rename(mapper, lowercase_data_labels=True)
 
-            # note that 'Pysat_UTS' was applied to data as 'pysat_uts'
+            # Note that 'Pysat_UTS' was applied to data as 'pysat_uts'
             print(inst['pysat_uts'])
 
-            # case is retained within inst.meta, though
-            # data access to meta is case insensitive
+            # Case is retained within inst.meta, though data access to meta is
+            # case insensitive
             print('True meta variable name is ', inst.meta['pysat_uts'].name)
 
-            # Note that the labels in meta may be used when creating a file
-            # thus 'Pysat_UTS' would be found in the resulting file
+            # Note that the labels in meta may be used when creating a file.
+            # Thus, 'Pysat_UTS' would be found in the resulting file
             inst.to_netcdf4('./test.nc', preserve_meta_case=True)
 
-            # load in file and check
+            # Load in file and check
             raw = netCDF4.Dataset('./test.nc')
             print(raw.variables['Pysat_UTS'])
 
-
         """
 
+        # Mirror xarray/pandas behaviour and raise a ValueError if mapper is
+        # a dict an an unknown variable name is provided.
+        if isinstance(mapper, dict):
+            for vkey in mapper.keys():
+                if vkey not in self.variables:
+                    raise ValueError(''.join(['cannot rename ', repr(vkey),
+                                              ' because it is not a variable ',
+                                              'in this Instrument']))
+
+        # Initalize the metadata mapping dict, which is only needed because
+        # of the potential higher-order input dictionaries
+        mdict = {}
+
         if self.pandas_format:
-            # Check for standard rename variables as well as
-            # renaming for higher order variables
-            fdict = {}  # filtered old variable names
-            hdict = {}  # higher order variable names
+            # Initialize dict for renaming normal pandas data
+            pdict = {}
 
-            # keys for existing higher order data labels
-            ho_keys = [a for a in self.meta.keys_nD()]
-            lo_keys = [a for a in self.meta.keys()]
+            # Collect normal variables and rename higher order variables
+            for vkey in self.variables:
+                map_key = utils.get_mapped_value(vkey, mapper)
 
-            # iterate, collect normal variables
-            # rename higher order variables
-            for vkey in var_names:
-                # original name, new name
-                oname, nname = vkey, var_names[vkey]
-                if oname not in ho_keys:
-                    if oname in lo_keys:
-                        # within low order (standard) variable name keys
-                        # may be renamed directly
-                        fdict[oname] = nname
-                    else:
-                        # not in standard or higher order variable name keys
-                        estr = ' '.join(('cannot rename', oname, 'because it',
-                                         'is not a variable in this dataset.'))
-                        raise ValueError(estr)
-                else:
-                    # Variable name is in higher order list
-                    if isinstance(nname, dict):
-                        # Changing a variable name within a higher order object
-                        label = [k for k in nname.keys()][0]
-                        hdict[label] = nname[label]
-                        # ensure variable is there
-                        if label not in self.meta[oname]['children']:
-                            estr = ' '.join(('cannot rename', label, 'because,'
-                                             'it is not a known',
-                                             'higher-order variable under',
-                                             oname, '.'))
-                            raise ValueError(estr)
+                if map_key is not None:
+                    # Treat higher-order pandas and normal pandas separately
+                    if vkey in self.meta.keys_nD():
+                        # Variable name is in higher order list
+                        hdict = {}
+                        if isinstance(map_key, dict):
+                            # Changing a variable name within a higher order
+                            # object using a dictionary. First ensure the
+                            # variable exist
+                            for hkey in map_key.keys():
+                                if hkey not in self.meta[
+                                        vkey]['children'].keys():
+                                    estr = ' '.join(
+                                        ('cannot rename', repr(hkey),
+                                         'because it is not a known ',
+                                         'higher-order variable under',
+                                         repr(vkey), '.'))
+                                    raise ValueError(estr)
+                            hdict = map_key
+                        else:
+                            # This is either a value or a mapping function
+                            for hkey in self.meta[vkey]['children'].keys():
+                                hmap = utils.get_mapped_value(hkey, mapper)
+                                if hmap is not None:
+                                    hdict[hkey] = hmap
+
                         # Check for lowercase flag
+                        change = True
                         if lowercase_data_labels:
-                            gdict = {}
-                            gdict[label] = nname[label].lower()
+                            gdict = {hkey: hdict[hkey].lower()
+                                     for hkey in hdict.keys()
+                                     if hkey != hdict[hkey].lower()}
+
+                            if len(list(gdict.keys())) == 0:
+                                change = False
                         else:
                             gdict = hdict
-                        # Change variables for frame at each time
-                        for i in np.arange(len(self.index)):
-                            # within data itself
-                            self[i, oname].rename(columns=gdict,
-                                                  inplace=True)
 
-                        # Change metadata, once per variable only hdict used as
-                        # it retains user provided case
-                        self.meta.ho_data[oname].data.rename(hdict,
+                        # Update the meta dict
+                        mdict[vkey] = hdict
+
+                        # Change the higher-order variable names frame-by-frame
+                        if change:
+                            for i in np.arange(len(self.index)):
+                                if isinstance(self[i, vkey], pds.Series):
+                                    if self[i, vkey].name in gdict:
+                                        new_name = gdict[self[i, vkey].name]
+                                        self[i, vkey].rename(new_name,
                                                              inplace=True)
-                        # Clear out dict for next loop
-                        hdict.pop(label)
-                    else:
-                        # Changing the outer 'column' label
-                        fdict[oname] = nname
+                                    else:
+                                        tkey = list(gdict.keys())[0]
+                                        if self[i, vkey].name != gdict[tkey]:
+                                            estr = ' '.join(
+                                                ('cannot rename', hkey,
+                                                 'because, it is not a known'
+                                                 'known higher-order ',
+                                                 'variable under', vkey, 'at',
+                                                 'index {:d}.'.format(i)))
+                                            raise ValueError(estr)
+                                else:
+                                    self[i, vkey].rename(columns=gdict,
+                                                         inplace=True)
 
-            # Rename regular variables, single go check for lower case data
-            # labels first
-            if lowercase_data_labels:
-                gdict = {}
-                for fkey in fdict:
-                    gdict[fkey] = fdict[fkey].lower()
-            else:
-                gdict = fdict
+                    else:
+                        # This is a normal variable. Add it to the pandas
+                        # renaming dictionary after accounting for the
+                        # `lowercase_data_labels` flag
+                        if lowercase_data_labels:
+                            if vkey != map_key.lower():
+                                pdict[vkey] = map_key.lower()
+                        else:
+                            pdict[vkey] = map_key
+
+                        # Update the meta dict
+                        mdict[vkey] = map_key
 
             # Change variable names for attached data object
-            self.data.rename(columns=gdict, inplace=True)
-
+            self.data.rename(columns=pdict, inplace=True)
         else:
-            # xarray renaming: account for lowercase data labels first
-            if lowercase_data_labels:
-                gdict = {}
-                for vkey in var_names:
-                    gdict[vkey] = var_names[vkey].lower()
-            else:
-                gdict = var_names
+            # Adjust mapper to account for lowercase data labels in Instrument
+            # data, but not the metadata. Xarray requires dict input for rename.
+            gdict = {}
+            for vkey in self.variables:
+                map_key = utils.get_mapped_value(vkey, mapper)
+                if map_key is not None:
+                    if lowercase_data_labels:
+                        gdict[vkey] = map_key.lower()
+                    else:
+                        gdict[vkey] = map_key
+                    mdict[vkey] = map_key
+
+            # Rename data variables using native xarray rename method
             self.data = self.data.rename(gdict)
 
-            # Set up dictionary for renaming metadata variables
-            fdict = var_names
-
-        # Update normal metadata parameters in a single go.  The case must
-        # always be preserved in Meta object
-        new_fdict = {}
-        for fkey in fdict:
-            case_old = self.meta.var_case_name(fkey)
-            new_fdict[case_old] = fdict[fkey]
-        self.meta.data.rename(index=new_fdict, inplace=True)
+        # Update the metadata, which does not usse `lowercase_data_labels` flag
+        self.meta.rename(mdict)
 
         return
 

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1095,6 +1095,11 @@ class Meta(object):
             Dictionary with old names as keys and new names as variables or
             a function to apply to all names
 
+        Raises
+        ------
+        ValueError
+            When normal data is treated like higher-order data in dict mapping.
+
         Note
         ----
         Checks first within standard attributes. If not found there, checks

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1118,7 +1118,7 @@ class Meta(object):
                     else:
                         raise ValueError('unknown mapped value at {:}'.format(
                             repr(var)))
-                else:  
+                else:
                     # Get and update the meta data
                     hold_meta = self[var].copy()
                     hold_meta.name = map_var

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -316,7 +316,7 @@ class TestMeta(object):
 
         assert str(verr).find("unknown mapped value at 'mlt'") >= 0
         return
-    
+
     # -------------------------
     # Test the Warning messages
 

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -302,6 +302,21 @@ class TestMeta(object):
         assert str(verr.value).find(err_msg) >= 0
         return
 
+    def test_meta_rename_bad_ho_input(self):
+        """Test raises ValueError when treating normal data like HO data."""
+
+        # Initialize the meta data
+        self.set_meta(inst_kwargs={'platform': 'pysat', 'name': 'testing2d'})
+
+        # Set a bad mapping dictionary
+        mapper = {'mlt': {'mlt_profile': 'mlt_density_is_not_real'}}
+
+        with pytest.raises(ValueError) as verr:
+            self.meta.rename(mapper)
+
+        assert str(verr).find("unknown mapped value at 'mlt'") >= 0
+        return
+    
     # -------------------------
     # Test the Warning messages
 

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -206,7 +206,7 @@ class TestListify(object):
         tst_iterable = [np.nan
                         for i in range(int(np.product(np.shape(iterable))))]
         utils.testing.assert_lists_equal(new_iterable, tst_iterable,
-                                               test_nan=True)
+                                         test_nan=True)
         return
 
     @pytest.mark.parametrize('iterable', [1, np.full((1, 1), 1),
@@ -469,7 +469,7 @@ class TestGenerateInstList(object):
         self.user_info = {'pysat_testmodel': {'user': 'GideonNav',
                                               'password': 'pasSWORD!'}}
         self.inst_list = utils.generate_instrument_list(
-            inst_loc = pysat.instruments, user_info=self.user_info)
+            inst_loc=pysat.instruments, user_info=self.user_info)
         return
 
     def teardown(self):
@@ -586,7 +586,3 @@ class TestMappedValue(object):
             assert val.upper() == utils.get_mapped_value(val, str.upper)
 
         return
-
-        
-
-        

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -18,8 +18,7 @@ import warnings
 
 import pysat
 from pysat.tests.classes.cls_registration import TestWithRegistration
-from pysat.utils import generate_instrument_list
-from pysat.utils import testing
+from pysat import utils
 
 
 class TestCIonly(object):
@@ -129,7 +128,7 @@ class TestScaleUnits(object):
     def test_scale_units_same(self):
         """Test scale_units when both units are the same."""
 
-        self.scale = pysat.utils.scale_units("happy", "happy")
+        self.scale = utils.scale_units("happy", "happy")
 
         assert self.scale == 1.0
         return
@@ -137,7 +136,7 @@ class TestScaleUnits(object):
     def test_scale_units_angles(self):
         """Test scale_units for angles."""
         for out_unit in self.deg_units:
-            self.scale = pysat.utils.scale_units(out_unit, "deg")
+            self.scale = utils.scale_units(out_unit, "deg")
             self.eval_unit_scale(out_unit, 'angles')
         return
 
@@ -145,7 +144,7 @@ class TestScaleUnits(object):
         """Test scale_units for distances."""
 
         for out_unit in self.dist_units:
-            self.scale = pysat.utils.scale_units(out_unit, "m")
+            self.scale = utils.scale_units(out_unit, "m")
             self.eval_unit_scale(out_unit, 'distance')
         return
 
@@ -153,7 +152,7 @@ class TestScaleUnits(object):
         """Test scale_units for velocities."""
 
         for out_unit in self.vel_units:
-            self.scale = pysat.utils.scale_units(out_unit, "m/s")
+            self.scale = utils.scale_units(out_unit, "m/s")
             self.eval_unit_scale(out_unit, 'velocity')
         return
 
@@ -165,7 +164,7 @@ class TestScaleUnits(object):
         """Test raises ValueError for bad input combinations."""
 
         with pytest.raises(ValueError) as verr:
-            pysat.utils.scale_units(*in_args)
+            utils.scale_units(*in_args)
 
         assert str(verr).find(err_msg) > 0
         return
@@ -177,7 +176,7 @@ class TestScaleUnits(object):
         """Test raises ValueError for all mismatched input pairings."""
 
         with pytest.raises(ValueError):
-            pysat.utils.scale_units(unit1, unit2)
+            utils.scale_units(unit1, unit2)
 
         return
 
@@ -192,9 +191,9 @@ class TestListify(object):
     def test_listify_list_string_inputs(self, iterable, nitem):
         """Test listify with various list levels of a string."""
 
-        new_iterable = pysat.utils.listify(iterable)
+        new_iterable = utils.listify(iterable)
         tst_iterable = ['test' for i in range(nitem)]
-        pysat.utils.testing.assert_lists_equal(new_iterable, tst_iterable)
+        utils.testing.assert_lists_equal(new_iterable, tst_iterable)
         return
 
     @pytest.mark.parametrize('iterable', [np.nan, np.full((1, 1), np.nan),
@@ -203,10 +202,10 @@ class TestListify(object):
     def test_listify_nan_arrays(self, iterable):
         """Test listify with various np.arrays of NaNs."""
 
-        new_iterable = pysat.utils.listify(iterable)
+        new_iterable = utils.listify(iterable)
         tst_iterable = [np.nan
                         for i in range(int(np.product(np.shape(iterable))))]
-        pysat.utils.testing.assert_lists_equal(new_iterable, tst_iterable,
+        utils.testing.assert_lists_equal(new_iterable, tst_iterable,
                                                test_nan=True)
         return
 
@@ -216,9 +215,9 @@ class TestListify(object):
     def test_listify_int_arrays(self, iterable):
         """Test listify with various np.arrays of integers."""
 
-        new_iterable = pysat.utils.listify(iterable)
+        new_iterable = utils.listify(iterable)
         tst_iterable = [1 for i in range(int(np.product(np.shape(iterable))))]
-        pysat.utils.testing.assert_lists_equal(new_iterable, tst_iterable)
+        utils.testing.assert_lists_equal(new_iterable, tst_iterable)
         return
 
     @pytest.mark.parametrize('iterable', [
@@ -228,10 +227,10 @@ class TestListify(object):
     def test_listify_class_arrays(self, iterable):
         """Test listify with various np.arrays of classes."""
 
-        new_iterable = pysat.utils.listify(iterable)
+        new_iterable = utils.listify(iterable)
         tst_iterable = [np.timedelta64(1)
                         for i in range(int(np.product(np.shape(iterable))))]
-        pysat.utils.testing.assert_lists_equal(new_iterable, tst_iterable)
+        utils.testing.assert_lists_equal(new_iterable, tst_iterable)
         return
 
 
@@ -288,8 +287,8 @@ class TestFmtCols(object):
     def test_neg_ncols(self):
         """Test the output if the column number is negative."""
         self.in_kwargs['ncols'] = -5
-        self.out_str = pysat.utils._core.fmt_output_in_cols(self.in_str,
-                                                            **self.in_kwargs)
+        self.out_str = utils._core.fmt_output_in_cols(self.in_str,
+                                                      **self.in_kwargs)
         assert len(self.out_str) == 0
         return
 
@@ -300,7 +299,7 @@ class TestFmtCols(object):
         """Test raises appropriate Errors for bad input values."""
         self.in_kwargs[key] = val
         with pytest.raises(raise_type):
-            pysat.utils._core.fmt_output_in_cols(self.in_str, **self.in_kwargs)
+            utils._core.fmt_output_in_cols(self.in_str, **self.in_kwargs)
         return
 
     @pytest.mark.parametrize("ncol", [(3), (5), (10)])
@@ -314,8 +313,8 @@ class TestFmtCols(object):
         self.nrows = int(np.ceil(self.in_kwargs['max_num'] / ncol))
 
         # Get and test the output
-        self.out_str = pysat.utils._core.fmt_output_in_cols(self.in_str,
-                                                            **self.in_kwargs)
+        self.out_str = utils._core.fmt_output_in_cols(self.in_str,
+                                                      **self.in_kwargs)
         self.eval_output()
         return
 
@@ -332,8 +331,8 @@ class TestFmtCols(object):
         self.nrows = nrow
 
         # Get and test the output
-        self.out_str = pysat.utils._core.fmt_output_in_cols(self.in_str,
-                                                            **self.in_kwargs)
+        self.out_str = utils._core.fmt_output_in_cols(self.in_str,
+                                                      **self.in_kwargs)
         self.eval_output()
         return
 
@@ -349,8 +348,8 @@ class TestFmtCols(object):
         self.lpad = in_pad
 
         # Get and test the output
-        self.out_str = pysat.utils._core.fmt_output_in_cols(self.in_str,
-                                                            **self.in_kwargs)
+        self.out_str = utils._core.fmt_output_in_cols(self.in_str,
+                                                      **self.in_kwargs)
         self.eval_output()
         return
 
@@ -366,9 +365,9 @@ class TestAvailableInst(TestWithRegistration):
         """Test display_available_instruments options."""
         # If using the pysat registry, make sure there is something registered
         if inst_loc is None:
-            pysat.utils.registry.register(self.module_names)
+            utils.registry.register(self.module_names)
 
-        pysat.utils.display_available_instruments(
+        utils.display_available_instruments(
             inst_loc, show_inst_mod=inst_flag, show_platform_name=plat_flag)
 
         captured = capsys.readouterr()
@@ -390,7 +389,7 @@ class TestAvailableInst(TestWithRegistration):
     def test_display_instrument_stats(self, inst_loc, capsys):
         """Test display_instrument_stats options."""
 
-        pysat.utils.display_instrument_stats(inst_loc)
+        utils.display_instrument_stats(inst_loc)
 
         captured = capsys.readouterr()
         # Numbers should match supported data products in `pysat.instruments`
@@ -402,7 +401,7 @@ class TestAvailableInst(TestWithRegistration):
     def test_import_error_in_available_instruments(self):
         """Test handling of import errors in available_instruments."""
 
-        idict = pysat.utils.available_instruments(os.path)
+        idict = utils.available_instruments(os.path)
 
         for platform in idict.keys():
             for name in idict[platform].keys():
@@ -436,9 +435,9 @@ class TestNetworkLock(object):
         """Test network locking with a timeout."""
         # Open the file two times
         with pytest.raises(portalocker.AlreadyLocked):
-            with pysat.utils.NetworkLock(self.fname, timeout=0.1):
-                with pysat.utils.NetworkLock(self.fname, mode='wb', timeout=0.1,
-                                             fail_when_locked=True):
+            with utils.NetworkLock(self.fname, timeout=0.1):
+                with utils.NetworkLock(self.fname, mode='wb', timeout=0.1,
+                                       fail_when_locked=True):
                     pass
         return
 
@@ -446,9 +445,8 @@ class TestNetworkLock(object):
         """Test network locking without a timeout."""
         # Open the file two times
         with pytest.raises(portalocker.LockException):
-            with pysat.utils.NetworkLock(self.fname, timeout=None):
-                with pysat.utils.NetworkLock(self.fname, timeout=None,
-                                             mode='w'):
+            with utils.NetworkLock(self.fname, timeout=None):
+                with utils.NetworkLock(self.fname, timeout=None, mode='w'):
                     pass
         return
 
@@ -456,8 +454,8 @@ class TestNetworkLock(object):
         """Test network locking without file conditions set."""
         # Open the file two times
         with pytest.raises(portalocker.LockException):
-            with pysat.utils.NetworkLock(self.fname, timeout=0.1):
-                lock = pysat.utils.NetworkLock(self.fname, timeout=0.1)
+            with utils.NetworkLock(self.fname, timeout=0.1):
+                lock = utils.NetworkLock(self.fname, timeout=0.1)
                 lock.acquire(check_interval=0.05, fail_when_locked=False)
         return
 
@@ -470,8 +468,8 @@ class TestGenerateInstList(object):
 
         self.user_info = {'pysat_testmodel': {'user': 'GideonNav',
                                               'password': 'pasSWORD!'}}
-        self.inst_list = generate_instrument_list(inst_loc=pysat.instruments,
-                                                  user_info=self.user_info)
+        self.inst_list = utils.generate_instrument_list(
+            inst_loc = pysat.instruments, user_info=self.user_info)
         return
 
     def teardown(self):
@@ -483,8 +481,8 @@ class TestGenerateInstList(object):
     def test_generate_module_names(self):
         """Test generation of module names."""
 
-        pysat.utils.testing.assert_lists_equal(self.inst_list['names'],
-                                               pysat.instruments.__all__)
+        utils.testing.assert_lists_equal(self.inst_list['names'],
+                                         pysat.instruments.__all__)
 
     @pytest.mark.parametrize("list_name", [('download'), ('no_download')])
     def test_generate_module_list_attributes(self, list_name):
@@ -535,7 +533,7 @@ class TestDeprecation(object):
         with warnings.catch_warnings(record=True) as war:
             try:
                 # Generate relocation warning and file_format warning
-                pysat.utils.load_netcdf4(**kwargs)
+                utils.load_netcdf4(**kwargs)
             except (FileNotFoundError, ValueError):
                 pass
 
@@ -554,5 +552,41 @@ class TestDeprecation(object):
         assert len(war) >= len(warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
-        testing.eval_warnings(war, warn_msgs)
+        utils.testing.eval_warnings(war, warn_msgs)
         return
+
+
+class TestMappedValue(object):
+    """Unit tests for utility `get_mapped_value`."""
+
+    def setup(self):
+        """Set up a clean testing environment."""
+        self.data_vals = ['one', 'two', 'three', 'four']
+        return
+
+    def teardown(self):
+        """Clean up the current testing enviornment."""
+        del self.data_vals
+        return
+
+    def test_get_mapped_value_dict(self):
+        """Test successful mapping from dict input."""
+
+        map_dict = {val: val.upper() for val in self.data_vals}
+
+        for val in self.data_vals:
+            assert val.upper() == utils.get_mapped_value(val, map_dict)
+
+        return
+
+    def test_get_mapped_value_func(self):
+        """Test successful mapping from an input function."""
+
+        for val in self.data_vals:
+            assert val.upper() == utils.get_mapped_value(val, str.upper)
+
+        return
+
+        
+
+        

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -11,6 +11,7 @@ from pysat.utils._core import display_available_instruments
 from pysat.utils._core import display_instrument_stats
 from pysat.utils._core import generate_instrument_list
 from pysat.utils._core import listify
+from pysat.utils._core import get_mapped_value
 from pysat.utils._core import load_netcdf4
 from pysat.utils._core import NetworkLock
 from pysat.utils._core import scale_units

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -9,9 +9,9 @@ for the pysat data directory structure.
 from pysat.utils._core import available_instruments
 from pysat.utils._core import display_available_instruments
 from pysat.utils._core import display_instrument_stats
+from pysat.utils._core import get_mapped_value
 from pysat.utils._core import generate_instrument_list
 from pysat.utils._core import listify
-from pysat.utils._core import get_mapped_value
 from pysat.utils._core import load_netcdf4
 from pysat.utils._core import NetworkLock
 from pysat.utils._core import scale_units

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -9,8 +9,8 @@ for the pysat data directory structure.
 from pysat.utils._core import available_instruments
 from pysat.utils._core import display_available_instruments
 from pysat.utils._core import display_instrument_stats
-from pysat.utils._core import get_mapped_value
 from pysat.utils._core import generate_instrument_list
+from pysat.utils._core import get_mapped_value
 from pysat.utils._core import listify
 from pysat.utils._core import load_netcdf4
 from pysat.utils._core import NetworkLock

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -235,6 +235,35 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
     return data, meta
 
 
+def get_mapped_value(value, mapper):
+    """Adjust value using mapping dict or function.
+
+    Parameters
+    ----------
+    value : str
+        MetaData variable name to be adjusted
+    mapper : dict or function
+        Dictionary with old names as keys and new names as variables or
+        a function to apply to all names
+
+    Returns
+    -------
+    mapped_val : str or NoneType
+        Adjusted MetaData variable name or NoneType if input value
+        should stay the same
+
+    """
+    if isinstance(mapper, dict):
+        if value in mapper.keys():
+            mapped_val = mapper[value]
+        else:
+            mapped_val = None
+    else:
+        mapped_val = mapper(value)
+
+    return mapped_val
+
+
 def fmt_output_in_cols(out_strs, ncols=3, max_num=6, lpad=None):
     """Format a string with desired output values in columns.
 


### PR DESCRIPTION
# Description

Addresses #900 by using Meta rename in Instrument rename.  Also updated Instrument rename to allow a function as mapping input alongside the dictionary input.  Fixed a bug in Meta rename to use the same style of dict input as Instrument (necessary for higher order data).

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Added new unit tests, running old unit tests, and added examples to the Instrument.rename docstring.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
