### PR TITLE
DEP: DeprecationWarnings for 2d pandas data, pysat_testing2d and pysat_testing_xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Changed `fname` from a kwarg to an arg in `pysat.Instruments.to_netcdf4`
    * Deprecated support for 2D pandas datasets
    * Deprecated `pysat.instruments.pysat_testing2d`
+   * Deprecated `pysat.instruments.pysat_testing_xarray`
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      with `pysat.utils.io.filter_netcdf4_metadata`.
    * Changed `fname` from a kwarg to an arg in `pysat.Instruments.to_netcdf4`
    * Deprecated support for 2D pandas datasets
-   * Deprecated `pysat.instruments.pysat_testing2d`
    * Deprecated `pysat.instruments.pysat_testing_xarray`
 * Documentation
    * Moved logo to 'docs\images'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Deprecated `pysat.Instrument._filter_netcdf4_metadata` and replaced it
      with `pysat.utils.io.filter_netcdf4_metadata`.
    * Changed `fname` from a kwarg to an arg in `pysat.Instruments.to_netcdf4`
+   * Deprecated support for 2D pandas datasets
+   * Deprecated `pysat.instruments.pysat_testing2d`
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -929,8 +929,8 @@ class Instrument(object):
                     warnings.warn(" ".join(["Support for 2D pandas instrument",
                                             "data has been deprecated and will",
                                             "be removed in 3.2.0+.  Please",
-                                            "update to use an xarray instrument",
-                                            "type by setting",
+                                            "update to use an xarray",
+                                            "instrument type by setting",
                                             "`pandas_format=False`."]),
                                   DeprecationWarning, stacklevel=2)
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -929,9 +929,10 @@ class Instrument(object):
                     warnings.warn(" ".join(["Support for 2D pandas instrument",
                                             "data has been deprecated and will",
                                             "be removed in 3.2.0+.  Please",
-                                            "update to use an xarray",
-                                            "instrument type by setting",
-                                            "`pandas_format=False`."]),
+                                            "either raise an issue with the",
+                                            "developers or modify the load",
+                                            "statement to use an",
+                                            "xarray.Dataset."]),
                                   DeprecationWarning, stacklevel=2)
 
                     if ('meta' not in new) and (key not in self.meta.keys_nD()):

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -918,12 +918,22 @@ class Instrument(object):
             # input dict must have data in 'data',
             # the rest of the keys are presumed to be metadata
             in_data = new.pop('data')
+
+            # TODO(#908): remove code below with removal of 2d pandas support.
             if hasattr(in_data, '__iter__'):
                 if isinstance(in_data, pds.DataFrame):
                     pass
                     # filter for elif
                 elif isinstance(next(iter(in_data), None), pds.DataFrame):
                     # Input is a list_like of frames, denoting higher order data
+                    warnings.warn(" ".join(["Support for 2D pandas instrument",
+                                            "data has been deprecated and will",
+                                            "be removed in 3.2.0+.  Please",
+                                            "update to use an xarray instrument",
+                                            "type by setting",
+                                            "`pandas_format=False`."]),
+                                  DeprecationWarning, stacklevel=2)
+
                     if ('meta' not in new) and (key not in self.meta.keys_nD()):
                         # Create an empty Meta instance but with variable names.
                         # This will ensure the correct defaults for all

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
-"""Produces fake instrument data for testing."""
+"""Produces fake instrument data for testing.
+
+.. deprecated:: 3.1.0
+    Support for 2d pandas objects will be removed in 3.2.0+.  This instrument
+    module simulates an object that will no longer be supported.
+
+"""
 
 import datetime as dt
 import functools
 import numpy as np
+import warnings
 
 import pandas as pds
 
@@ -20,7 +27,15 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 
 # Init method
-init = mm_test.init
+def init(self):
+    """Initialize the test instrument."""
+
+    warnings.warn(" ".join(["The instrument module `pysat_testing2d` has been",
+                            "deprecated and will be removed in 3.2.0+."]),
+                  DeprecationWarning, stacklevel=2)
+
+    mm_test.init
+    return
 
 
 # Clean method

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -40,7 +40,9 @@ def init(self, test_init_kwarg=None):
     """
 
     warnings.warn(" ".join(["The instrument module `pysat_testing2d` has been",
-                            "deprecated and will be removed in 3.2.0+."]),
+                            "deprecated and will be removed in 3.2.0+. This",
+                            "module simulates an object that will no longer be",
+                            "supported."]),
                   DeprecationWarning, stacklevel=2)
 
     mm_test.init(self, test_init_kwarg=test_init_kwarg)

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -28,13 +28,22 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 # Init method
 def init(self):
-    """Initialize the test instrument."""
+    """Initialize the test instrument.
+
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+    test_init_kwarg : any or NoneType
+        Testing keyword (default=None)
+
+    """
 
     warnings.warn(" ".join(["The instrument module `pysat_testing2d` has been",
                             "deprecated and will be removed in 3.2.0+."]),
                   DeprecationWarning, stacklevel=2)
 
-    mm_test.init
+    mm_test.init(self, test_init_kwarg=test_init_kwarg)
     return
 
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -27,7 +27,7 @@ _test_dates = {'': {'': dt.datetime(2009, 1, 1)}}
 
 
 # Init method
-def init(self):
+def init(self, test_init_kwarg=None):
     """Initialize the test instrument.
 
     Parameters

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -33,14 +33,23 @@ epoch_name = u'time'
 
 
 # Init method
-def init(self):
-    """Initialize the test instrument."""
+def init(self, test_init_kwarg=None):
+    """Initialize the test instrument.
+
+    Parameters
+    ----------
+    self : pysat.Instrument
+        This object
+    test_init_kwarg : any or NoneType
+        Testing keyword (default=None)
+
+    """
 
     warnings.warn(" ".join(["The instrument module `pysat_testing_xarray` has",
                             "been deprecated and will be removed in 3.2.0+."]),
                   DeprecationWarning, stacklevel=2)
 
-    mm_test.init
+    mm_test.init(self, test_init_kwarg=test_init_kwarg)
     return
 
 

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -1,9 +1,16 @@
 # -*- coding: utf-8 -*-
-"""Produces fake instrument data for testing."""
+"""Produces fake instrument data for testing.
+
+.. deprecated:: 3.1.0
+    All data present in this instrument is duplicated in pysat_testing2d_xarray.
+    This instrument is removed to reduce redundancy.
+
+"""
 
 import datetime as dt
 import functools
 import numpy as np
+import warnings
 
 import xarray as xr
 
@@ -26,7 +33,15 @@ epoch_name = u'time'
 
 
 # Init method
-init = mm_test.init
+def init(self):
+    """Initialize the test instrument."""
+
+    warnings.warn(" ".join(["The instrument module `pysat_testing_xarray` has",
+                            "been deprecated and will be removed in 3.2.0+."]),
+                  DeprecationWarning, stacklevel=2)
+
+    mm_test.init
+    return
 
 
 # Clean method

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -3,7 +3,7 @@
 
 .. deprecated:: 3.1.0
     All data present in this instrument is duplicated in pysat_testing2d_xarray.
-    This instrument is removed to reduce redundancy.
+    This instrument will be removed in 3.2.0+ to reduce redundancy.
 
 """
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -508,10 +508,7 @@ class TestDeprecation(object):
 
         warn_msgs = [" ".join(["Support for 2D pandas instrument",
                                "data has been deprecated and will",
-                               "be removed in 3.2.0+.  Please",
-                               "update to use an xarray instrument",
-                               "type by setting",
-                               "`pandas_format=False`."])]
+                               "be removed in 3.2.0+."])]
 
         # Ensure the minimum number of warnings were raised.
         assert len(war) >= len(warn_msgs)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -87,6 +87,7 @@ class TestBasicsInstModule(TestBasics):
         return
 
 
+# TODO(#908): remove below class when pysat_testing_xarray is removed.
 class TestBasicsXarray(TestBasics):
     """Basic tests for xarray `pysat.Instrument`."""
 
@@ -113,6 +114,7 @@ class TestBasicsXarray(TestBasics):
         return
 
 
+# TODO(#908): remove below class when pysat_testing2d is removed.
 class TestBasics2D(TestBasics):
     """Basic tests for 2D pandas `pysat.Instrument`."""
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -494,3 +494,25 @@ class TestDeprecation(object):
         # Test the warning messages, ensuring each attribute is present.
         testing.eval_warnings(war, warn_msgs)
         return
+
+    def test_set_2d_pandas_data(self):
+        """Check that setting 2d data for pandas raises a DeprecationWarning."""
+
+        test_inst = pysat.Instrument('pysat', 'testing2d')
+        test_inst.load(2009, 1)
+        with warnings.catch_warnings(record=True) as war:
+            test_inst['new_profiles'] = 2 * test_inst['profiles']
+
+        warn_msgs = [" ".join(["Support for 2D pandas instrument",
+                               "data has been deprecated and will",
+                               "be removed in 3.2.0+.  Please",
+                               "update to use an xarray instrument",
+                               "type by setting",
+                               "`pandas_format=False`."])]
+
+        # Ensure the minimum number of warnings were raised.
+        assert len(war) >= len(warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present.
+        testing.eval_warnings(war, warn_msgs)
+        return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -499,7 +499,8 @@ class TestDeprecation(object):
         """Check that setting 2d data for pandas raises a DeprecationWarning."""
 
         test_inst = pysat.Instrument('pysat', 'testing2d')
-        test_inst.load(2009, 1)
+        test_date = pysat.instruments.pysat_testing2d._test_dates['']['']
+        test_inst.load(date=test_date)
         with warnings.catch_warnings(record=True) as war:
             test_inst['new_profiles'] = 2 * test_inst['profiles']
 

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -185,15 +185,25 @@ class TestDeprecation(object):
 
         assert "download" in mark_names
 
-    def test_pysat_testing2d(self):
-        """Check that instantiating pysat_testing2d raises a DeprecationWarning."""
+    @pytest.mark.parametrize("inst_module", ['pysat_testing2d',
+                                             'pysat_testing_xarray'])
+    def test_deprecated_instruments(self, inst_module):
+        """Check that instantiating old instruments raises a DeprecationWarning.
+
+        Parameters
+        ----------
+        inst_module : str
+            name of deprecated module.
+
+        """
 
         with warnings.catch_warnings(record=True) as war:
-            test_inst = pysat.Instrument('pysat', 'testing2d')
+            test_inst = pysat.Instrument(
+                inst_module=getattr(pysat.instruments, inst_module))
 
-        warn_msgs = [" ".join(["The instrument module `pysat_testing2d` has",
-                               "been deprecated and will be removed in",
-                               "3.2.0+."])]
+        warn_msgs = [" ".join(["The instrument module `{:}`".format(inst_module),
+                               "has been deprecated and will be removed",
+                               "in 3.2.0+."])]
 
         # Ensure the minimum number of warnings were raised.
         assert len(war) >= len(warn_msgs)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -201,7 +201,7 @@ class TestDeprecation(object):
             pysat.Instrument(inst_module=getattr(pysat.instruments,
                                                  inst_module))
 
-        warn_msgs = [" ".join(["The instrument module"
+        warn_msgs = [" ".join(["The instrument module",
                                "`{:}`".format(inst_module),
                                "has been deprecated and will be removed",
                                "in 3.2.0+."])]

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -184,3 +184,20 @@ class TestDeprecation(object):
                       for j in range(0, n_args)]
 
         assert "download" in mark_names
+
+    def test_pysat_testing2d(self):
+        """Check that instantiating pysat_testing2d raises a DeprecationWarning."""
+
+        with warnings.catch_warnings(record=True) as war:
+            test_inst = pysat.Instrument('pysat', 'testing2d')
+
+        warn_msgs = [" ".join(["The instrument module `pysat_testing2d` has",
+                               "been deprecated and will be removed in",
+                               "3.2.0+."])]
+
+        # Ensure the minimum number of warnings were raised.
+        assert len(war) >= len(warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present.
+        testing.eval_warnings(war, warn_msgs)
+        return

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -198,10 +198,11 @@ class TestDeprecation(object):
         """
 
         with warnings.catch_warnings(record=True) as war:
-            test_inst = pysat.Instrument(
-                inst_module=getattr(pysat.instruments, inst_module))
+            pysat.Instrument(inst_module=getattr(pysat.instruments,
+                                                 inst_module))
 
-        warn_msgs = [" ".join(["The instrument module `{:}`".format(inst_module),
+        warn_msgs = [" ".join(["The instrument module"
+                               "`{:}`".format(inst_module),
                                "has been deprecated and will be removed",
                                "in 3.2.0+."])]
 

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -195,6 +195,7 @@ class TestMeta(object):
         assert str(ierr).find('expected tuple, list, or str') >= 0
         return
 
+    # TODO(#913): remove tests for 2d metadata
     @pytest.mark.parametrize("parent_child", [
         (['alt_profiles', 'profiles'], 'density'),
         (['alt_profiles', 'profiles'], ['density', 'dummy_str']),
@@ -237,6 +238,7 @@ class TestMeta(object):
             'Duplicated keys (variable names) in Meta.keys()') >= 0
         return
 
+    # TODO(#913): remove tests for 2d metadata
     def test_concat_strict_w_ho_collision(self):
         """Test raises KeyError when higher-order variable nams overlap."""
 
@@ -302,6 +304,7 @@ class TestMeta(object):
         assert str(verr.value).find(err_msg) >= 0
         return
 
+    # TODO(#913): remove tests for 2d metadata
     def test_meta_rename_bad_ho_input(self):
         """Test raises ValueError when treating normal data like HO data."""
 
@@ -432,6 +435,7 @@ class TestMeta(object):
         assert out.find('Meta(') >= 0
         return
 
+    # TODO(#913): remove tests for 2d metadata
     @pytest.mark.parametrize('long_str', [True, False])
     @pytest.mark.parametrize('inst_kwargs',
                              [None, {'platform': 'pysat', 'name': 'testing'},
@@ -497,6 +501,7 @@ class TestMeta(object):
         assert cmeta == self.meta, "identical meta objects differ"
         return
 
+    # TODO(#908): remove tests for deprecated instruments
     @pytest.mark.parametrize("inst_name", ["testing", "testing2d",
                                            "testing2d_xarray", "testing_xarray",
                                            "testmodel"])
@@ -593,6 +598,7 @@ class TestMeta(object):
             "differences not detected in label {:s}".format(label_key)
         return
 
+    # TODO(#908): remove tests for deprecated instruments
     @pytest.mark.parametrize("inst_name", ["testing", "testing2d",
                                            "testing2d_xarray", "testing_xarray",
                                            "testmodel"])
@@ -700,6 +706,7 @@ class TestMeta(object):
             self.eval_meta_settings()
         return
 
+    # TODO(#913): remove tests for 2d metadata
     @pytest.mark.parametrize('inst_name', ['testing', 'testing2d'])
     @pytest.mark.parametrize('num_mvals', [0, 1, 3])
     @pytest.mark.parametrize('num_dvals', [0, 1, 3])
@@ -868,6 +875,7 @@ class TestMeta(object):
 
         return
 
+    # TODO(#913): remove tests for 2d metadata
     @pytest.mark.parametrize('inst_name', ['testing', 'testing2d'])
     def test_assign_nonstandard_metalabels(self, inst_name):
         """Test labels do not conform to the standard values if set that way.
@@ -1521,6 +1529,7 @@ class TestMeta(object):
         self.eval_ho_meta_settings(meta_dict)
         return
 
+    # TODO(#913): remove tests for 2d metadata
     def test_inst_ho_data_assign_meta_different_labels(self):
         """Test the higher order assignment of custom metadata labels."""
 
@@ -1581,6 +1590,7 @@ class TestMeta(object):
         assert self.meta['new4'].children['new41'].units == 'hey4'
         return
 
+    # TODO(#913): remove tests for 2d metadata
     def test_concat_not_strict_w_ho_collision(self):
         """Test non-strict concat with overlapping higher-order data."""
 
@@ -1670,6 +1680,7 @@ class TestMeta(object):
         assert self.meta[self.dval].children.hasattr_case_neutral(label)
         return
 
+    # TODO(#913): remove tests for 2d metadata
     def test_ho_meta_rename_function(self):
         """Test `meta.rename` method with ho data using a function."""
 
@@ -1705,6 +1716,7 @@ class TestMeta(object):
 
         return
 
+    # TODO(#913): remove tests for 2d metadata
     def test_ho_meta_rename_dict(self):
         """Test `meta.rename` method with ho data using a dict."""
 

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -481,6 +481,7 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
                             nc_key)
                     meta[key] = meta_dict
 
+                # TODO(#913): Remove 2D support
                 if len(data.variables[key].dimensions) == 2:
                     # Part of dataframe within dataframe
                     two_d_keys.append(key)
@@ -491,6 +492,7 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
                                                'data in pandas. Please use',
                                                'xarray for this file.')))
 
+            # TODO(#913): Remove 2D support
             # We now have a list of keys that need to go into a dataframe,
             # could be more than one, collect unique dimensions for 2D keys
             for dim in set(two_d_dims):


### PR DESCRIPTION
# Description

Addresses #908 (partial) and #913

After merge, bump milestones of issues rather than close.

- Adds a DeprecationWarning when a user attempts to set a data object for 2d data.
- Deprecates pandas2d instrument.
- Deprecates the 1d xarray instrument (redendant) in partial support of #908.

The deprecation of meta children (#789) will be handled in a separate pull.

## Type of change

- Warnings for upcoming Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

```
import pysat
import warnings
warnings.simplefilter("always", DeprecationWarning)

# Instantiating should produce a DeprecationWarning
test = pysat.Instrument('pysat', 'testing2d')

test.load(2009, 1)

# Setting 1d data should NOT produce a DeprecationWarning
test['new_mlt'] = 2 * test['mlt']

# Setting 2d data should produce a DeprecationWarning
test['new_profiles'] = 2 * test['profiles']
```

**Test Configuration**:
* Operating system: Mac OS X 11.6.1
* Version number: Python 3.9.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no ***unexpected*** warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
