### PR TITLE
DEP: higher order metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Deprecated support for 2D pandas datasets
    * Deprecated `pysat.instruments.pysat_testing2d`
    * Deprecated `pysat.instruments.pysat_testing_xarray`
+   * Deprecated usage of higher order metadata
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -454,6 +454,7 @@ class Meta(object):
                     # metadata. Meta inputs could be part of a larger multiple
                     # parameter assignment, so not all names may actually have
                     # a 'meta' object to add.
+                    self.warn_meta_children()
                     for item, val in zip(data_vars, input_data['meta']):
                         if val is not None:
                             # Assign meta data, using a recursive call...
@@ -465,6 +466,7 @@ class Meta(object):
             # from a Meta object. Set data using standard assignment via a dict
             in_dict = input_data.to_dict()
             if 'children' in in_dict:
+                self.warn_meta_children()
                 child = in_dict.pop('children')
                 if child is not None:
                     # If there is data in the child object, assign it here
@@ -475,6 +477,7 @@ class Meta(object):
 
         elif isinstance(input_data, Meta):
             # Dealing with a higher order data set.
+            self.warn_meta_children()
             # data_vars is only a single name here (by choice for support)
             if (data_vars in self._ho_data) and input_data.empty:
                 # No actual metadata provided and there is already some
@@ -1476,6 +1479,14 @@ class Meta(object):
         else:
             raise ValueError(''.join(['Unable to retrieve information from ',
                                       filename]))
+
+    def warn_meta_children(self):
+        """Warn the user that higher order metadata is deprecated."""
+
+        warnings.warn(" ".join(["Support for higher order metadata has been",
+                                "deprecated and will be removed in 3.2.0+."]),
+                      DeprecationWarning, stacklevel=2)
+        return
 
 
 class MetaLabels(object):


### PR DESCRIPTION
# Description

Addresses #789 (milestone bump).  Downstream of #969, will rebase to develop when that is merged.

Adds DeprecationWarning when new higher order metadata is set.

## Type of change

- Warning for upcoming Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

```
import pysat
import warnings
warnings.simplefilter("always", DeprecationWarning)

# Instantiating should produce a DeprecationWarning
test = pysat.Instrument('pysat', 'testing2d')

# Loading data produces 7 DeprecationWarnings :O
test.load(2009, 1)
```

**Test Configuration**:
* Operating system: Mac OS X 11.6.1
* Version number: Python 3.9.9

# Checklist:

- [ ] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
