### PR TITLE
ENH: Improve file parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      after adapting routine to use `Meta.rename`
    * Added an update method and type evaluation method to MetaLabels.
    * Allowed MetaLabels to be expanded through setting new Meta data values.
+   * Added support for user variables when parsing template filenames
+     in `pysat.utils.files`.
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for
@@ -93,6 +95,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      `utils.coords.update_longitude`
    * Fixed pysat_testmodel Instrument longitude range
    * Corrected link to testing badge in README.md
+   * `from_os` now always returns a sorted Series.
+   * Improved robustness of parsing delimited files.
 * Maintenance
    * Added unit tests for deprecation warnings related to io_utils reorg.
    * Added missing unit tests for `pysat.utils.time`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Allowed MetaLabels to be expanded through setting new Meta data values.
    * Added support for user variables when parsing template filenames
      in `pysat.utils.files`.
+   * Improved robustness of parsing delimited files.
 * Deprecations
    * Removed `freq` as a standard kwarg for `pysat.Instruments.download`
    * Deprecated `_test_download_travis` as a standard attribute for
@@ -96,7 +97,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Fixed pysat_testmodel Instrument longitude range
    * Corrected link to testing badge in README.md
    * `from_os` now always returns a sorted Series.
-   * Improved robustness of parsing delimited files.
 * Maintenance
    * Added unit tests for deprecation warnings related to io_utils reorg.
    * Added missing unit tests for `pysat.utils.time`

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -304,9 +304,9 @@ decades of space science parsing filenames with and without a `delimiter`
 can typically generate the same results, even for filenames without a
 consistently applied delimiter. As such either parser will function for most
 situations however both remain within pysat to support currently unknown edge
-cases that users may encounter. More practically, Parsing with a delimiter
-offers more support for the '*' wildcard than the fixed width parser.
-It is generally advised to limit use of the '*' wildcard to prevent
+cases that users may encounter. More practically, parsing with a delimiter
+offers more support for the `*` wildcard than the fixed width parser.
+It is generally advised to limit use of the `*` wildcard to prevent
 potential false positives if a directory has more than one instrument within.
 
 If the constructor is not appropriate, then lower level methods within

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -269,11 +269,13 @@ A complete method is available in
 :py:meth:`pysat.Files.from_os` is a convenience constructor provided for
 filenames that include time information in the filename and utilize a constant
 field width or a consistent delimiter. The location and format of the time
-information is specified using standard python formatting and keywords year,
-month, day of month, day of year, hour, minute, second. Additionally, version,
-revision, and cycle keywords are supported. When present, the
+information is specified using standard python formatting and keywords `year`,
+`month`, `day` of month (year), `hour`, `minute`, `second`. Additionally,
+`version`, `revision`, and `cycle` keywords are supported. When present, the
 :py:meth:`pysat.Files.from_os` constructor will filter down the file list to
-the latest version/revision/cycle combination.
+the latest version/revision/cycle combination. Additional
+user specified template variables are supported though they will not be used
+to extract date information.
 
 A complete list_files routine could be as simple as
 
@@ -281,10 +283,10 @@ A complete list_files routine could be as simple as
 
    def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
        if format_str is None:
-           # set default string template consistent with files from
+           # Set default string template consistent with files from
            # the data provider that will be supported by the instrument
-           # module download method
-           # template string below works for CINDI IVM data that looks like
+           # module download method.
+           # Template string below works for CINDI IVM data that looks like
            # 'cindi-2009310-ivm-v02.hdf'
            # format_str supported keywords: year, month, day,
            # hour, minute, second, version, revision, and cycle
@@ -294,17 +296,31 @@ A complete list_files routine could be as simple as
 The constructor presumes the template string is for a fixed width format
 unless a delimiter string is supplied. This constructor supports conversion
 of years with only 2 digits and expands them to 4 using the
-two_digit_year_break keyword. Note the support for format_str.
+`two_digit_year_break` keyword. Note the support for a user provided
+`format_str` at runtime.
+
+Given the range of compliance of filenames to a strict standard across the
+decades of space science parsing filenames with and without a `delimiter`
+can typically generate the same results, even for filenames without a
+consistently applied delimiter. As such either parser will function for most
+situations however both remain within pysat to support currently unknown edge
+cases that users may encounter. More practically, Parsing with a delimiter
+offers more support for the '*' wildcard than the fixed width parser.
+It is generally advised to limit use of the '*' wildcard to prevent
+potential false positives if a directory has more than one instrument within.
 
 If the constructor is not appropriate, then lower level methods within
 :py:class:`pysat.Files` may also be used to reduce the workload in adding a new
-instrument.
+instrument. Access to the values of user provided template variables is not
+available via :py:meth:`pysat.Files.from_os` and thus requires use of the
+same lower level methods in :py:class:`pysat.Files`.
 
 See :py:func:`pysat.utils.time.create_datetime_index` for creating a datetime
 index for an array of irregularly sampled times.
 
 pysat will invoke the list_files method the first time a particular instrument
-is instantiated. After the first instantiation, by default, pysat will not
+is instantiated. After the first instantiation, by default :ref:`tutorial-params`,
+pysat will not
 search for instrument files as some missions can produce a large number of
 files, which may take time to identify. The list of files associated
 with an Instrument may be updated by adding ``update_files=True`` to the kwargs.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -912,17 +912,18 @@ class Files(object):
         part of the name that need not be extracted.
         'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v??.cdf'
 
-        Leading '*' wilcards are supported when parsing fixed width filenames,
-        '*{year:4d}{month:02d}{day:02d}_v??.cdf', though the '*' is not
-        supported after the first template variable. The '?' wildcard
-        may be used anywhere in the template string.
+        When parsing using fixed width filenames (`delimiter=None`), leading
+        '*' wilcards are supported, '*{year:4d}{month:02d}{day:02d}_v??.cdf',
+        though the '*' is not supported after the first template variable. The
+        '?' wildcard may be used anywhere in the template string.
 
-        When parsing delimited filenames, the '*' wildcard is supported
+        When parsing using a delimiter, the '*' wildcard is supported
         when leading, trailing, or wholly contained between delimiters, such as
         'data_name-{year:04d}-*-{day:02d}.txt', or '*-{year:04d}-{day:02d}*',
         where '-' is the delimiter. There can not be a mixture of a template
         variable and '*' without a delimiter in between, unless the '*'
-        occurs after the variable.
+        occurs after the variable. The '?' wildcard may be used anywhere in
+        the template string.
 
         The 'day' format keyword may be used to specify either day of month
         (if month is included) or day of year.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -918,9 +918,11 @@ class Files(object):
         '*{year:4d}{month:02d}{day:02d}_v*.cdf' will not work.
 
         When parsing delimited filenames, the '*' wildcard is supported
-        when wholly contained between delimiters, such as
+        when leading, trailing, or wholly contained between delimiters, such as
         'data_name-{year:04d}-*-{day:02d}.txt',
         or '*-{year:04d}-{day:02d}_something.txt', where '-' is the delimiter.
+        There can not be a mixture of a template variable and '*' without a
+        delimiter in between.
 
         The 'day' format keyword may be used to specify either day of month
         (if month is included) or day of year.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -912,17 +912,17 @@ class Files(object):
         part of the name that need not be extracted.
         'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v??.cdf'
 
-        Leading wilcards are supported when parsing fixed width filenames,
+        Leading '*' wilcards are supported when parsing fixed width filenames,
         '*{year:4d}{month:02d}{day:02d}_v??.cdf', though the '*' is not
-        supported after the first template variable. The '?' wildcard stands in place
-        of a single character and may be used anywhere in the template string.
+        supported after the first template variable. The '?' wildcard
+        may be used anywhere in the template string.
 
         When parsing delimited filenames, the '*' wildcard is supported
         when leading, trailing, or wholly contained between delimiters, such as
-        'data_name-{year:04d}-*-{day:02d}.txt',
-        or '*-{year:04d}-{day:02d}*', where '-' is the delimiter.
-        There can not be a mixture of a template variable and '*' without a
-        delimiter in between, unless the '*' occurs after the variable.
+        'data_name-{year:04d}-*-{day:02d}.txt', or '*-{year:04d}-{day:02d}*',
+        where '-' is the delimiter. There can not be a mixture of a template
+        variable and '*' without a delimiter in between, unless the '*'
+        occurs after the variable.
 
         The 'day' format keyword may be used to specify either day of month
         (if month is included) or day of year.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -912,6 +912,16 @@ class Files(object):
         part of the name that need not be extracted.
         'cnofs_cindi_ivm_500ms_{year:4d}{month:02d}{day:02d}_v??.cdf'
 
+        Leading wilcards are supported when parsing fixed width filenames,
+        '*{year:4d}{month:02d}{day:02d}_v??.cdf', though the '*' is not
+        supported after the first template variable, thus
+        '*{year:4d}{month:02d}{day:02d}_v*.cdf' will not work.
+
+        When parsing delimited filenames, the '*' wildcard is supported
+        when wholly contained between delimiters, such as
+        'data_name-{year:04d}-*-{day:02d}.txt',
+        or '*-{year:04d}-{day:02d}_something.txt', where '-' is the delimiter.
+
         The 'day' format keyword may be used to specify either day of month
         (if month is included) or day of year.
 

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -920,9 +920,9 @@ class Files(object):
         When parsing delimited filenames, the '*' wildcard is supported
         when leading, trailing, or wholly contained between delimiters, such as
         'data_name-{year:04d}-*-{day:02d}.txt',
-        or '*-{year:04d}-{day:02d}_something.txt', where '-' is the delimiter.
+        or '*-{year:04d}-{day:02d}*', where '-' is the delimiter.
         There can not be a mixture of a template variable and '*' without a
-        delimiter in between.
+        delimiter in between, unless the '*' occurs after the variable.
 
         The 'day' format keyword may be used to specify either day of month
         (if month is included) or day of year.

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -948,11 +948,8 @@ class Files(object):
                                        "(dir_path)")))
 
         # Parse format string to figure out which search string should be used
-        # to identify files in the filesystem. Different option required if
-        # filename is delimited
-        wildcard = False if delimiter is None else True
-        search_dict = futils.construct_searchstring_from_format(
-            format_str, wildcard=wildcard)
+        # to identify files in the filesystem.
+        search_dict = futils.construct_searchstring_from_format(format_str)
         search_str = search_dict['search_string']
 
         # Perform the local file search

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -48,10 +48,7 @@ import datetime as dt
 import pysat
 
 # Assign the pysat logger to the local log commands, as these functions will
-# all be executed within pysat.  If this is the only instance pysat is used,
-# consider omitting the pysat import and logger assignment and replacing it
-# with:
-# from pysat import logger
+# all be executed within pysat.
 logger = pysat.logger
 
 # ----------------------------------------------------------------------------

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -189,17 +189,17 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
 
     Parameters
     ----------
-    tag : string
+    tag : str
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. (default='')
-    inst_id : string
+    inst_id : str
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. (default='')
-    data_path : string
+    data_path : str
         Full path to directory containing files to be loaded. This
         is provided by pysat. The user may specify their own data path
         at Instrument instantiation and it will appear here. (default=None)
-    format_str : string
+    format_str : str
         String template used to parse the datasets filenames. If a user
         supplies a template string at Instrument instantiation
         then it will appear here, otherwise defaults to None. (default=None)
@@ -222,20 +222,32 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
     ----
     The returned Series should not have any duplicate datetimes. If there are
     multiple versions of a file the most recent version should be kept and the
-    rest discarded. This routine uses the pysat.Files.from_os constructor, thus
-    the returned files are up to pysat specifications.
+    rest discarded. This routine uses the `pysat.Files.from_os` constructor,
+    thus the returned files are up to pysat specifications.
 
     Multiple data levels may be supported via the 'tag' input string.
-    Multiple instruments via the inst_id string.
+    Multiple instruments via the `inst_id` string.
 
     """
 
     if format_str is None:
-        # user did not supply an alternative format template string
-        format_str = 'example_name_{year:04d}_{month:02d}_{day:02d}.nc'
-    # we use a pysat provided function to grab list of files from the
-    # local file system that match the format defined above
-    file_list = pysat.Files.from_os(data_path=data_path, format_str=format_str)
+        # User did not supply an alternative format template string
+        format_str = 'example-name_{year:04d}_{month:02d}_{day:02d}.nc'
+
+    # We use a pysat provided function to grab list of files from the
+    # local file system that match the format defined above. This example
+    # is set to parse filenames from the local system using the delimiter '_'.
+    # Alternately, leaving the `delimiter` to the default of `None` will
+    # engage the fixed width filename parser. Given the range of standards
+    # compliance across the decades of space science both parsers have
+    # been expanded to improve robustness. In practice then, either parser
+    # may be used for most filenames. Both are still included to account for
+    # currently unknown edge cases users may encounter. The delimited parser
+    # has better support for using the '*' wildcard with the caveat that
+    # the '*' can potentially produce false positives if a directory has
+    # multiple instrument files that satisfy the same format string pattern.
+    file_list = pysat.Files.from_os(data_path=data_path, format_str=format_str,
+                                    delimiter='_')
 
     return file_list
 
@@ -253,19 +265,19 @@ def download(date_array, tag, inst_id, data_path=None, user=None, password=None,
     date_array : array-like
         list of datetimes to download data for. The sequence of dates need not
         be contiguous.
-    tag : string
+    tag : str
         Tag identifier used for particular dataset. This input is provided by
         pysat. (default='')
-    inst_id : string
+    inst_id : str
         Satellite ID string identifier used for particular dataset. This input
         is provided by pysat. (default='')
-    data_path : string
+    data_path : str
         Path to directory to download data to. (default=None)
-    user : string (OPTIONAL)
+    user : str (OPTIONAL)
         User string input used for download. Provided by user and passed via
         pysat. If an account is required for dowloads this routine here must
         error if user not supplied. (default=None)
-    password : string (OPTIONAL)
+    password : str (OPTIONAL)
         Password for data download. (default=None)
     custom_keywords : placeholder
         Additional keywords supplied by user when invoking the download
@@ -289,12 +301,12 @@ def load(fnames, tag=None, inst_id=None, custom_keyword=None):
     fnames : array-like
         iterable of filename strings, full path, to data files to be loaded.
         This input is nominally provided by pysat itself.
-    tag : string
+    tag : str
         tag name used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. While
         tag defaults to None here, pysat provides '' as the default
         tag unless specified by user at Instrument instantiation. (default='')
-    inst_id : string
+    inst_id : str
         Satellite ID used to identify particular data set to be loaded.
         This input is nominally provided by pysat itself. (default='')
     custom_keyword : type to be set
@@ -370,16 +382,16 @@ def list_remote_files(tag, inst_id, user=None, password=None):
 
     Parameters
     -----------
-    tag : string or NoneType
+    tag : str or NoneType
         Denotes type of file to load.  Accepted types are <tag strings>.
         (default=None)
-    inst_id : string or NoneType
+    inst_id : str or NoneType
         Specifies the satellite ID for a constellation.  Not used.
         (default=None)
-    user : string or NoneType
+    user : str or NoneType
         Username to be passed along to resource with relevant data.
         (default=None)
-    password : string or NoneType
+    password : str or NoneType
         User password to be passed along to resource with relevant data.
         (default=None)
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -235,14 +235,16 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None):
     # local file system that match the format defined above. This example
     # is set to parse filenames from the local system using the delimiter '_'.
     # Alternately, leaving the `delimiter` to the default of `None` will
-    # engage the fixed width filename parser. Given the range of standards
-    # compliance across the decades of space science both parsers have
-    # been expanded to improve robustness. In practice then, either parser
-    # may be used for most filenames. Both are still included to account for
-    # currently unknown edge cases users may encounter. The delimited parser
-    # has better support for using the '*' wildcard with the caveat that
-    # the '*' can potentially produce false positives if a directory has
-    # multiple instrument files that satisfy the same format string pattern.
+    # engage the fixed width filename parser. If there is not a common
+    # delimiter then the fixed width parser is suggested though not always
+    # required. Given the range of standards compliance across the decades of
+    # space science both parsers have been expanded to improve robustness.
+    # In practice then, either parser may be used for most filenames.
+    # Both are still included to account for currently unknown edge cases
+    # users may encounter. The delimited parser has better support for
+    # using the '*' wildcard with the caveat that the '*' can potentially
+    # produce false positives if a directory has multiple instrument files
+    # that satisfy the same format string pattern.
     file_list = pysat.Files.from_os(data_path=data_path, format_str=format_str,
                                     delimiter='_')
 

--- a/pysat/instruments/templates/template_instrument.py
+++ b/pysat/instruments/templates/template_instrument.py
@@ -234,17 +234,17 @@ def list_files(tag='', inst_id='', data_path=None, format_str=None):
     # We use a pysat provided function to grab list of files from the
     # local file system that match the format defined above. This example
     # is set to parse filenames from the local system using the delimiter '_'.
-    # Alternately, leaving the `delimiter` to the default of `None` will
-    # engage the fixed width filename parser. If there is not a common
-    # delimiter then the fixed width parser is suggested though not always
-    # required. Given the range of standards compliance across the decades of
-    # space science both parsers have been expanded to improve robustness.
-    # In practice then, either parser may be used for most filenames.
-    # Both are still included to account for currently unknown edge cases
-    # users may encounter. The delimited parser has better support for
-    # using the '*' wildcard with the caveat that the '*' can potentially
-    # produce false positives if a directory has multiple instrument files
-    # that satisfy the same format string pattern.
+    # Alternately, leaving the `delimiter` to the default of `None` in the
+    # `from_os` function call below will engage the fixed width filename parser.
+    # If there is not a common delimiter then the fixed width parser is
+    # suggested though not always required. Given the range of standards
+    # compliance across the decades of space science both parsers have been
+    # expanded to improve robustness. In practice then, either parser may be
+    # used for most filenames. Both are still included to account for currently
+    # unknown edge cases users may encounter. The delimited parser has better
+    # support for using the '*' wildcard with the caveat that the '*' can
+    # potentially produce false positives if a directory has multiple instrument
+    # files that satisfy the same format string pattern.
     file_list = pysat.Files.from_os(data_path=data_path, format_str=format_str,
                                     delimiter='_')
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -345,6 +345,53 @@ class TestBasics(object):
 
         return
 
+    @pytest.mark.parametrize("root_fname,root_pname",
+                             [[''.join(['pysat_1234567_junk_{year:04d}_gold_',
+                                       '{day:03d}_stuff.pysat_testing_file']),
+                               ''.join(['pysat_*_junk_{year:04d}_gold_',
+                                        '{day:03d}_stuff.pysat_testing_file'])],
+                              [''.join(['pysat_1234567_junk_{year:04d}_gold_',
+                                        '{day:03d}_stuff.pysat_testing_file']),
+                               ''.join(['pysat_123*_junk_{year:04d}_',
+                                        'gold_{day:03d}_stuff.pysat_testing',
+                                        '_file'])],
+                              [''.join(['pysat_1234567_junk_{year:04d}_gold_',
+                                        '{day:03d}_stuff.pysat_testing_file']),
+                               ''.join(['{code:5s}_{code2:7s}_*_{year:04d}',
+                                        '_*_{day:03d}_*.*_*_*'])],
+                              [''.join(['pysat_1234567_junk_{year:04d}_gold_',
+                                        '{day:03d}_stuff.pysat_testing_file']),
+                               ''.join(['{code:5s}_{code2:7s}_*_{year:04d}',
+                                        '_*_{day:03d}_*.*'])]
+                              ])
+    @pytest.mark.parametrize("delimiter", ['_'])
+    def test_from_os_wilcards(self, delimiter, root_fname, root_pname):
+        """Check that Files.from_os generates file list wildcards."""
+
+        # Truth dates
+        dates = pysat.utils.time.create_date_range(self.start, self.stop, '1D')
+
+        # Create a bunch of files by year and doy
+        create_files(self.testInst, self.start, self.stop, freq='1D',
+                     root_fname=root_fname, version=self.version,
+                     use_doy=True)
+
+        # Use `from_os` function to get pandas Series of files and dates
+        files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
+                                    format_str=root_pname, delimiter=delimiter)
+
+        # Ensure sorted and increasing
+        assert files.index.is_monotonic_increasing
+
+        # Check overall length
+        assert len(files) == len(dates)
+
+        # Check specific date
+        fdates = [pds.to_datetime(item) for item in files.index]
+        assert np.all(files.index == dates)
+
+        return
+
     def test_instrument_has_no_files(self):
         """Test that instrument generates empty file list if no files."""
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -296,7 +296,6 @@ class TestBasics(object):
         assert len(files) == len(dates)
 
         # Check specific date
-        fdates = [pds.to_datetime(item) for item in files.index]
         assert np.all(files.index == dates)
 
         return
@@ -386,7 +385,6 @@ class TestBasics(object):
         assert len(files) == len(dates)
 
         # Check specific date
-        fdates = [pds.to_datetime(item) for item in files.index]
         assert np.all(files.index == dates)
 
         return

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -420,9 +420,6 @@ class TestBasics(object):
                                user_vars, truth_vals):
         """Check that user vars are parsed from filenames."""
 
-        # Truth dates
-        dates = pysat.utils.time.create_date_range(self.start, self.stop, '10D')
-
         # Create a bunch of files by year and doy
         create_files(self.testInst, self.start, self.stop, freq='10D',
                      root_fname=root_fname, version=self.version,
@@ -451,9 +448,6 @@ class TestBasics(object):
         for var, truth in zip(user_vars, truth_vals):
             assert var in stored
             assert np.all(stored[var] == [truth] * len(stored[var]))
-
-        # Check specific dates
-        assert np.all(files.index == dates)
 
         return
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -238,6 +238,12 @@ class TestBasics(object):
                              [[''.join(['pysat_testing_junk_{year:04d}_gold_',
                                        '{day:03d}_stuff.pysat_testing_file']),
                                '1D', True],
+                              [''.join(['{year:04d}_gold_pysat_testing_junk_',
+                                        '{day:03d}_stuff.pysat_testing_file']),
+                               '1D', True],
+                              [''.join(['{year:04d}{day:03d}.pysat_testing_',
+                                        'file']),
+                               '1D', True],
                               [''.join(['pysat_testing_junk_{year:04d}',
                                         '{day:03d}_stuff.pysat_testing_file']),
                                '1D', True],
@@ -282,6 +288,10 @@ class TestBasics(object):
         # Use `from_os` function to get pandas Series of files and dates
         files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
                                     format_str=root_fname, delimiter=delimiter)
+
+        # Ensure sorted and increasing
+        assert files.index.is_monotonic_increasing
+
         # Check overall length
         assert len(files) == len(dates)
 
@@ -291,24 +301,6 @@ class TestBasics(object):
 
         return
 
-    @pytest.mark.parametrize("delimiter", [None, '_'])
-    def test_year_month_files_direct_call_to_from_os(self, delimiter):
-        """Test that `Files.from_os` generates file list for monthly files."""
-        # create a bunch of files by year and doy
-        root_fname = ''.join(('pysat_testing_junk_{year:04d}_gold_stuff',
-                              '_{month:02d}.pysat_testing_file'))
-        create_files(self.testInst, self.start, self.stop, freq='1MS',
-                     root_fname=root_fname, version=self.version)
-        # use from_os function to get pandas Series of files and dates
-        files = pysat.Files.from_os(data_path=self.testInst.files.data_path,
-                                    format_str=root_fname, delimiter=delimiter)
-        # check overall length
-        assert len(files) == 24
-        # check specific dates
-        assert pds.to_datetime(files.index[0]) == dt.datetime(2008, 1, 1)
-        assert pds.to_datetime(files.index[11]) == dt.datetime(2008, 12, 1)
-        assert pds.to_datetime(files.index[-1]) == dt.datetime(2009, 12, 1)
-        return
 
     def test_instrument_has_no_files(self):
         """Test that instrument generates empty file list if no files."""

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -360,7 +360,15 @@ class TestBasics(object):
                               [''.join(['pysat_1234567_junk_{year:04d}_gold_',
                                         '{day:03d}_stuff.pysat_testing_file']),
                                ''.join(['{code:5s}_{code2:7s}_*_{year:04d}',
-                                        '_*_{day:03d}_*.*'])]
+                                        '_*_{day:03d}_*.*'])],
+                              [''.join(['pysat_1234567_junk_{year:04d}_gold_',
+                                        '{day:03d}stuff.pysat_testing_file']),
+                               ''.join(['{code:5s}_{code2:7s}_*_{year:04d}',
+                                        '_*_{day:03d}*.*'])],
+                              [''.join(['pysat_1234567_junk_{year:04d}_gold_',
+                                        '{day:03d}stuff.pysat_testing_file']),
+                               ''.join(['*_*_*_{year:04d}',
+                                        '_*_{day:03d}*'])],
                               ])
     @pytest.mark.parametrize("delimiter", ['_'])
     def test_from_os_wilcards(self, delimiter, root_fname, root_pname):

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -301,22 +301,21 @@ class TestBasics(object):
 
         return
 
-    @pytest.mark.parametrize("root_fname,root_pname,freq,use_doy",
+    @pytest.mark.parametrize("root_fname,root_pname",
                              [[''.join(['pysat_1234567_junk_{year:04d}_gold_',
                                        '{day:03d}_stuff.pysat_testing_file']),
                                ''.join(['pysat_{code:7s}_junk_{year:04d}_gold_',
-                                        '{day:03d}_stuff.pysat_testing_file']),
-                               '1D', True],
+                                        '{day:03d}_stuff.pysat_testing_file'])],
                               [''.join(['pysat_1234567_junk_{year:04d}_gold_',
                                         '{day:03d}_stuff.pysat_testing_file']),
-                               ''.join(['pysat_123{code:4s}_junk_{year:04d}_gold_',
-                                        '{day:03d}_stuff.pysat_testing_file']),
-                               '1D', True],
+                               ''.join(['pysat_123{code:4s}_junk_{year:04d}_',
+                                        'gold_{day:03d}_stuff.pysat_testing',
+                                        '_file'])],
                               [''.join(['pysat_1234567_junk_{year:04d}_gold_',
                                         '{day:03d}_stuff.pysat_testing_file']),
-                               ''.join(['{code:5s}_{code2:7s}_junk_{year:04d}_gold_',
-                                        '{day:03d}_stuff.pysat_testing_file']),
-                               '1D', True]
+                               ''.join(['{code:5s}_{code2:7s}_junk_{year:04d}',
+                                        '_gold_{day:03d}_stuff.pysat_testing',
+                                        '_file'])]
                               ])
     @pytest.mark.parametrize("delimiter", [None, '_'])
     def test_from_os_user_vars(self, delimiter, root_fname, root_pname):

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -272,7 +272,21 @@ class TestBasics(object):
                                '1MS', False]])
     @pytest.mark.parametrize("delimiter", [None, '_'])
     def test_from_os(self, delimiter, root_fname, freq, use_doy):
-        """Check that Files.from_os generates file list."""
+        """Check that Files.from_os generates file list.
+
+        Parameters
+        ----------
+        delimiter : str
+            Delimiter to parse filename. None for fixed width parsing.
+        root_fname : str
+            Template string used to create filenames.
+        freq : str
+            File frequency string, `create_date_range`.
+        use_doy : bool
+            If True, during creation the day of year is used. If False,
+            the day in the month is used.
+
+        """
 
         # Truth dates
         dates = pysat.utils.time.create_date_range(self.start, self.stop, freq)
@@ -319,7 +333,18 @@ class TestBasics(object):
                               ])
     @pytest.mark.parametrize("delimiter", [None, '_'])
     def test_from_os_user_vars(self, delimiter, root_fname, root_pname):
-        """Check that Files.from_os works with user vars."""
+        """Check that Files.from_os works with user vars.
+
+        Parameters
+        ----------
+        delimiter : str
+            Delimiter to parse filename. None for fixed width parsing.
+        root_fname : str
+            Template string used to create filenames.
+        root_pname : str
+            Template string used when parsing filenames.
+
+        """
 
         # Truth dates
         dates = pysat.utils.time.create_date_range(self.start, self.stop, '1D')
@@ -373,7 +398,18 @@ class TestBasics(object):
                               ])
     @pytest.mark.parametrize("delimiter", ['_'])
     def test_from_os_wilcards(self, delimiter, root_fname, root_pname):
-        """Check that Files.from_os works with delimited names and wildcards."""
+        """Check that Files.from_os works with delimited names and wildcards.
+
+        Parameters
+        ----------
+        delimiter : str
+            Delimiter to parse filename. None for fixed width parsing.
+        root_fname : str
+            Template string used to create filenames.
+        root_pname : str
+            Template string used when parsing filenames.
+
+        """
 
         # Truth dates
         dates = pysat.utils.time.create_date_range(self.start, self.stop, '1D')
@@ -418,7 +454,22 @@ class TestBasics(object):
     @pytest.mark.parametrize("delimiter", ['_', None])
     def test_user_vars_parsing(self, delimiter, root_fname, root_pname,
                                user_vars, truth_vals):
-        """Check that user vars are parsed from filenames."""
+        """Check that user vars are parsed from filenames.
+
+        Parameters
+        ----------
+        delimiter : str
+            Delimiter to parse filename. None for fixed width parsing.
+        root_fname : str
+            Template string used to create filenames.
+        root_pname : str
+            Template string used when parsing filenames.
+        user_vars : list
+            List of user template variables in `root_pname`
+        truth_vals : list
+            List of values `user_vars` maps to in `root_fname`
+
+        """
 
         # Create a bunch of files by year and doy
         create_files(self.testInst, self.start, self.stop, freq='10D',
@@ -463,7 +514,16 @@ class TestBasics(object):
                                         '{year:04d}_{d:4}_{day:03d}_{code2:5d}',
                                        '.{final_code:18}'])]])
     def test_wilcard_searching(self, root_fname, root_pname):
-        """Check that searching with wildcard=True works."""
+        """Check that searching with wildcard=True works.
+
+        Parameters
+        ----------
+        root_fname : str
+            Template string used to create filenames.
+        root_pname : str
+            Template string used when parsing filenames.
+
+        """
 
         # Create a bunch of files by year and doy
         create_files(self.testInst, self.start, self.stop, freq='10D',

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -319,7 +319,7 @@ class TestBasics(object):
                               ])
     @pytest.mark.parametrize("delimiter", [None, '_'])
     def test_from_os_user_vars(self, delimiter, root_fname, root_pname):
-        """Check that Files.from_os generates file list with user vars."""
+        """Check that Files.from_os works with user vars."""
 
         # Truth dates
         dates = pysat.utils.time.create_date_range(self.start, self.stop, '1D')
@@ -366,7 +366,7 @@ class TestBasics(object):
                               ])
     @pytest.mark.parametrize("delimiter", ['_'])
     def test_from_os_wilcards(self, delimiter, root_fname, root_pname):
-        """Check that Files.from_os generates file list wildcards."""
+        """Check that Files.from_os works with delimited names and wildcards."""
 
         # Truth dates
         dates = pysat.utils.time.create_date_range(self.start, self.stop, '1D')

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -301,7 +301,6 @@ class TestBasics(object):
 
         return
 
-
     def test_instrument_has_no_files(self):
         """Test that instrument generates empty file list if no files."""
 

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -18,6 +18,7 @@ import pysat.instruments.pysat_testing
 from pysat.tests.classes.cls_ci import CICleanSetup
 from pysat.utils import files as futils
 
+
 def create_dir(inst=None, temporary_file_list=False):
     """Create a temporary datset directory for a test instrument."""
     if inst is None:
@@ -451,6 +452,9 @@ class TestBasics(object):
             assert var in stored
             assert np.all(stored[var] == [truth] * len(stored[var]))
 
+        # Check specific dates
+        assert np.all(files.index == dates)
+
         return
 
     @pytest.mark.parametrize("root_fname,root_pname",
@@ -466,9 +470,6 @@ class TestBasics(object):
                                        '.{final_code:18}'])]])
     def test_wilcard_searching(self, root_fname, root_pname):
         """Check that searching with wildcard=True works."""
-
-        # Truth dates
-        dates = pysat.utils.time.create_date_range(self.start, self.stop, '10D')
 
         # Create a bunch of files by year and doy
         create_files(self.testInst, self.start, self.stop, freq='10D',

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -340,7 +340,6 @@ class TestBasics(object):
         assert len(files) == len(dates)
 
         # Check specific date
-        fdates = [pds.to_datetime(item) for item in files.index]
         assert np.all(files.index == dates)
 
         return

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -364,7 +364,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         For example,
         `instrument_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf`
     wildcard : bool
-        If True, replaces each '?' sequence with a single '*'.
+        If True, replaces each '?' sequence that would normally
+        be returned with a single '*'.
 
     Returns
     -------

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -227,7 +227,9 @@ def parse_delimited_filenames(files, format_str, delimiter):
     every parsed item to be a variable, and more than one variable
     may be within a parsed section. Thus, the main practical
     difference with `parse_fixed_width_filenames` is more support for
-    the use of the wildcard '*' within `format_str`.
+    the use of the wildcard '*' within `format_str`. Overuse
+    of the '*' wildcard increases the probability of false positive matches
+    if there are multiple instrument files in the directory.
 
     Parameters
     ----------
@@ -276,7 +278,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
         return stored
 
     # Parse format string to get information needed to parse filenames
-    search_dict = construct_searchstring_from_format(format_str, wildcard=True)
+    search_dict = construct_searchstring_from_format(format_str, wildcard=False)
     snips = search_dict['string_blocks']
     keys = search_dict['keys']
     lengths = search_dict['lengths']

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -168,12 +168,9 @@ def parse_fixed_width_filenames(files, format_str):
 
     # Parse format string to get information needed to parse filenames
     search_dict = construct_searchstring_from_format(format_str)
-    snips = search_dict['string_blocks']
-    lengths = search_dict['lengths']
-    keys = search_dict['keys']
 
     # Add non-standard keys
-    for key in keys:
+    for key in search_dict['keys']:
         if key not in stored:
             stored[key] = []
 
@@ -182,11 +179,11 @@ def parse_fixed_width_filenames(files, format_str):
     idx = 0
     begin_key = []
     end_key = []
-    for i, snip in enumerate(snips):
+    for i, snip in enumerate(search_dict['string_blocks']):
         idx += len(snip)
-        if i < len(lengths):
+        if i < len(search_dict['lengths']):
             begin_key.append(idx)
-            idx += lengths[i]
+            idx += search_dict['lengths'][i]
             end_key.append(idx)
     max_len = idx
 
@@ -196,7 +193,7 @@ def parse_fixed_width_filenames(files, format_str):
 
     # Need to parse out dates for datetime index
     for i, temp in enumerate(files):
-        for j, key in enumerate(keys):
+        for j, key in enumerate(search_dict['keys']):
             if key_str_idx[1][j] == 0:
                 # Last element is a variable to be parsed out
                 val = temp[key_str_idx[0][j]:]

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -430,11 +430,6 @@ def construct_searchstring_from_format(format_str, wildcard=False):
             else:
                 raise ValueError("Couldn't determine formatting width")
 
-    # Last block could potentially end upon a variable that needs to be parsed,
-    # rather than a string. Check for this condition.
-    if snip[1] is not None:
-        out_dict['string_blocks'].append('')
-
     return out_dict
 
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -287,7 +287,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
     search_dict = construct_searchstring_from_format(format_str, wildcard=False)
 
     # Add non-standard keys
-    for key in keys:
+    for key in search_dict['keys']:
         if key not in stored:
             stored[key] = None
 
@@ -339,8 +339,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
             for j, sidx in enumerate(loop_split_idx):
                 if sidx is not None:
                     # Pull out value from filename and shorten str.
-                    val = loop_sname[sidx:sidx + lengths[idx]]
-                    loop_sname = loop_sname[sidx + lengths[idx]:]
+                    val = loop_sname[sidx:sidx + search_dict['lengths'][idx]]
+                    loop_sname = loop_sname[sidx + search_dict['lengths'][idx]:]
 
                     # Store parsed info and increment key index
                     stored[search_dict['keys'][idx]].append(val)

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -161,7 +161,7 @@ def parse_fixed_width_filenames(files, format_str):
 
     if len(files) == 0:
         stored['files'] = []
-        # include format string as convenience for later functions
+        # Include format string as convenience for later functions
         stored['format_str'] = format_str
         return stored
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -360,7 +360,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
 
     A standards compliant filename can be constructed by adding the first
     element from `string_blocks`, then the first item in `keys`, and iterating
-    until all items are used.
+    that alternating pattern until all items are used.
     """
 
     out_dict = {'search_string': '', 'keys': [], 'lengths': [],

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -124,10 +124,6 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 def parse_fixed_width_filenames(files, format_str):
     """Parse list of files, extracting data identified by `format_str`.
 
-    Uses the fixed-width format of the filename to find and parse
-    out variable information. The functions begins at the end of the filename,
-    parsing towards the begining.
-
     Parameters
     ----------
     files : list

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -196,7 +196,11 @@ def parse_fixed_width_filenames(files, format_str):
     # Need to parse out dates for datetime index
     for i, temp in enumerate(files):
         for j, key in enumerate(keys):
-            val = temp[key_str_idx[0][j]:key_str_idx[1][j]]
+            if key_str_idx[1][j] == 0:
+                # Last element is a variable to be parsed out
+                val = temp[key_str_idx[0][j]:]
+            else:
+                val = temp[key_str_idx[0][j]:key_str_idx[1][j]]
             stored[key].append(val)
 
     # Convert to numpy arrays
@@ -425,6 +429,11 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                         break
             else:
                 raise ValueError("Couldn't determine formatting width")
+
+    # Last block could potentially end upon a variable that needs to be parsed,
+    # rather than a string. Check for this condition.
+    if snip[1] is not None:
+        out_dict['string_blocks'].append('')
 
     return out_dict
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -127,7 +127,8 @@ def parse_fixed_width_filenames(files, format_str):
     Parameters
     ----------
     files : list
-        List of files
+        List of files, typically provided by
+        `files.search_local_system_formatted_filename`.
     format_str : str
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
@@ -238,7 +239,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
     Parameters
     ----------
     files : list
-        List of files
+        List of files, typically provided by
+        `files.search_local_system_formatted_filename`.
     format_str : str
         Provides the naming pattern of the instrument files and the
         locations of date information so an ordered list may be produced.
@@ -390,6 +392,9 @@ def construct_searchstring_from_format(format_str, wildcard=False):
     A standards compliant filename can be constructed by adding the first
     element from `string_blocks`, then the first item in `keys`, and iterating
     that alternating pattern until all items are used.
+
+    This is the first function employed by `pysat.Files.from_os`.
+
     """
 
     out_dict = {'search_string': '', 'keys': [], 'lengths': [],
@@ -446,6 +451,8 @@ def search_local_system_formatted_filename(data_path, search_str):
     search_str : str
         String used to search for local files. For example,
         `cnofs_cindi_ivm_500ms_????????_v??.cdf` or `inst-name-*-v??.cdf`
+        Typically this input is provided by
+        `files.construct_searchstring_from_format`.
 
     Returns
     -------

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -293,7 +293,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
                     # Found template variable marker, pull out value
                     # from filename.
                     val = loop_sname[sidx:sidx + lengths[idx]]
-                    loop_rname = loop_rname[sidx+2:]
+                    loop_rname = loop_rname[sidx + 2:]
                     loop_sname = loop_sname[sidx + lengths[idx]:]
 
                 if stored[keys[idx]] is None:

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -343,7 +343,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
                     loop_sname = loop_sname[sidx + lengths[idx]:]
 
                     # Store parsed info and increment key index
-                    stored[keys[idx]].append(val)
+                    stored[search_dict['keys'][idx]].append(val)
                     idx += 1
                 else:
                     # No variable to be parsed, remove indices from

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -226,16 +226,16 @@ def parse_delimited_filenames(files, format_str, delimiter):
         'month', 'day', 'hour', 'minute', 'second', 'version', 'revision',
         and 'cycle' will be used for time and sorting information. For example,
         `instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf`
-    delimiter : string
+    delimiter : str
         Delimiter string upon which files will be split (e.g., '.')
 
     Returns
     -------
     stored : collections.OrderedDict
-        Information parsed from filenames that inclues: 'year', 'month', 'day',
-        'hour', 'minute', 'second', 'version', 'revision', and 'cycle'.  Also
-        includes 'files', an input list of files, and 'format_str', a formatted
-        string from input
+        Information parsed from filenames that includes: 'year', 'month', 'day',
+        'hour', 'minute', 'second', 'version', 'revision', and 'cycle', as
+        well as any other user provided template variables. Also
+        includes `files`, an input list of files, and `format_str`.
 
     """
 
@@ -283,7 +283,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
         for i, (sname, rname) in enumerate(zip(split_name, split_recon)):
             loop_rname = rname
             loop_sname = sname
-            loop_len = 0
+
             while True:
                 sidx = loop_rname.find('{}')
                 if sidx < 0:

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -224,8 +224,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
     """Parse list of files, extracting data identified by format_str.
 
     Will parse file using `delimiter` though the function does not require
-    every delimited item to be a variable, and more than one variable
-    may be within a delimited section. Thus, the main practical
+    every parsed item to be a variable, and more than one variable
+    may be within a parsed section. Thus, the main practical
     difference with `parse_fixed_width_filenames` is more support for
     the use of the wildcard '*' within `format_str`.
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -360,8 +360,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         For example,
         `instrument_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf`
     wildcard : bool
-        If True, replaces the '?' sequence with a '*'. This option may be well
-        suited when dealing with delimited filenames.
+        If True, replaces each '?' sequence with a single '*'.
 
     Returns
     -------

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -350,9 +350,8 @@ def parse_delimited_filenames(files, format_str, delimiter):
                 else:
                     # No variable to be parsed, remove indices from `lsidxs`
                     # already used.
-                    lsidxs = lsidxs[j+1:]
+                    lsidxs = lsidxs[j + 1:]
                     break
-
 
     # Convert to numpy arrays
     for key in stored.keys():

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -417,7 +417,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                         # Store length and add to the search string
                         out_dict['lengths'].append(np.int64(fwidth))
                         if not wildcard:
-                            out_dict['search_string'] += '?' * out_dict['lengths'][-1]
+                            val = '?' * out_dict['lengths'][-1]
+                            out_dict['search_string'] += val
                         else:
                             out_dict['search_string'] += '*'
                         break

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -423,7 +423,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
     form = string.Formatter()
     for snip in form.parse(format_str):
         # Collect all of the format keywords. Replace them in the string with
-        # the '?' wildcard. The numnber of '?'s corresponds to the length of
+        # the '?' wildcard. The number of '?'s corresponds to the length of
         # data to be parsed. The length is obtained from format keywords so
         # that we know later on where to parse information out from.
         out_dict['search_string'] += snip[0]
@@ -449,7 +449,10 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                             out_dict['search_string'] += '*'
                         break
             else:
-                raise ValueError("Couldn't determine formatting width")
+                estr = ''.join(["Couldn't determine formatting width. ",
+                                "This may be due to the use of unsupported ",
+                                "wildcard characters."])
+                raise ValueError(estr)
 
     return out_dict
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -116,7 +116,7 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 
             return frame['files']
         else:
-            return pds.Series(files, index=index)
+            return pds.Series(files, index=index).sort_index()
     else:
         return pds.Series(None, dtype='object')
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -124,6 +124,10 @@ def process_parsed_filenames(stored, two_digit_year_break=None):
 def parse_fixed_width_filenames(files, format_str):
     """Parse list of files, extracting data identified by `format_str`.
 
+    Uses the fixed-width format of the filename to find and parse
+    out variable information. The functions begins at the end of the filename,
+    parsing towards the begining.
+
     Parameters
     ----------
     files : list
@@ -134,7 +138,8 @@ def parse_fixed_width_filenames(files, format_str):
         Supports all provided string formatting codes though only 'year',
         'month', 'day', 'hour', 'minute', 'second', 'version', 'revision',
         and 'cycle' will be used for time and sorting information. For example,
-        `instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf`
+        `instrument-{year:4d}_{month:02d}-{day:02d}_v{version:02d}.cdf`, or
+        `*-{year:4d}_{month:02d}hithere{day:02d}_v{version:02d}.cdf`
 
     Returns
     -------
@@ -143,6 +148,13 @@ def parse_fixed_width_filenames(files, format_str):
         'hour', 'minute', 'second', 'version', 'revision', and 'cycle', as
         well as any other user provided template variables. Also
         includes `files`, an input list of files, and `format_str`.
+
+    Note
+    ----
+    The function uses the lengths of the fixed characters within `format_str`,
+    as well as the supplied lengths for template variables, to determine
+    where to parse out information. Thus, support for the wildcard '*' is
+    limited to locations before the first template variable.
 
     """
 
@@ -215,6 +227,12 @@ def parse_fixed_width_filenames(files, format_str):
 def parse_delimited_filenames(files, format_str, delimiter):
     """Parse list of files, extracting data identified by format_str.
 
+    Will parse file using `delimiter` though the function does not require
+    every delimited item to be a variable, and more than one variable
+    may be within a delimited section. Thus, the main practical
+    difference with `parse_fixed_width_filenames` is more support for
+    the use of the wildcard '*' within `format_str`.
+
     Parameters
     ----------
     files : list
@@ -225,7 +243,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
         Supports all provided string formatting codes though only 'year',
         'month', 'day', 'hour', 'minute', 'second', 'version', 'revision',
         and 'cycle' will be used for time and sorting information. For example,
-        `instrument_{year:4d}{month:02d}{day:02d}_v{version:02d}.cdf`
+        `*_{year:4d}_{month:02d}_{day:02d}_*_v{version:02d}_*.cdf`
     delimiter : str
         Delimiter string upon which files will be split (e.g., '.')
 
@@ -236,6 +254,15 @@ def parse_delimited_filenames(files, format_str, delimiter):
         'hour', 'minute', 'second', 'version', 'revision', and 'cycle', as
         well as any other user provided template variables. Also
         includes `files`, an input list of files, and `format_str`.
+
+    Note
+    ----
+    The '*' wildcard is supported when leading, trailing, or wholly contained
+    between delimiters, such as 'data_name-{year:04d}-*-{day:02d}.txt',
+    or '*-{year:04d}*-*-{day:02d}*', where '-' is the delimiter.
+    There can not be a mixture of a template variable and '*' without a
+    delimiter in between, unless the '*' occurs after the variables. The
+    '*' should not be used to replace the delimited character in the filename.
 
     """
 


### PR DESCRIPTION
# Description

Addresses #763, #762

- Added support for user supplied variables in file template strings, not just those used for dates.
- Improved support for delimited filenames. More than one variable can be within a single delimited section. Delimited sections are not required to have a variable.
- Updated docstring in `from_os` as well as supporting methods. 
- Added tests for delimited filenames, user variables, and wildcard use.
- Condensed existing tests
- Output from `process_parsed_filenames` is now always sorted

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Verified parsing delimited filenames now works on COSMIC. COSMIC filenames violate a strict interpretation of delimited information. Two examples using the `fixed_width` parser, two examples using the delimited parser.
```
pysat.Files.from_os(data_path, '{year2:04d}.{day2:03d}/ionPrf_C{sat_id:03d}.{year:04d}.{day:03d}.{hour:02d}.{minute:02d}.???_????.????_nc')
pysat.Files.from_os(data_path, '{year2:04d}.{day2:03d}/ionPrf_C{sat_id:03d}.{year:04d}.{day:03d}.{hour:02d}.{minute:02d}.G{code:02d}_{year3:04d}.{radio:04d}_nc')
pysat.Files.from_os(data_path, '{year2:04d}.{day2:03d}/ionPrf_C{sat_id:03d}.{year:04d}.{day:03d}.{hour:02d}.{minute:02d}.{code:8}.{radio:04d}_nc', delimiter='.')
pysat.Files.from_os(data_path, '{year2:04d}.{day2:03d}/ionPrf_C{sat_id:03d}.{year:04d}.{day:03d}.{hour:02d}.{minute:02d}.*.{radio:04d}_nc', delimiter='.')
```
<img width="660" alt="image" src="https://user-images.githubusercontent.com/3595641/151458528-68eccb69-1805-424d-bb9b-48ba616a5569.png">

 - Added unit tests

**Test Configuration**:
* Operating system: MacOS
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
