### PR TITLE
STY: reduce code duplication in test for warnings

### DIFF
--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -386,11 +386,6 @@ class TestDeprecation(object):
         self.warn_msgs = ["".join(["`pysat.Instrument.download` kwarg `freq` ",
                                    "has been deprecated and will be removed ",
                                    "in pysat 3.2.0+"])]
-        self.warn_msgs = np.array(self.warn_msgs)
-
-        # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(self.warn_msgs)
-
         # Test the warning messages, ensuring each attribute is present
         testing.eval_warnings(war, self.warn_msgs)
         return
@@ -406,17 +401,12 @@ class TestDeprecation(object):
                                     "deprecated and will be replaced",
                                     "by `_test_download_ci` in",
                                     "3.2.0+"])]
-        self.warn_msgs = np.array(self.warn_msgs)
-
         # Catch the warnings.
         with warnings.catch_warnings(record=True) as war:
             tinst = pysat.Instrument(inst_module=inst_module)
 
         # Ensure attributes set properly.
         assert tinst._test_download_ci is False
-
-        # Ensure the minimum number of warnings were raised.
-        assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present.
         testing.eval_warnings(war, self.warn_msgs)
@@ -438,10 +428,6 @@ class TestDeprecation(object):
                                    "has been deprecated and will be removed ",
                                    "in pysat 3.2.0+. Use `pysat.utils.io.",
                                    "filter_netcdf4_metadata` instead."])]
-        self.warn_msgs = np.array(self.warn_msgs)
-
-        # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         testing.eval_warnings(war, self.warn_msgs)
@@ -460,10 +446,6 @@ class TestDeprecation(object):
 
         self.warn_msgs = ["".join(["`fname` as a kwarg has been deprecated, ",
                                    "must supply a filename 3.2.0+"])]
-        self.warn_msgs = np.array(self.warn_msgs)
-
-        # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         testing.eval_warnings(war, self.warn_msgs)
@@ -488,8 +470,6 @@ class TestDeprecation(object):
                                "has been deprecated and will be removed",
                                "in 3.2.0+. Please use '' instead of",
                                "None."])]
-        # Ensure the minimum number of warnings were raised.
-        assert len(war) >= len(warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present.
         testing.eval_warnings(war, warn_msgs)

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -147,10 +147,6 @@ class TestDeprecation(object):
 
         self.warn_msgs = ["`InstTestClass` has been deprecated",
                           "`test_load` now uses `@pytest.mark.load_options`"]
-        self.warn_msgs = np.array(self.warn_msgs)
-
-        # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         testing.eval_warnings(war, self.warn_msgs)
@@ -167,10 +163,6 @@ class TestDeprecation(object):
                 pass
 
         self.warn_msgs = ["`initialize_test_inst_and_date` has been moved to"]
-        self.warn_msgs = np.array(self.warn_msgs)
-
-        # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(self.warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         testing.eval_warnings(war, self.warn_msgs)

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -599,8 +599,6 @@ class TestDeprecation(object):
                               "for same behavior."])]
 
         warn_msgs = [warn_msgs[ind] for ind in msg_inds]
-        # Ensure the minimum number of warnings were raised
-        assert len(war) >= len(warn_msgs)
 
         # Test the warning messages, ensuring each attribute is present
         utils.testing.eval_warnings(war, warn_msgs)

--- a/pysat/utils/testing.py
+++ b/pysat/utils/testing.py
@@ -137,6 +137,9 @@ def eval_warnings(warns, check_msgs, warn_type=DeprecationWarning):
     # Initialize the output
     found_msgs = [False for msg in check_msgs]
 
+    # Ensure the minimum number of warnings were raised
+    assert len(warns) >= len(check_msgs)
+
     # Test the warning messages, ensuring each attribute is present
     for iwar in warns:
         for i, msg in enumerate(check_msgs):


### PR DESCRIPTION
# Description

Addresses #912.

Moves the check for number of warnings inside `eval_warnings`. Cleans up the list construction of warning messages.

## Type of change

- Style fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via Github Actions.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes -- changes to non-released code.

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
