### PR TITLE
MAINT/BUG: meta warnings for arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added a warning evaluation utility to `pysat.utils.testing`.
    * Added the ability to only download new files if remote file listing
      capabilities are not available for the Instrument.
-   * Vectorized `Meta.var_case_name` and `Meta.attr_case_name` to support 
+   * Vectorized `Meta.var_case_name` and `Meta.attr_case_name` to support
      list of str as input as well as str.
    * Added a time function to calculate decimal year from datetime.
    * Allow `Instrument.rename` to take a fuction or mapping dict as input,
@@ -80,6 +80,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      instrument data (#924)
    * Fixed a bug where empty check for xarray instruments fail when time not
      present. (#922)
+   * Improved feedback when users try to set meta with an array.
 * Maintenance
    * Added unit tests for deprecation warnings related to io_utils reorg.
    * Added missing unit tests for `pysat.utils.time`
@@ -99,6 +100,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Separated MetaLabels tests from Meta test class
    * Organized and reduced duplication in the Meta test class
    * Added CI reports for supported data products
+   * Added a cap on coveralls to ensure success of continuous integration
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -403,8 +403,8 @@ class Meta(object):
                             else:
                                 warnings.warn(' '.join(('Array elements are',
                                                         'not allowed in meta.',
-                                                        'Dropping input :',
-                                                        key)))
+                                                        'Dropping input for',
+                                                        var, 'with key', ikey)))
                         else:
                             self._data.loc[var, ikey] = to_be_set
                 else:

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -349,6 +349,23 @@ class TestMeta(object):
         self.eval_meta_settings()
         return
 
+    def test_set_meta_with_array(self):
+        """Test that setting meta as an array raises appropriate warning."""
+
+        with warnings.catch_warnings(record=True) as war:
+            self.meta['fake_var'] = {'units': [1, 2]}
+
+        # Test the warning
+        default_str = ' '.join(['Array elements are not allowed in meta.',
+                                'Dropping input for fake_var with key units'])
+        assert len(war) >= 1
+        assert war[0].category == UserWarning
+        assert default_str in str(war[0].message)
+
+        # Check that meta is blank
+        assert self.meta['fake_var']['units'] == ''
+        return
+
     # -------------------------
     # Test the logging messages
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,4 @@
-coveralls
+coveralls<3.3
 flake8
 flake8-docstrings
 hacking


### PR DESCRIPTION
# Description

If a user supplies an array to metadata as part of an instrument, pysat will warn them. However, the warning currently gives them the wrong key as feedback, meaning every warning says that 'Var_Type' is the problem key even if it has done nothing wrong. 😿 

This provides the correct key as well as the variable name to aid in debugging problems. 

Additionally, this imposes a version on coveralls to keep breaking changes there from affecting the continuous integration.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Follow instructions in pysat/pysatNASA#99 to see the feedback.  Or, in a simpler fashion
```
import pysat
meta = pysat.Meta()
meta['new_var'] = {'valid_range': [-100, 100]}
```

**Test Configuration**:
* Operating system: Mac OS X 10.15.7
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
