### PR TITLE
Expand pysat testing kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Standardized Instrument instantiation to always define `inst_module`
    * Extended testing options for `pysat.utils.testing` functions
    * Added `start_time` keyword for test instruments
+   * Added `max_latitude` keyword for non-model test instruments
    * Added `_test_download_ci` as a standard attribute for `pysat.Instrument`
    * Added a testing model similar to TIEGCM to
      `pysat.instruments.pysat_testmodel` as tag='pressure_levels'.

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -45,7 +45,8 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, malformed_index=False,
-         start_time=None, num_samples=86400, test_load_kwarg=None):
+         start_time=None, num_samples=86400, test_load_kwarg=None,
+         max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -57,16 +58,16 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         certain instrument aspects for testing)
     inst_id : str or NoneType
         Instrument satellite ID (accepts '')
-    sim_multi_file_right : boolean
+    sim_multi_file_right : bool
         Adjusts date range to be 12 hours in the future or twelve hours beyond
         root_date (default=False)
-    sim_multi_file_left : boolean
+    sim_multi_file_left : bool
         Adjusts date range to be 12 hours in the past or twelve hours before
         root_date (default=False)
     root_date : NoneType
         Optional central date, uses _test_dates if not specified.
         (default=None)
-    malformed_index : boolean
+    malformed_index : bool
         If True, time index will be non-unique and non-monotonic (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data
@@ -77,6 +78,9 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         current day. (default=86400)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
+    max_latitude : float
+        Latitude simulated as `max_latitude` * cos(theta(t))`, where
+        theta is a linear periodic signal bounded by [0, 2 * pi) (default=90.).
 
     Returns
     -------
@@ -132,7 +136,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     angle = mm_test.generate_fake_data(time_delta.total_seconds(),
                                        uts, period=iperiod['angle'],
                                        data_range=drange['angle'])
-    data['latitude'] = 90.0 * np.cos(angle)
+    data['latitude'] = max_latitude * np.cos(angle)
 
     # Create constant altitude at 400 km
     alt0 = 400.0

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -32,7 +32,8 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         start_time=None, num_samples=864, test_load_kwarg=None):
+         start_time=None, num_samples=864, test_load_kwarg=None,
+         max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -55,6 +56,9 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         current day. (default=864)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
+    max_latitude : float
+        Latitude simulated as `max_latitude` * cos(theta(t))`, where
+        theta is a linear periodic signal bounded by [0, 2 * pi) (default=90.).
 
     Returns
     -------
@@ -102,7 +106,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     angle = mm_test.generate_fake_data(time_delta.total_seconds(),
                                        uts, period=iperiod['angle'],
                                        data_range=drange['angle'])
-    data['latitude'] = 90.0 * np.cos(angle)
+    data['latitude'] = max_latitude * np.cos(angle)
 
     # create constant altitude at 400 km
     alt0 = 400.0

--- a/pysat/instruments/pysat_testing2d_xarray.py
+++ b/pysat/instruments/pysat_testing2d_xarray.py
@@ -38,7 +38,8 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag=None, inst_id=None, malformed_index=False,
-         start_time=None, num_samples=864, test_load_kwarg=None):
+         start_time=None, num_samples=864, test_load_kwarg=None,
+         max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -61,6 +62,9 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         current day. (default=864)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
+    max_latitude : float
+        Latitude simulated as `max_latitude` * cos(theta(t))`, where
+        theta is a linear periodic signal bounded by [0, 2 * pi) (default=90.).
 
     Returns
     -------
@@ -122,7 +126,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
     angle = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
                                        period=iperiod['angle'],
                                        data_range=drange['angle'])
-    latitude = 90.0 * np.cos(angle)
+    latitude = max_latitude * np.cos(angle)
     data['latitude'] = ((epoch_name), latitude)
 
     # create constant altitude at 400 km for a satellite that has yet

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -39,7 +39,8 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
          sim_multi_file_left=False, malformed_index=False,
-         start_time=None, num_samples=86400, test_load_kwarg=None):
+         start_time=None, num_samples=86400, test_load_kwarg=None,
+         max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -67,6 +68,9 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
         current day. (default=86400)
     test_load_kwarg : any or NoneType
         Testing keyword (default=None)
+    max_latitude : float
+        Latitude simulated as `max_latitude` * cos(theta(t))`, where
+        theta is a linear periodic signal bounded by [0, 2 * pi) (default=90.).
 
     Returns
     -------
@@ -131,7 +135,7 @@ def load(fnames, tag=None, inst_id=None, sim_multi_file_right=False,
     angle = mm_test.generate_fake_data(time_delta.total_seconds(), uts,
                                        period=iperiod['angle'],
                                        data_range=drange['angle'])
-    latitude = 90.0 * np.cos(angle)
+    latitude = max_latitude * np.cos(angle)
     data['latitude'] = ((epoch_name), latitude)
 
     # create constant altitude at 400 km

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -107,11 +107,8 @@ class TestInstruments(InstLibTests):
 
     @pytest.mark.parametrize("inst_dict", instruments['download'])
     def test_inst_max_latitude(self, inst_dict):
-        """Test operation of num_samples keyword."""
+        """Test operation of max_latitude keyword."""
 
-        # Number of samples needs to be <96 because freq is not settable.
-        # Different test instruments have different default number of points.
-        num = 10
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'])
         if self.test_inst.name != 'testmodel':

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -105,6 +105,24 @@ class TestInstruments(InstLibTests):
         assert all(file_date_range == file_list.index)
         return
 
+    @pytest.mark.parametrize("inst_dict", instruments['download'])
+    def test_inst_max_latitude(self, inst_dict):
+        """Test operation of num_samples keyword."""
+
+        # Number of samples needs to be <96 because freq is not settable.
+        # Different test instruments have different default number of points.
+        num = 10
+        _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
+        self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'])
+        if self.test_inst.name != 'testmodel':
+            self.test_inst.load(date=date, max_latitude=10.)
+            assert np.all(np.abs(self.test_inst['latitude']) <= 10.)
+        else:
+            # Skipping testmodel Instrument
+            assert True
+
+        return
+
 
 class TestDeprecation(object):
     """Unit test for deprecation warnings."""

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -116,7 +116,7 @@ class TestInstruments(InstLibTests):
             assert np.all(np.abs(self.test_inst['latitude']) <= 10.)
         else:
             # Skipping testmodel Instrument
-            assert True
+            pytest.skip("kwarg not implemented in testmodel")
 
         return
 


### PR DESCRIPTION
# Description

Addresses https://github.com/pysat/pysatModels/pull/96

Been working on adding unit tests for pysatModels and the irregular interpolation function. Ran into an issue driven by the starting latitude (90 degrees) of pysat test instruments. Added a keyword argument `max_latitude` that defaults to 90.


## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Unit tests developed in pysatModels
- Will check on what to do here.

**Test Configuration**:
* Operating system: MacOS
* Version number: Python 3.8
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
