### PR TITLE
MAINT: NEP29 dec2021 updates + netCDF4 cap removal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.9", "3.10"]
         numpy_ver: ["latest"]
         include:
-          - python-version: "3.7"
-            numpy_ver: "1.18"
+          - python-version: "3.8"
+            numpy_ver: "1.19"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -101,7 +101,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Update usage of caplog and capsys in unit tests
    * Reorganized tests for the `pysat.Instrument` class into multiple files
    * Updated unit tests for `pysat.Instrument` with pytest.mark.parametrize
-   * Update minimum numpy in CI tests to 1.18 following NEP29
+   * Update minimum numpy in CI tests to 1.19 following NEP29
    * Made `InstLibTests` more portable to streamline user implementation of the
      standard end-to-end instrument tests.
    * Moved test classes to `pysat.tests.classes`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 dask
-# netCDF 1.5.7 released after RC pull started.
-netCDF4<1.5.7
+netCDF4
 numpy>=1.12
 pandas
 portalocker

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires = dask
 		   numpy
 		   pandas
 		   portalocker
-       pytest
+			 pytest
 		   scipy
 		   toolz
 		   xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,7 +45,7 @@ install_requires = dask
 		   numpy
 		   pandas
 		   portalocker
-                   pytest
+       pytest
 		   scipy
 		   toolz
 		   xarray

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,14 +41,14 @@ include_package_data = True
 zip_safe = False
 packages = find:
 install_requires = dask
-		   netCDF4
-		   numpy
-		   pandas
-		   portalocker
-			 pytest
-		   scipy
-		   toolz
-		   xarray
+		netCDF4
+		numpy
+		pandas
+		portalocker
+		pytest
+		scipy
+		toolz
+		xarray
 
 [coverage:report]
 omit =


### PR DESCRIPTION
# Description

Addresses #828.  May address #824 as far as CI testing is concerned.

Updates test versions according to NEP29: https://numpy.org/neps/nep-0029-deprecation_policy.html

- On Dec 22, 2021, support for numpy 1.18 can be dropped.
- On Dec 26, 2021, support for python 3.7 can be dropped.
- Adds support for python 3.10, released Oct 2021.
- Drops version cap on netCDF4 with release of v1.5.8, which fixes the windows issues encountered in pysat CI tests previously.  Included here for improved python 3.10 compliance.
- Fixed tab/space mixing in setup.cfg

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via github actions

**Test Configuration**:
* Operating system: ubuntu, windows
* Version number: Python 3.8, 3.9, 3.10
* python 3.8 run with numpy 1.19

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
