### PR TITLE
ENH/DEP: timestamp conversions for xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Deprecated `pysat.Instrument._filter_netcdf4_metadata` and replaced it
      with `pysat.utils.io.filter_netcdf4_metadata`.
    * Changed `fname` from a kwarg to an arg in `pysat.Instruments.to_netcdf4`
+   * Deprecated `pysat.instruments.methods.general.convert_timestamp_to_datetime`
+     which is replaced by new functionality in `load_netCDF4`.
 * Documentation
    * Moved logo to 'docs\images'
    * Improved consistency of headers throughout documentation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-[3.1.0] - 2021-XX-XX
+[3.1.0] - 2022-XX-XX
 --------------------
 * New Features
    * Added the property `empty_partial` to the Constellation class

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -4,6 +4,7 @@
 import datetime as dt
 import numpy as np
 import pandas as pds
+import warnings
 
 import pysat
 
@@ -148,6 +149,11 @@ def list_files(tag=None, inst_id=None, data_path=None, format_str=None,
 def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
     """Use datetime instead of timestamp for Epoch.
 
+    .. deprecated:: 3.1.0
+        This routine has been deprecated with the addition of the kwargs
+        `epoch_unit` and `epoch_origin` to `pysat.utils.io.load_netcdf4`.
+        This routing will be removed in 3.2.0.
+
     Parameters
     ----------
     inst : pysat.Instrument
@@ -158,6 +164,11 @@ def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
         variable name for instrument index (default='Epoch')
 
     """
+
+    warnings.warn(" ".join(["New kwargs added to `pysat.utils.io.load_netCDF4`",
+                            "for generalized handling, deprecated",
+                            "function will be removed in pysat 3.2.0+"]),
+                  DeprecationWarning, stacklevel=2)
 
     inst.data[epoch_name] = pds.to_datetime(
         [dt.datetime.utcfromtimestamp(int(np.floor(epoch_time * sec_mult)))

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -163,6 +163,11 @@ def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
     epoch_name : str
         variable name for instrument index (default='Epoch')
 
+    Note
+    ----
+    If the variable represented by epoch_name is not a float64, data is passed
+    through unchanged.
+
     """
 
     warnings.warn(" ".join(["New kwargs added to `pysat.utils.io.load_netCDF4`",
@@ -170,9 +175,10 @@ def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
                             "function will be removed in pysat 3.2.0+"]),
                   DeprecationWarning, stacklevel=2)
 
-    inst.data[epoch_name] = pds.to_datetime(
-        [dt.datetime.utcfromtimestamp(int(np.floor(epoch_time * sec_mult)))
-         for epoch_time in inst.data[epoch_name]])
+    if inst.data[epoch_name].dtype == 'float64':
+        inst.data[epoch_name] = pds.to_datetime(
+            [dt.datetime.utcfromtimestamp(int(np.floor(epoch_time * sec_mult)))
+             for epoch_time in inst.data[epoch_name]])
 
     return
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -146,7 +146,7 @@ def load(fnames, tag=None, inst_id=None, malformed_index=False,
         index[6:9] = [index[6]] * 3
 
     data.index = index
-    data.index.name = 'epoch'
+    data.index.name = 'Epoch'
     # higher rate time signal (for scalar >= 2)
     # this time signal used for 2D profiles associated with each time in main
     # DataFrame

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -4,6 +4,7 @@ import datetime as dt
 from os import path
 import pandas as pds
 import pytest
+import warnings
 
 import pysat
 from pysat.instruments.methods import general as gen
@@ -259,4 +260,38 @@ class TestLoadCSVData(object):
         assert isinstance(self.data.index, pds.DatetimeIndex)
         self.eval_data_cols()
         assert len(self.data.columns) == len(self.data_cols)
+        return
+
+class TestDeprecation(object):
+    """Unit tests for deprecated methods."""
+
+    def setup(self):
+        """Set up the unit test environment for each method."""
+
+        warnings.simplefilter("always", DeprecationWarning)
+        return
+
+    def teardown(self):
+        """Clean up the unit test environment after each method."""
+
+        return
+
+    def test_convert_timestamp_to_datetime(self):
+        """Test that convert_timestamp_to_datetime is deprecated."""
+
+        warn_msgs = [" ".join(
+            ["New kwargs added to `pysat.utils.io.load_netCDF4`",
+             "for generalized handling, deprecated",
+             "function will be removed in pysat 3.2.0+"])]
+
+        test = pysat.Instrument('pysat', 'testing')
+        test.load(2009, 1)
+        with warnings.catch_warnings(record=True) as war:
+            gen.convert_timestamp_to_datetime(test, epoch_name='uts')
+
+        # Ensure the minimum number of warnings were raised
+        assert len(war) >= len(warn_msgs)
+
+        # Test the warning messages, ensuring each attribute is present
+        pysat.utils.testing.eval_warnings(war, warn_msgs)
         return

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -262,6 +262,7 @@ class TestLoadCSVData(object):
         assert len(self.data.columns) == len(self.data_cols)
         return
 
+
 class TestDeprecation(object):
     """Unit tests for deprecated methods."""
 

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -298,8 +298,10 @@ class TestLoadNetCDF(object):
             loaded_delta = np.diff(self.loaded_inst.index[:2])
         else:
             default_delta = np.diff(self.testInst[self.epoch_name][:2])
+
             # Average over 4 deltas to prevent rounding errors
             loaded_delta = np.diff(self.loaded_inst[test_epoch][:5]).mean()
+
         # Ratio of step_sizes should equal ratio of interpreted units
         assert ((default_delta / loaded_delta)
                 == (dt.timedelta(seconds=1) / target))
@@ -320,6 +322,7 @@ class TestLoadNetCDF(object):
             load_uts = pds.to_datetime(self.loaded_inst[test_epoch][0].values)
             default_start = (def_uts - unix_origin)
             loaded_start = (load_uts - file_origin)
+
         # Ratio of distances should equal ratio of interpreted units
         assert (default_start.total_seconds() / loaded_start.total_seconds()
                 == (dt.timedelta(seconds=1) / target))

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -275,7 +275,8 @@ class TestLoadNetCDF(object):
         outfile = os.path.join(self.tempdir.name,
                                'pysat_{:}_ncdf.nc'.format(self.testInst.name))
         self.testInst.load(date=self.stime, use_header=True)
-        # TODO(#991): remove once custom epochs are integrated into `io.inst_to_netcdf for xarray
+        # TODO(#991): remove once custom epochs are integrated into 
+        # `io.inst_to_netcdf` for xarray instruments.
         if not self.testInst.pandas_format:
             # A distinct epoch name must be used for the saved xarray dataset.
             test_epoch = 'test_epoch'

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -282,6 +282,9 @@ class TestLoadNetCDF(object):
             # Xarray testing requires conversion to integer with ms default
             self.testInst.data[test_epoch] = \
                 self.testInst[self.epoch_name].astype('int64') / 1.e6
+        else:
+            if 'epoch_name' in kwargs:
+                kwargs.pop('epoch_name')
 
         io.inst_to_netcdf(self.testInst, fname=outfile)
 

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -278,10 +278,6 @@ class TestLoadNetCDF(object):
 
         """
 
-        # TODO(#947) Expand to xarray objects once functionality is updated
-        if not self.testInst.pandas_format:
-            pytest.skip('Not yet implemented for xarray')
-
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.testInst.files.data_path,
                                'pysat_test_ncdf.nc')

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -275,7 +275,7 @@ class TestLoadNetCDF(object):
         outfile = os.path.join(self.tempdir.name,
                                'pysat_{:}_ncdf.nc'.format(self.testInst.name))
         self.testInst.load(date=self.stime, use_header=True)
-        # TODO(#991): remove once custom epochs are integrated into 
+        # TODO(#991): remove once custom epochs are integrated into
         # `io.inst_to_netcdf` for xarray instruments.
         if not self.testInst.pandas_format:
             # A distinct epoch name must be used for the saved xarray dataset.

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -275,6 +275,7 @@ class TestLoadNetCDF(object):
         outfile = os.path.join(self.tempdir.name,
                                'pysat_{:}_ncdf.nc'.format(self.testInst.name))
         self.testInst.load(date=self.stime, use_header=True)
+        # TODO(#991): remove once custom epochs are integrated into `io.inst_to_netcdf for xarray
         if not self.testInst.pandas_format:
             # A distinct epoch name must be used for the saved xarray dataset.
             test_epoch = 'test_epoch'

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -365,6 +365,8 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         data, meta = load_netcdf_xarray(fnames, strict_meta=strict_meta,
                                         file_format=file_format,
                                         epoch_name=epoch_name,
+                                        epoch_unit=epoch_unit,
+                                        epoch_origin=epoch_origin,
                                         decode_timedelta=decode_timedelta,
                                         labels=labels)
 
@@ -654,7 +656,8 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
 
 
 def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
-                       epoch_name='Epoch', decode_timedelta=False,
+                       epoch_name='Epoch', epoch_unit='ms', epoch_origin='unix',
+                       decode_timedelta=False,
                        labels={'units': ('units', str),
                                'name': ('long_name', str),
                                'notes': ('notes', str), 'desc': ('desc', str),
@@ -678,7 +681,23 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         'NETCDF3_CLASSIC', 'NETCDF3_64BIT', 'NETCDF4_CLASSIC', or 'NETCDF4'.
         (default='NETCDF4')
     epoch_name : str
-        Data key for time variable (default='Epoch')
+        Data key for epoch variable.  The epoch variable is expected to be an
+        array of integer or float values denoting time elapsed from an origin
+        specified by `epoch_origin` with units specified by `epoch_unit`. This
+        epoch variable will be converted to a `DatetimeIndex` for consistency
+        across pysat instruments.  (default='Epoch')
+    epoch_unit : str
+        The pandas-defined unit of the epoch variable ('D', 's', 'ms', 'us',
+        'ns'). (default='ms')
+    epoch_origin : str or timestamp-convertable
+        Origin of epoch calculation, following convention for
+        `pandas.to_datetime`.  Accepts timestamp-convertable objects, as well as
+        two specific strings for commonly used calendars.  These conversions are
+        handled by `pandas.to_datetime`.
+        If ‘unix’ (or POSIX) time; origin is set to 1970-01-01.
+        If ‘julian’, `epoch_unit` must be ‘D’, and origin is set to beginning of
+        Julian Calendar. Julian day number 0 is assigned to the day starting at
+        noon on January 1, 4713 BC. (default='unix')
     decode_timedelta : bool
         If True, variables with unit attributes that are 'timelike' ('hours',
         'minutes', etc) are converted to `np.timedelta64`. (default=False)

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -499,7 +499,9 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
                 elif dim[1] == epoch_name:
                     obj_key = dim[0]
                 else:
-                    raise KeyError('Epoch not found!')
+                    estr = ''.join(['"', epoch_name, '"', ' not found in [',
+                                    ', '.join(dim), ']'])
+                    raise KeyError(estr)
 
                 # Collect variable names associated with dimension
                 idx_bool = [dim == i for i in two_d_dims]

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -499,7 +499,8 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
                 elif dim[1] == epoch_name:
                     obj_key = dim[0]
                 else:
-                    estr = ''.join(['"', epoch_name, '"', ' not found in [',
+                    estr = ''.join(['Epoch label: "', epoch_name, '"',
+                                    ' was not found in loaded dimensions [',
                                     ', '.join(dim), ']'])
                     raise KeyError(estr)
 

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -735,9 +735,15 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
                                  combine='by_coords')
 
-    # Prepare xarray index for this netcdf file
-    data[epoch_name] = pds.to_datetime(data[epoch_name], unit=epoch_unit,
-                                       origin=epoch_origin)
+    # If epoch can be converted to a datetime, convert
+    try:
+        data[epoch_name] = xr.DataArray(pds.to_datetime(data[epoch_name],
+                                                        unit=epoch_unit,
+                                                        origin=epoch_origin),
+                                        coords=data[epoch_name].coords)
+    except (KeyError, ValueError):
+        # Value does not exist or cannot be converted to datetime
+        pass
 
     # Copy the variable attributes from the data object to the metadata
     for key in data.variables.keys():

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -735,9 +735,9 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
                                  combine='by_coords')
 
-    # TODO(#947) Add conversion for timestamps that may have been treated
-    # incorrectly, including origin and unit.  At the moment this is only done
-    # for Pandas data.
+    # Prepare xarray index for this netcdf file
+    data[epoch_name] = pds.to_datetime(data[epoch_name], unit=epoch_unit,
+                                       origin=epoch_origin)
 
     # Copy the variable attributes from the data object to the metadata
     for key in data.variables.keys():

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -738,15 +738,14 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
                                  combine='by_coords')
 
-    # If epoch can be converted to a datetime, convert
-    try:
+    # If epoch exists, convert to datetime object.
+    # TODO(#991): epoch does not necessarily exist.  May need to update if
+    # assumptions about time change.
+    if epoch_name in data.variables:
         data[epoch_name] = xr.DataArray(pds.to_datetime(data[epoch_name],
                                                         unit=epoch_unit,
                                                         origin=epoch_origin),
                                         coords=data[epoch_name].coords)
-    except (KeyError, ValueError):
-        # Value does not exist or cannot be converted to datetime
-        pass
 
     # Copy the variable attributes from the data object to the metadata
     for key in data.variables.keys():
@@ -1271,6 +1270,8 @@ def inst_to_netcdf(inst, fname, base_instrument=None, epoch_name='Epoch',
         # the Instrument data object is unchanged.
         xr_data = xr.Dataset(inst.data)
         pysat_meta_to_xarray_attr(xr_data, inst.meta, export_nan)
+
+        # TODO(#991): custom epoch_name should be implemented if it exists.
 
         # If the case needs to be preserved, update Dataset variables
         if preserve_meta_case:


### PR DESCRIPTION
# Description

Addresses #947

The timestamp conversion for datasets loaded using `io.load_netcdf` is not consistently handled in pandas and xarray.  This fixes that issue so there are not separate workflows for data types.  Note that `io.inst_to_netcdf` still needs to be updated.  That is documented in #991.

Converts timestamps for `xarray` datasets in a manner similar to the conversion for `pandas` datasets.  Deprecates the function `instruments.methods.general.convert_timestamp_to_datetime` as this is used by some instruments outside of the core code to convert timestamps for xarray objects.

Note that if the deprecated function `convert_timestamp_to_datetime` is run on a variable already converted to datetime, it is now passed through unchanged.  This allows for backwards compatibility for outside packaged until the deprecated function is removed.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Loading data from `pysatNASA`: icon_euv, icon_fuv, icon_mighti

Example:
```
import datetime as dt
import pysat
euv = pysat.Instrument('icon', 'euv')
euv.download(dt.datetime(2020, 1, 1), dt.datetime(2020, 1, 1)
euv.load(2020, 1)
euv['Epoch']
```
The data array should be `dtype='datetime64[ns]'`

- Loading data with the develop code should load as normal.  The changes here update the preprocess routine to leave data unchanged if the data is not a float.
- Comment out the preprocess line `mm_gen.convert_timestamp_to_datetime(self, sec_mult=1.0e-3)` on line 106 in the euv file.

This ensures that pysatNASA behaviour will continue across versions.

**Test Configuration**:
* Operating system: Mac OS X 11.6.3
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release

part of changelog line 35 from previous pull