### PR TITLE
MAINT: pandas 1.4.0 deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -116,6 +116,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Added CI reports for supported data products
    * Added a cap on coveralls to ensure success of continuous integration
    * Updated tests in `test_meta` to search all warnings, not just the first
+   * Updated pandas syntax to be compatible with pandas 2.0 (pandas 1.4
+     deprecations)
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -591,7 +591,7 @@ class Files(object):
             if self.write_to_disk:
                 # Load data stored on the local drive.
                 loaded = pds.read_csv(fname, index_col=0, parse_dates=True,
-                                      squeeze=True, header=0)
+                                      header=0).squeeze("columns")
                 if update_path:
                     # Store the data_path from the .csv onto Files
                     self.data_path = loaded.name

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -218,7 +218,7 @@ class TestBasics(object):
     def test_inequality_different_data(self):
         """Test that equality is false if different data."""
         self.out = self.testInst.files.copy()
-        self.out.files = pds.Series([], dtype='str')
+        self.out.files = pds.Series([], dtype='object')
         assert self.out != self.testInst.files
         return
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -218,7 +218,7 @@ class TestBasics(object):
     def test_inequality_different_data(self):
         """Test that equality is false if different data."""
         self.out = self.testInst.files.copy()
-        self.out.files = pds.Series()
+        self.out.files = pds.Series([], dtype='str')
         assert self.out != self.testInst.files
         return
 

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -245,7 +245,7 @@ class TestLoadCSVData(object):
         """Test the CVS data load with multiple files."""
 
         self.data = gen.load_csv_data([self.csv_file, self.csv_file])
-        assert isinstance(self.data.index, pds.Int64Index)
+        assert self.data.index.dtype == 'int64'
         self.eval_data_cols()
         assert len(self.data.columns) == len(self.data_cols) + 1
         return


### PR DESCRIPTION
# Description

Closes #976, #977, #978

Updates pandas standards in accordance with newly deprecated behaviour in pandas 1.4.0.  Deprecated pandas syntax will be removed in pandas 2.0.0.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

tested via github actions.  Inspection of the logs shows that new FutureWarnings from pandas are suppressed (compare with develop).

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
