### PR TITLE
ENH: updated meta assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,11 +31,13 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added the ability to only download new files if remote file listing
      capabilities are not available for the Instrument.
    * Added kwargs for epoch units and origin in `pysat.utils.io.load_netCDF`.
-   * Vectorized `Meta.var_case_name` and `Meta.attr_case_name` to support 
+   * Vectorized `Meta.var_case_name` and `Meta.attr_case_name` to support
      list of str as input as well as str.
    * Added a time function to calculate decimal year from datetime.
    * Allow `Instrument.rename` to take a fuction or mapping dict as input,
      after adapting routine to use `Meta.rename`
+   * Added an update method and type evaluation method to MetaLabels.
+   * Allowed MetaLabels to be expanded through setting new Meta data values.
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1645,13 +1645,13 @@ class MetaLabels(object):
 
         default_val = self.default_values_from_type(val_type)
         valid = True
-        
+
         if default_val is None and val_type not in [type(None), bool, bytes]:
             # Ensure the type is not iterable
             try:
                 val_type([])
                 valid = False
-            except (TypeError, ValueError) as err:
+            except (TypeError, ValueError):
                 # If a list can't be cast, the type is not iterable and is
                 # likely valid.  There may be some objects that prove
                 # problematic, but they haven't been encountered yet.

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -396,8 +396,8 @@ class Meta(object):
                                     to_be_set, self.labels.label_type[iattr]):
                                 # If this is a disagreement between byte data
                                 # and an expected str, resolve it here
-                                if isinstance(to_be_set, bytes) and isinstance(
-                                        self.labels.label_type[iattr], str):
+                                if(isinstance(to_be_set, bytes)
+                                   and self.labels.label_type[iattr] == str):
                                     to_be_set = to_be_set.decode("utf-8")
                                 else:
                                     warnings.warn(''.join((
@@ -408,11 +408,20 @@ class Meta(object):
                                     good_set = False
                         else:
                             # Extend the meta labels. Ensure the attribute
-                            # name has no spaces.
+                            # name has no spaces and that bytes are used instead
+                            # of strings
                             iattr = ikey.replace(" ", "_")
+                            itype = type(to_be_set)
+                            if itype == bytes:
+                                itype = str
+
+                            # Update the MetaLabels object
                             setattr(self.labels, iattr, ikey)
-                            self.labels.label_type[iattr] = type(to_be_set)
+                            self.labels.label_type[iattr] = itype
                             self.labels.label_attrs[ikey] = iattr
+
+                            # Update the existing metadata to include this
+                            # new label
                             self._label_setter(ikey, ikey, type(to_be_set))
 
                         # Set the data

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -398,11 +398,13 @@ class Meta(object):
                                 # and an expected str, resolve it here
                                 if(isinstance(to_be_set, bytes)
                                    and self.labels.label_type[iattr] == str):
-                                    to_be_set = to_be_set.decode("utf-8")
+                                    to_be_set = core_utils.stringify(to_be_set)
                                 else:
                                     # This type is incorrect, try casting it
-                                    wmsg = ''.join(['Metadata does not have ',
-                                                    'expected type ',
+                                    wmsg = ''.join(['Metadata with type ',
+                                                    repr(type(to_be_set)),
+                                                    'does not match expected ',
+                                                    'type ',
                                                     repr(self.labels.label_type[
                                                         iattr])])
                                     try:
@@ -419,7 +421,7 @@ class Meta(object):
                                                 iattr](to_be_set)
 
                                         # Inform user data was recast
-                                        pysat.logger.warning(''.join((
+                                        pysat.logger.info(''.join((
                                             wmsg, '. Recasting input for ',
                                             repr(var), ' with key ',
                                             repr(ikey))))

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -366,7 +366,7 @@ class TestMeta(object):
         # Test the warning
         assert len(war) >= 1
         assert war[0].category == UserWarning
-        assert 'Metadata does not have expected type' in str(war[0].message)
+        assert 'Metadata with type' in str(war[0].message)
         assert 'Dropping input' in str(war[0].message)
 
         # Check that meta is blank
@@ -392,7 +392,7 @@ class TestMeta(object):
 
         # Test the warning
         captured = caplog.text
-        assert captured.find('Metadata does not have expected type') >= 0
+        assert captured.find('Metadata with type') >= 0
         assert captured.find('Recasting input') >= 0
 
         # Check that meta is set

--- a/pysat/tests/test_meta_labels.py
+++ b/pysat/tests/test_meta_labels.py
@@ -170,7 +170,7 @@ class TestMetaLabels(object):
         assert self.meta_labels.new_label == 'new_name'
         assert self.meta_labels.label_type['new_label'] == int
         return
-        
+
     # ----------------------------------------
     # Test the integration with the Meta class
 

--- a/pysat/tests/test_meta_labels.py
+++ b/pysat/tests/test_meta_labels.py
@@ -5,6 +5,7 @@
 # ----------------------------------------------------------------------------
 """Tests the pysat MetaLabels object."""
 
+import datetime as dt
 import logging
 import numpy as np
 import pytest
@@ -41,6 +42,40 @@ class TestMetaLabels(object):
         assert verr.match("unknown label attribute")
         return
 
+    @pytest.mark.parametrize("iter_type", [list, dict, set, tuple, np.ndarray])
+    def test_set_bad_type(self, iter_type):
+        """Test MetaLabels type evaluations does not allow iterables.
+
+        Parameters
+        ----------
+        iter_type : type
+            Different iterable types
+
+        """
+
+        with pytest.raises(TypeError) as terr:
+            pysat.MetaLabels(value_range=('val_range', iter_type))
+
+        assert str(terr).find("iterable types like") >= 0
+        return
+
+    @pytest.mark.parametrize("iter_type", [list, dict, set, tuple, np.ndarray])
+    def test_update_bad_type(self, iter_type):
+        """Test MetaLabels type evaluations does not allow iterables.
+
+        Parameters
+        ----------
+        iter_type : type
+            Different iterable types
+
+        """
+
+        with pytest.raises(TypeError) as terr:
+            self.meta_labels.update("value_range", 'val_range', iter_type)
+
+        assert str(terr).find("iterable types like") >= 0
+        return
+
     # -------------------------
     # Test the logging messages
 
@@ -70,6 +105,40 @@ class TestMetaLabels(object):
         return
 
     # -----------------------------
+    # Test the class hidden methods
+
+    @pytest.mark.parametrize("val_type", [int, float, type(None), str, bytes,
+                                          bool, np.float32, np.float64,
+                                          np.int32, np.int64, np.datetime64,
+                                          dt.datetime, dt.timedelta])
+    def test_eval_label_type_true(self, val_type):
+        """Test successful ID of an allowable meta data type.
+
+        Parameters
+        ----------
+        val_type : type
+            Scalar data type
+
+        """
+
+        assert self.meta_labels._eval_label_type(val_type)
+        return
+
+    @pytest.mark.parametrize("val_type", [list, dict, set, tuple, np.ndarray])
+    def test_eval_label_type_false(self, val_type):
+        """Test successful ID of an allowable meta data type.
+
+        Parameters
+        ----------
+        val_type : type
+            Iterable data type
+
+        """
+
+        assert not self.meta_labels._eval_label_type(val_type)
+        return
+
+    # -----------------------------
     # Test the class public methods
 
     @pytest.mark.parametrize("in_val",
@@ -93,6 +162,15 @@ class TestMetaLabels(object):
 
         return
 
+    def test_update(self):
+        """Test successful update of MetaLabels."""
+        self.meta_labels.update('new_label', 'new_name', int)
+
+        assert hasattr(self.meta_labels, 'new_label')
+        assert self.meta_labels.new_label == 'new_name'
+        assert self.meta_labels.label_type['new_label'] == int
+        return
+        
     # ----------------------------------------
     # Test the integration with the Meta class
 

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -661,7 +661,7 @@ class TestNetCDF4Integration(object):
 
             assert 'Depend_1' not in init_meta[var]
             if init_meta[var].children is None:
-                assert np.isnan(self.testInst.meta[var, 'Depend_1'])
+                assert self.testInst.meta[var, 'Depend_1'] == ''
             else:
                 assert self.testInst.meta[
                     var, 'Depend_1'] in self.testInst.variables


### PR DESCRIPTION
# Description

Updated the meta data assignment by checking type against expected label type, updating MetaLabels if needed, and *not* allowing array inputs.  Possibly addresses #940 and was meant to address https://github.com/pysat/pysatNASA/issues/99.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

```
import pysat
test_inst = pysat.Instrument('pysat', 'testing')
test_inst.load(2009, 1)
test_inst.meta['dummy1'] = {'new meta': 'test string'}
test_inst.meta['dummy1'] = {'new meta': 'test string'}
test_inst.meta['dummy1'] = {'new meta': b'test bytes'}
test_inst.meta['dummy2'] = {'new_bytes': b'test bytes'}
test_inst.meta.labels.label_type

{'units': str,
 'name': str,
 'notes': str,
 'desc': str,
 'min_val': numpy.float64,
 'max_val': numpy.float64,
 'fill_val': numpy.float64,
 'new_meta': str,
 'new_bytes': str}
```

Now let's raise an error!
```
import numpy as np

test_inst.meta['dummy1'] = {'new_array': np.array([0, 1.0])}

---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-7-05d199d2ff20> in <module>
----> 1 test_inst.meta['dummy1'] = {'new_array': np.array([0, 1.0])}

~/Programs/Git/pysat/pysat/_meta.py in __setitem__(self, data_vars, input_dat)
    418                             # Update the MetaLabels object and the existing
    419                             # metadata to ensure all data have all labels
--> 420                             self.labels.update(iattr, ikey, itype)
    421                             self._label_setter(ikey, ikey, type(to_be_set))
    422 

~/Programs/Git/pysat/pysat/_meta.py in update(self, lattr, lname, ltype)
   1788         else:
   1789             # This is an invalid meta data type, raise a TypeError
-> 1790             raise TypeError(''.join(['iterable types like ', repr(ltype),
   1791                                      ' (set for ', repr(lattr),
   1792                                      ') are not allowed']))

TypeError: iterable types like <class 'numpy.ndarray'> (set for 'new_array') are not allowed
```
**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.8
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
