### PR TITLE
Scale units bugfix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,7 +69,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed an issue in generating filenames for `pysat.Instrument._iter_list`
    * Allow `tag` and `inst_id` to be specified as None (#892)
    * Fixed a bug in `pysat.utils.time.create_datetime_index` (#906)
-   * Fixed a bug in `pysat.utils.scale_units`.
+   * Fixed a bug in `pysat.utils.scale_units` and ensured '/cc' compatibility.
    * Added a warning if `inst_module` and `platform`/`name` are used to
      instantiate an instrument (#850). In case of this, `inst_module` takes
      priority.

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -83,6 +83,7 @@ class TestScaleUnits(object):
         self.dist_units = ["m", "km", "cm"]
         self.vel_units = ["m/s", "cm/s", "km/s", 'm s$^{-1}$', 'cm s$^{-1}$',
                           'km s$^{-1}$', 'm s-1', 'cm s-1', 'km s-1']
+        self.vol_units = ["m-3", "cm-3", "/cc", 'n/cc', 'm$^{-3}$', 'cm$^{-3}$']
         self.scale = 0.0
         return
 
@@ -90,6 +91,7 @@ class TestScaleUnits(object):
         """Clean up the test environment."""
 
         del self.deg_units, self.dist_units, self.vel_units, self.scale
+        del self.vol_units
         return
 
     def eval_unit_scale(self, out_unit, scale_type):
@@ -123,6 +125,11 @@ class TestScaleUnits(object):
                 assert self.scale == 1.0
             elif out_unit.find("km") == 0:
                 assert self.scale == 0.001
+        elif scale_type.lower() == 'volume':
+            if out_unit.find("m") == 0:
+                assert self.scale == 1.0
+            else:
+                assert self.scale == 1000000.0
         return
 
     def test_scale_units_same(self):
@@ -154,6 +161,14 @@ class TestScaleUnits(object):
         for out_unit in self.vel_units:
             self.scale = utils.scale_units(out_unit, "m/s")
             self.eval_unit_scale(out_unit, 'velocity')
+        return
+
+    def test_scale_units_vol(self):
+        """Test scale_units for volumes."""
+
+        for out_unit in self.vol_units:
+            self.scale = utils.scale_units(out_unit, "m-3")
+            self.eval_unit_scale(out_unit, 'volume')
         return
 
     @pytest.mark.parametrize("in_args,err_msg", [

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -105,21 +105,24 @@ def scale_units(out_unit, in_unit):
         if in_key != out_key:
             raise ValueError('Cannot scale {:s} and {:s}'.format(out_unit,
                                                                  in_unit))
+
         # Recast units as keys for the scales dictionary and ensure that
         # the format is consistent
-        rkey = ''
+        rkeys = []
         for rr in replace_str.keys():
-            if out_key.find(rr) >= 0:
-                rkey = rr
+            if out_key.find(rr) >= 0 or rr.find(out_key) >= 0:
+                rkeys.append(rr)
 
+        # Redefine keys to find correct values for scaling
         out_key = out_unit.lower()
         in_key = in_unit.lower()
 
-        if rkey in replace_str.keys():
+        for rkey in rkeys:
             for rval in replace_str[rkey]:
                 out_key = out_key.replace(rval, rkey)
                 in_key = in_key.replace(rval, rkey)
 
+    # Calculate the scaling factor
     unit_scale = scales[out_key] / scales[in_key]
 
     return unit_scale


### PR DESCRIPTION
# Description

Fixes a bug found when trying to scale 'n/cc' or '/cc'.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added unit tests.  Also:

```
import pytest

pysat.utils.scale_units('n/cc', 'cm-3')
1.0
```

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
