### PR TITLE
DOC: update deprecation info

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1665,7 +1665,7 @@ class Instrument(object):
                                  export_nan=None):
         """Filter metadata properties to be consistent with netCDF4.
 
-        .. deprecated:: 3.1.0
+        .. deprecated:: 3.0.2
             Moved to `pysat.utils.io.filter_netcdf4_metadata. This wrapper
             will be removed in 3.2.0+.
 
@@ -3458,7 +3458,7 @@ class Instrument(object):
                    unlimited_time=True, modify=False):
         """Store loaded data into a netCDF4 file.
 
-        .. deprecated:: 3.1.0
+        .. deprecated:: 3.0.2
             Changed `fname` from a kwarg to an arg of type str in the 3.2.0+
             release.
 

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -149,7 +149,7 @@ def list_files(tag='', inst_id='', data_path='', format_str=None,
 def convert_timestamp_to_datetime(inst, sec_mult=1.0, epoch_name='Epoch'):
     """Use datetime instead of timestamp for Epoch.
 
-    .. deprecated:: 3.1.0
+    .. deprecated:: 3.0.2
         This routine has been deprecated with the addition of the kwargs
         `epoch_unit` and `epoch_origin` to `pysat.utils.io.load_netcdf4`.
         This routing will be removed in 3.2.0.

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Produces fake instrument data for testing.
 
-.. deprecated:: 3.1.0
+.. deprecated:: 3.0.2
     Support for 2d pandas objects will be removed in 3.2.0+.  This instrument
     module simulates an object that will no longer be supported.
 

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 """Produces fake instrument data for testing.
 
-.. deprecated:: 3.1.0
+.. deprecated:: 3.0.2
     All data present in this instrument is duplicated in pysat_testing2d_xarray.
     This instrument will be removed in 3.2.0+ to reduce redundancy.
 

--- a/pysat/tests/instrument_test_class.py
+++ b/pysat/tests/instrument_test_class.py
@@ -15,7 +15,7 @@ import pysat.tests.classes.cls_instrument_library as cls_inst_lib
 def initialize_test_inst_and_date(inst_dict):
     """Initialize the instrument object to test and date.
 
-    .. deprecated:: 3.1.0
+    .. deprecated:: 3.0.2
         `initialize_test_inst_and_date` will be removed in pysat 3.2.0, it is
         moved to `pysat.tests.classes.cls_instrument_library`.
 
@@ -44,7 +44,7 @@ def initialize_test_inst_and_date(inst_dict):
 class InstTestClass(cls_inst_lib.InstLibTests):
     """Provide standardized tests for pysat instrument libraries.
 
-    .. deprecated:: 3.1.0
+    .. deprecated:: 3.0.2
         `InstTestClass` will be removed in pysat 3.2.0, it is replaced by
         `pysat.tests.classes.cls_instrument_library.InstLibTests`.
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -191,7 +191,7 @@ def load_netcdf4(fnames=None, strict_meta=False, file_format='NETCDF4',
                          'fill_val': ('fill', np.float64)}):
     """Load netCDF-3/4 file produced by pysat.
 
-    .. deprecated:: 3.1.0
+    .. deprecated:: 3.0.2
        Function moved to `pysat.utils.io.load_netcdf`, this wrapper will be
        removed in the 3.2.0+ release.
        No longer allow non-string file formats in the 3.2.0+ release.


### PR DESCRIPTION
# Description

Now that pysat 3.0.2 is next on the release schedule, this updates the documentation to show that existing deprecations were added there rather than the future 3.1.0.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

using find all in atom.

**Test Configuration**:
* Operating system: Big Sur
* Version number: Python 3.8.11
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes (fixes previously documented changes in this version)

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
