### PR TITLE
DEP: DeprecationWarning for higher order metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Deprecated support for 2D pandas datasets
    * Deprecated `pysat.instruments.pysat_testing2d`
    * Deprecated `pysat.instruments.pysat_testing_xarray`
+   * Deprecated usage of higher order metadata
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -467,7 +467,6 @@ class Meta(object):
                     # metadata. Meta inputs could be part of a larger multiple
                     # parameter assignment, so not all names may actually have
                     # a 'meta' object to add.
-                    self._warn_meta_children()
                     for item, val in zip(data_vars, input_data['meta']):
                         if val is not None:
                             # Assign meta data, using a recursive call...

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -454,6 +454,7 @@ class Meta(object):
                     # metadata. Meta inputs could be part of a larger multiple
                     # parameter assignment, so not all names may actually have
                     # a 'meta' object to add.
+                    self.warn_meta_children()
                     for item, val in zip(data_vars, input_data['meta']):
                         if val is not None:
                             # Assign meta data, using a recursive call...
@@ -465,6 +466,7 @@ class Meta(object):
             # from a Meta object. Set data using standard assignment via a dict
             in_dict = input_data.to_dict()
             if 'children' in in_dict:
+                self.warn_meta_children()
                 child = in_dict.pop('children')
                 if child is not None:
                     # If there is data in the child object, assign it here
@@ -475,6 +477,7 @@ class Meta(object):
 
         elif isinstance(input_data, Meta):
             # Dealing with a higher order data set.
+            self.warn_meta_children()
             # data_vars is only a single name here (by choice for support)
             if (data_vars in self._ho_data) and input_data.empty:
                 # No actual metadata provided and there is already some
@@ -1476,6 +1479,14 @@ class Meta(object):
         else:
             raise ValueError(''.join(['Unable to retrieve information from ',
                                       filename]))
+
+    def warn_meta_children(self):
+        """Warn the user that higher order metadata is deprecated."""
+
+        warnings.warn(" ".join(["Support for higher order metadata has been",
+                                "deprecated and will be removed in 3.2.0+."]),
+                      DeprecationWarning, stacklevel=2)
+        return
 
 
 class MetaLabels(object):

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -467,7 +467,7 @@ class Meta(object):
                     # metadata. Meta inputs could be part of a larger multiple
                     # parameter assignment, so not all names may actually have
                     # a 'meta' object to add.
-                    self.warn_meta_children()
+                    self._warn_meta_children()
                     for item, val in zip(data_vars, input_data['meta']):
                         if val is not None:
                             # Assign meta data, using a recursive call...
@@ -479,7 +479,7 @@ class Meta(object):
             # from a Meta object. Set data using standard assignment via a dict
             in_dict = input_data.to_dict()
             if 'children' in in_dict:
-                self.warn_meta_children()
+                self._warn_meta_children()
                 child = in_dict.pop('children')
                 if child is not None:
                     # If there is data in the child object, assign it here
@@ -490,7 +490,7 @@ class Meta(object):
 
         elif isinstance(input_data, Meta):
             # Dealing with a higher order data set.
-            self.warn_meta_children()
+            self._warn_meta_children()
             # data_vars is only a single name here (by choice for support)
             if (data_vars in self._ho_data) and input_data.empty:
                 # No actual metadata provided and there is already some
@@ -1528,7 +1528,8 @@ class Meta(object):
             raise ValueError(''.join(['Unable to retrieve information from ',
                                       filename]))
 
-    def warn_meta_children(self):
+    # TODO(#789): remove in pysat 3.2.0
+    def _warn_meta_children(self):
         """Warn the user that higher order metadata is deprecated."""
 
         warnings.warn(" ".join(["Support for higher order metadata has been",

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -2055,3 +2055,40 @@ class TestMetaMutable(object):
         assert self.meta._hidden_attribute == 'is it me'
         assert self.meta.__private_attribute == "you're looking for"
         return
+
+
+class TestDeprecation(object):
+    """Unit tests for DeprecationWarning."""
+
+    def setup(self):
+        """Set up the unit test environment for each method."""
+
+        warnings.simplefilter("always", DeprecationWarning)
+        self.meta = pysat.Meta()
+        return
+
+    def teardown(self):
+        """Clean up the unit test environment after each method."""
+
+        del self.meta
+        return
+
+    def test_higher_order_meta_deprecation(self):
+        """Test that setting higher order meta raises DeprecationWarning."""
+
+        ho_meta = pysat.Meta()
+        ho_meta['series_profiles'] = {'long_name': 'series'}
+        with warnings.catch_warnings(record=True) as war:
+            self.meta['series_profiles'] = {'meta': ho_meta,
+                                            'long_name': 'series'}
+
+        self.warn_msgs = ["Support for higher order metadata has been"]
+        self.warn_msgs = np.array(self.warn_msgs)
+
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(self.warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        testing.eval_warnings(war, self.warn_msgs)
+
+        return

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -2058,7 +2058,7 @@ class TestMetaMutable(object):
 
 
 class TestDeprecation(object):
-    """Unit tests for DeprecationWarning."""
+    """Unit tests for DeprecationWarnings in the Meta class."""
 
     def setup(self):
         """Set up the unit test environment for each method."""
@@ -2076,12 +2076,16 @@ class TestDeprecation(object):
     def test_higher_order_meta_deprecation(self):
         """Test that setting higher order meta raises DeprecationWarning."""
 
+        # Initialize higher-order metadata to add to the main meta object
         ho_meta = pysat.Meta()
         ho_meta['series_profiles'] = {'long_name': 'series'}
+
+        # Raise and catch warnings
         with warnings.catch_warnings(record=True) as war:
             self.meta['series_profiles'] = {'meta': ho_meta,
                                             'long_name': 'series'}
 
+        # Evaluate warnings
         self.warn_msgs = ["Support for higher order metadata has been"]
         self.warn_msgs = np.array(self.warn_msgs)
 

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -547,6 +547,7 @@ class TestMeta(object):
         assert emeta != self.meta, "meta equality not detectinng differences"
         return
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize('val_dict', [
         {'units': 'U', 'long_name': 'HO Val', 'radn': 'raiden'},
         {'units': 'MetaU', 'long_name': 'HO Val'}])
@@ -1415,6 +1416,7 @@ class TestMeta(object):
     # -------------------------------
     # Tests for higher order metadata
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize('meta_dict', [
         None, {'units': 'V', 'long_name': 'test name'},
         {'units': 'V', 'long_name': 'test name',
@@ -1460,6 +1462,7 @@ class TestMeta(object):
         self.eval_ho_meta_settings(meta_dict)
         return
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize("num_ho, num_lo", [(1, 1), (2, 2)])
     def test_assign_mult_higher_order_meta_from_dict(self, num_ho, num_lo):
         """Test assign higher order metadata from dict with multiple types.
@@ -1502,6 +1505,7 @@ class TestMeta(object):
                 self.eval_meta_settings()
         return
 
+    # TODO(#789): remove tests for higher order meta
     def test_inst_ho_data_assign_meta_then_data(self):
         """Test assignment of higher order metadata before assigning data."""
 
@@ -1579,6 +1583,7 @@ class TestMeta(object):
             assert self.meta['profiles']['children'][dvar, 'bananas'] == 2
         return
 
+    # TODO(#789): remove tests for higher order meta
     def test_concat_w_ho(self):
         """Test `meta.concat` adds new meta objects with higher order data."""
 
@@ -1630,6 +1635,7 @@ class TestMeta(object):
                     cvar, self.meta.labels.units].find('Updated') < 0
         return
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize("label", ['meta_label', 'META_LABEL', 'Meta_Label',
                                        'MeTa_lAbEl'])
     def test_ho_attribute_name_case(self, label):
@@ -1657,6 +1663,7 @@ class TestMeta(object):
         assert self.meta.attr_case_name(label) == label
         return
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize("label", ['meta_label', 'META_LABEL', 'Meta_Label',
                                        'MeTa_lAbEl'])
     def test_ho_hasattr_case_neutral(self, label):
@@ -1776,6 +1783,7 @@ class TestMeta(object):
 
         return
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize("label", ['meta_label', 'META_LABEL', 'Meta_Label',
                                        'MeTa_lAbEl'])
     def test_get_attribute_name_case_preservation_w_higher_order_list_in(self,
@@ -1811,6 +1819,7 @@ class TestMeta(object):
 
         return
 
+    # TODO(#789): remove tests for higher order meta
     def test_ho_data_retrieval_case_insensitive(self):
         """Test that higher order data variables are case insensitive."""
 
@@ -1866,6 +1875,7 @@ class TestMetaImmutable(TestMeta):
         del self.mutable
         return
 
+    # TODO(#789): remove tests for higher order meta
     @pytest.mark.parametrize("prop,set_val", [('data', pds.DataFrame()),
                                               ('ho_data', {})])
     def test_meta_mutable_properties(self, prop, set_val):

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -2065,12 +2065,13 @@ class TestDeprecation(object):
 
         warnings.simplefilter("always", DeprecationWarning)
         self.meta = pysat.Meta()
+        self.warn_msgs = []
         return
 
     def teardown(self):
         """Clean up the unit test environment after each method."""
 
-        del self.meta
+        del self.meta, self.warn_msgs
         return
 
     def test_higher_order_meta_deprecation(self):
@@ -2084,6 +2085,31 @@ class TestDeprecation(object):
         with warnings.catch_warnings(record=True) as war:
             self.meta['series_profiles'] = {'meta': ho_meta,
                                             'long_name': 'series'}
+
+        # Evaluate warnings
+        self.warn_msgs = ["Support for higher order metadata has been"]
+        self.warn_msgs = np.array(self.warn_msgs)
+
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(self.warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        testing.eval_warnings(war, self.warn_msgs)
+
+        return
+
+    def test_higher_order_meta_rename_deprecation(self):
+        """Test that renaming higher order meta raises DeprecationWarning."""
+
+        # Initialize higher-order metadata to add to the main meta object
+        ho_meta = pysat.Meta()
+        ho_meta['series_profiles'] = {'long_name': 'series'}
+        self.meta['series_profiles'] = {'meta': ho_meta,
+                                        'long_name': 'series'}
+
+        # Raise and catch warnings
+        with warnings.catch_warnings(record=True) as war:
+            self.meta.rename(str.upper)
 
         # Evaluate warnings
         self.warn_msgs = ["Support for higher order metadata has been"]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,7 +1,7 @@
 coveralls<3.3
 flake8
 flake8-docstrings
-hacking
+hacking>=1.0
 ipython
 m2r2
 numpydoc


### PR DESCRIPTION
# Description

Addresses #789 (milestone bump).  

Adds DeprecationWarning when new higher order metadata is set.

## Type of change

- Warning for upcoming Breaking change (fix or feature that would cause existing functionality
      to not work as expected)

# How Has This Been Tested?

```
import pysat
import warnings
warnings.simplefilter("always", DeprecationWarning)

# Instantiating should produce a DeprecationWarning
test = pysat.Instrument('pysat', 'testing2d')

# Loading data produces 7 DeprecationWarnings :O
test.load(2009, 1)
```

**Test Configuration**:
* Operating system: Mac OS X 11.6.1
* Version number: Python 3.9.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no ***unexpected*** warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
