### PR TITLE
BUG: update_longitude assignment issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed a bug where empty check for xarray instruments fail when time not
      present. (#922)
    * Improved feedback when users try to set meta with an array.
+   * Fixed a bug that expected special treatment by `Instrument.data` type in
+     `utils.coords.update_longitude`
+   * Fixed pysat_testmodel Instrument longitude range
 * Maintenance
    * Added unit tests for deprecation warnings related to io_utils reorg.
    * Added missing unit tests for `pysat.utils.time`

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -80,7 +80,7 @@ def load(fnames, tag=None, inst_id=None, start_time=None, num_samples=96,
     # Define range of simulated model as well as data, depending upon tag.
     if tag == '':
         latitude = np.linspace(-50, 50, 21)
-        longitude = np.linspace(0, 360, 73)
+        longitude = np.linspace(0, 360, 72, endpoint=False)
         altitude = np.linspace(300, 500, 41)
         data = xr.Dataset({'uts': (('time'), np.mod(uts, 86400.))},
                           coords={'time': index, 'latitude': latitude,

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -62,7 +62,8 @@ class TestUpdateLon(object):
         del self.py_inst, self.inst_time
         return
 
-    @pytest.mark.parametrize("name", ["testing", "testing_xarray"])
+    @pytest.mark.parametrize("name", ["testing", "testing_xarray",
+                                      "testing2d_xarray", "testmodel"])
     def test_update_longitude(self, name):
         """Test update_longitude successful run."""
 

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -63,16 +63,10 @@ def update_longitude(inst, lon_name=None, high=180.0, low=-180.0):
     Updates instrument data in column provided by `lon_name`
 
     """
-    if lon_name not in inst.data.keys():
+    if lon_name not in inst.variables:
         raise ValueError('unknown longitude variable name')
 
-    new_lon = adjust_cyclic_data(inst[lon_name], high=high, low=low)
-
-    # Update based on data type
-    if inst.pandas_format:
-        inst[lon_name] = new_lon
-    else:
-        inst[lon_name].data = new_lon
+    inst[lon_name] = adjust_cyclic_data(inst[lon_name], high=high, low=low)
 
     return
 


### PR DESCRIPTION
# Description

When running a model validation period, I encountered the following error:

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-22-0f94a05e9ffd> in <module>
----> 1 (pairs, pairs_meta, inst_dat, mod_dat, inst_loc) = sami3_val.pair_sami3_inst(stime, etime, inst_name, mod_prefix,
      2                                     user=user, password=password,
      3                                     skip_download=skip_download,
      4                                     mod_dir=mod_dir, data_dir=data_dir,
      5                                     data_type=data_type, comp_clean=comp_clean)

~/Programs/Models/SAMI3/tools/sami3_validation_rout.py in pair_sami3_inst(stime, etime, inst_name, mod_prefix, user, password, skip_download, mod_dir, data_dir, data_type, comp_clean)
    299                     'exb_mer': 'u1p'}
    300 
--> 301     inst_sami = pm_utils.match.collect_inst_model_pairs(
    302         stime, etime, tinc, inst,
    303         inst_download_kwargs={'skip_download': skip_download},

~/Programs/Git/pysatModels/pysatModels/utils/match.py in collect_inst_model_pairs(start, stop, tinc, inst, inst_download_kwargs, model_load_rout, model_load_kwargs, inst_clean_rout, inst_lon_name, mod_lon_name, lon_pos, inst_name, mod_name, mod_datetime_name, mod_time_name, mod_units, sel_name, time_method, pair_method, method, model_label, comp_clean)
    209                                            'lon_name': inst_lon_name,
    210                                            'high': lon_high})
--> 211                 inst.load(date=istart)
    212 
    213                 # Set flag to false now that the range has been set

~/Programs/Git/pysat/pysat/_instrument.py in load(self, yr, doy, end_yr, end_doy, date, end_date, fname, stop_fname, verifyPad, **kwargs)
   3043         # Apply custom functions via the nanokernel in self.custom
   3044         if not self.empty:
-> 3045             self.custom_apply_all()
   3046 
   3047         # Remove the excess data padding, if any applied

~/Programs/Git/pysat/pysat/_instrument.py in custom_apply_all(self)
   2132                     # object by the method are retained. No data may be returned
   2133                     # by method itself.
-> 2134                     null_out = func(self, *arg, **kwarg)
   2135                     if null_out is not None:
   2136                         raise ValueError(''.join(('Custom functions should not',

~/Programs/Git/pysat/pysat/utils/coords.py in update_longitude(inst, lon_name, high, low)
     73         inst[lon_name] = new_lon
     74     else:
---> 75         inst[lon_name].data = new_lon
     76 
     77     return

~/Library/Python/3.8/lib/python/site-packages/xarray/core/common.py in __setattr__(self, name, value)
    260         """
    261         try:
--> 262             object.__setattr__(self, name, value)
    263         except AttributeError as e:
    264             # Don't accidentally shadow custom AttributeErrors, e.g.

~/Library/Python/3.8/lib/python/site-packages/xarray/core/dataarray.py in data(self, value)
    563     @data.setter
    564     def data(self, value: Any) -> None:
--> 565         self.variable.data = value
    566 
    567     @property

~/Library/Python/3.8/lib/python/site-packages/xarray/core/variable.py in data(self, data)
   2279     @Variable.data.setter  # type: ignore
   2280     def data(self, data):
-> 2281         raise ValueError(
   2282             f"Cannot assign to the .data attribute of dimension coordinate a.k.a IndexVariable {self.name!r}. "
   2283             f"Please use DataArray.assign_coords, Dataset.assign_coords or Dataset.assign as appropriate."

ValueError: Cannot assign to the .data attribute of dimension coordinate a.k.a IndexVariable 'glon'. Please use DataArray.assign_coords, Dataset.assign_coords or Dataset.assign as appropriate.
```

Entering debug, I found this could be solved by simply assigning the xarray data as one did the pandas data.  I am guessing we either improved the pysat Instrument class to be more robust, or xarray changed things.  Either way, the code needed to be updated.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

1. Expanded the unit tests to use more pysat Instruments
2. Rerunning the code that flagged the initial problem.

**Test Configuration**:
* Operating system: OS X Mojave
* Version number: Python 3.8
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
