### PR TITLE
STY: remove temporary init variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -121,6 +121,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Updated tests in `test_meta` to search all warnings, not just the first
    * Updated pandas syntax to be compatible with pandas 2.0 (pandas 1.4
      deprecations)
+   * Cleaned up excess variables upon import
 
 [3.0.1] - 2021-07-28
 --------------------

--- a/pysat/constellations/__init__.py
+++ b/pysat/constellations/__init__.py
@@ -8,3 +8,5 @@ __all__ = ['testing', 'testing_empty', 'single_test']
 
 for const in __all__:
     exec("from pysat.constellations import {:}".format(const))
+
+del const

--- a/pysat/instruments/__init__.py
+++ b/pysat/instruments/__init__.py
@@ -9,3 +9,5 @@ __all__ = ['pysat_netcdf', 'pysat_testing', 'pysat_testing_xarray',
 
 for inst in __all__:
     exec("from pysat.instruments import {x}".format(x=inst))
+
+del inst


### PR DESCRIPTION
# Description

Addresses #829

Deletes temporary variables invoked as part of certain init files.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest, importing pysat and loading instruments.

**Test Configuration**:
* Operating system: Mac 11.6.3
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
