### PR TITLE
BUG: warning check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Organized and reduced duplication in the Meta test class
    * Added CI reports for supported data products
    * Added a cap on coveralls to ensure success of continuous integration
+   * Updated tests in `test_meta` to search all warnings, not just the first
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -336,8 +336,10 @@ class TestMeta(object):
         default_str = ''.join(['Metadata set to defaults, as they were',
                                ' missing in the Instrument'])
         assert len(war) >= 1
-        assert war[0].category == UserWarning
-        assert default_str in str(war[0].message)
+        categories = [war[j].category for j in range(len(war))]
+        assert UserWarning in categories
+        ind = categories.index(UserWarning)
+        assert default_str in str(war[ind].message)
 
         # Prepare to test the Metadata
         self.dval = 'int32_dummy'

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -336,8 +336,10 @@ class TestMeta(object):
         default_str = ''.join(['Metadata set to defaults, as they were',
                                ' missing in the Instrument'])
         assert len(war) >= 1
+
         categories = [war[j].category for j in range(len(war))]
         assert UserWarning in categories
+
         ind = categories.index(UserWarning)
         assert default_str in str(war[ind].message)
 


### PR DESCRIPTION
pandas 1.4 throws some FutureWarnings which mess up the warning checks in test_meta.  This adjusts things so pysat does not assume the required UserWarnings are not necessarily the first warnings raised.