### PR TITLE
Added `_call_inst_method` to Constellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      of platforms, names, tags, and/or inst_ids, which are new attributes
    * Added hidden Constellation methods to determine unique attribute elements
      and set Instrument attributes across all instruments
+   * Added hidden Constellation method to sequentially call Instrument methods
    * Extended Constellation unit tests
    * Standardized Instrument instantiation to always define `inst_module`
    * Extended testing options for `pysat.utils.testing` functions

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -448,6 +448,36 @@ class Constellation(object):
 
         return
 
+    def _call_inst_method(self, method, *args, **kwargs):
+        """Call a method across all instrumennts.
+
+        Parameters
+        ----------
+        method : str
+            Instrument method name
+        *args : list-like
+            Optional list of arguments for the method
+        **kwargs : dict-like
+            Optional dict of keyword arguments for the method
+
+        Raises
+        ------
+        AttributeError
+            If `method` is missing from any Constellation Instrument.
+
+        """
+
+        for instrument in self.instruments:
+            if not hasattr(instrument, method):
+                raise AttributeError(
+                    'unknown method {:} in Instrument {:}'.format(
+                        repr(method), repr(instrument)))
+
+            inst_method = getattr(instrument, method)
+            inst_method(*args, **kwargs)
+
+        return
+
     # -----------------------------------------------------------------------
     # Define the public methods and properties
 
@@ -565,9 +595,7 @@ class Constellation(object):
 
         """
 
-        for instrument in self.instruments:
-            instrument.custom_attach(*args, **kwargs)
-
+        self._call_inst_method('custom_attach', *args, **kwargs)
         return
 
     def custom_clear(self):
@@ -579,9 +607,7 @@ class Constellation(object):
 
         """
 
-        for instrument in self.instruments:
-            instrument.custom_clear()
-
+        self._call_inst_method('custom_clear')
         return
 
     def load(self, *args, **kwargs):
@@ -601,8 +627,7 @@ class Constellation(object):
         """
 
         # Load the data for each instrument
-        for instrument in self.instruments:
-            instrument.load(*args, **kwargs)
+        self._call_inst_method('load', *args, **kwargs)
 
         # Set the year and doy attributes for the constellation and instruments
         self.yr, self.doy = pysat.utils.time.getyrdoy(self.date)
@@ -631,7 +656,5 @@ class Constellation(object):
 
         """
 
-        for instrument in self.instruments:
-            instrument.download(*args, **kwargs)
-
+        self._call_inst_method('download', *args, **kwargs)
         return

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -468,11 +468,13 @@ class Constellation(object):
         """
 
         for instrument in self.instruments:
+            # Test to see that method exists
             if not hasattr(instrument, method):
                 raise AttributeError(
                     'unknown method {:} in Instrument {:}'.format(
                         repr(method), repr(instrument)))
 
+            # Apply method to Instrument
             inst_method = getattr(instrument, method)
             inst_method(*args, **kwargs)
 

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -372,10 +372,19 @@ class TestConstellationFunc(object):
         return
 
     def test_get_unique_attr_vals_bad_type(self):
-        """Test raises AttributeError for bad input attribute type."""
+        """Test raises TypeError for bad input attribute type."""
 
         with pytest.raises(TypeError) as terr:
             self.const._get_unique_attr_vals('empty')
 
         assert str(terr).find("attribute is not list-like") >= 0
+        return
+
+    def test_bad_call_inst_method(self):
+        """Test raises AttributeError for missing Instrument method."""
+
+        with pytest.raises(AttributeError) as aerr:
+            self.const._call_inst_method('not a method')
+
+        assert str(aerr).find("unknown method") >= 0
         return


### PR DESCRIPTION
# Description

Addresses #842 and reduces duplicate code lines by adding a hidden Constellation method to iteratively call Instrument methods.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Added a unit test and called existing unit tests.


**Test Configuration**:
* Operating system: OSX Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
