### PR TITLE
Clarified `listify` limitations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Improved docstring style and consistency
    * Added docstring linting via flake-docstrings and hacking to CI tests
    * Added clarification to the tutorials
+   * Added limitations to the `listify` docstring
 * Bug Fix
    * Fixed default MetaLabel specification in `pysat.utils.load_netcdf4`
    * Fixed `parse_delimited_filename` output consistency and ability to handle

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -235,6 +235,22 @@ class TestIfyFunctions(object):
         utils.testing.assert_lists_equal(new_iterable, tst_iterable)
         return
 
+    @pytest.mark.parametrize('iterable', [{'key1': 1, 'key2': 2}.keys(),
+                                          {'key1': 1, 'key2': 2}.values()])
+    def test_listify_failure_with_dict_iterable(self, iterable):
+        """Test listify failes with various dict iterables.
+
+        Parameters
+        ----------
+        iterable : dict_keys or dict_values
+            Iterable dict object
+
+        """
+
+        new_iterable = utils.listify(iterable)
+        assert new_iterable[0] == iterable
+        return
+
     @pytest.mark.parametrize('iterable', [
         np.timedelta64(1), np.full((1, 1), np.timedelta64(1)),
         np.full((2, 2), np.timedelta64(1)),

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -141,9 +141,16 @@ def listify(iterable):
     list
         An enclosing 1-D list of iterable if not already a list
 
+    Note
+    ----
+    Does not accept dict_keys or dict_values as input.
+
     """
 
+    # Cast as an array-like object
     arr_iter = np.asarray(iterable)
+
+    # Treat output differently based on the array shape
     if arr_iter.shape == ():
         list_iter = [arr_iter.tolist()]
     elif arr_iter.shape[0] == 0:

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coveralls
+coveralls<3.3
 flake8
 flake8-docstrings
 hacking


### PR DESCRIPTION
# Description

Listify cannot handle dict_keys or dict_values as input.  Added a note to the docstring and a unit test to ensure it is incorrectly handled in the expected fashion.  Technically fixes this bug by descoping the routine.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Added new unit test

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
