### PR TITLE
ENH: allow `use_header` setting at init

### DIFF
--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -59,6 +59,11 @@ class Constellation(object):
         Input dict containing dicts of inputs for `custom_attach` method inputs
         that may be applied to all instruments or at the Constellation-level or
         None (default=None)
+    **kwargs : dict
+        Additional keyword arguments are passed to Instruments instantiated
+        within the class through use of input arguments `platforms`, `names`,
+        `tags`, and `inst_ids`. Additional keywords are not applied when
+        using the `const_module` or `instruments` inputs.
 
     Attributes
     ----------
@@ -124,7 +129,7 @@ class Constellation(object):
 
     def __init__(self, platforms=None, names=None, tags=None, inst_ids=None,
                  const_module=None, instruments=None, index_res=None,
-                 common_index=True, custom=None):
+                 common_index=True, custom=None, **kwargs):
         """Initialize the Constellation object."""
 
         # Initalize the `instruments` attribute to be an empty list before
@@ -171,7 +176,7 @@ class Constellation(object):
                                 # name, inst_id, and tag
                                 self.instruments.append(pysat.Instrument(
                                     platform=ptf, name=flg, tag=tflg,
-                                    inst_id=iid))
+                                    inst_id=iid, **kwargs))
                                 added_platforms.append(ptf)
                                 added_names.append(flg)
                                 added_tags.append(tflg)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3123,8 +3123,9 @@ class Instrument(object):
                                    'metadata (MetaHeader). Default attachment ',
                                    'of global attributes to Instrument will ',
                                    'be Deprecated in pysat 3.2.0+. Set ',
-                                   '`use_header=True` to remove this ',
-                                   'warning.']), DeprecationWarning,
+                                   '`use_header=True` in this load call or ',
+                                   'on instrument instantiation to remove this',
+                                   ' warning.']), DeprecationWarning,
                           stacklevel=2)
             self.meta.transfer_attributes_to_instrument(self)
         self.meta.mutable = False

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -326,6 +326,12 @@ class Instrument(object):
             # Get dict of supported keywords and values
             default_kwargs = _get_supported_keywords(func)
 
+            # Expand the dict to include method keywords for load.
+            # TODO(#1020): Remove this if statement for the 3.2.0+ release 
+            if fkey == 'load':
+                meth = getattr(self, fkey)
+                default_kwargs.update(_get_supported_keywords(meth))
+
             # Confirm there are no reserved keywords present
             for kwarg in kwargs.keys():
                 if kwarg in self.kwargs_reserved:
@@ -3100,8 +3106,9 @@ class Instrument(object):
                 if (self.index[-1] == last_time) & (not want_last_pad):
                     self.data = self[:-1]
 
-        # Transfer any extra attributes in meta to the Instrument object
-        if use_header:
+        # Transfer any extra attributes in meta to the Instrument object.
+        # TODO(#1020): Change the way this kwarg is handled
+        if use_header or self.kwargs['load']['use_header']:
             self.meta.transfer_attributes_to_header()
         else:
             warnings.warn(''.join(['Meta now contains a class for global ',
@@ -3529,9 +3536,10 @@ class Instrument(object):
 # Hidden variable to store pysat reserved keywords. Defined here, since these
 # values are used by both the Instrument class and a function defined below.
 # In release 3.2.0+ `freq` will be removed.
-_reserved_keywords = ['fnames', 'inst_id', 'tag', 'date_array',
-                      'data_path', 'format_str', 'supported_tags',
-                      'start', 'stop', 'freq']
+_reserved_keywords = ['inst_id', 'tag', 'date_array', 'data_path', 'format_str',
+                      'supported_tags', 'start', 'stop', 'freq', 'yr', 'doy',
+                      'end_yr', 'end_doy', 'date', 'end_date', 'fname',
+                      'fnames', 'stop_fname']
 
 
 def _kwargs_keys_to_func_name(kwargs_key):

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1420,6 +1420,9 @@ class Instrument(object):
         if load_kwargs is None:
             load_kwargs = self.kwargs['load']
 
+        # Ensure that the local optional kwarg `use_header` is not passed
+        # to the instrument routine.
+        #
         # TODO(#1020): Remove after removing `use_header`
         if 'use_header' in load_kwargs.keys():
             del load_kwargs['use_header']
@@ -3112,7 +3115,8 @@ class Instrument(object):
 
         # Transfer any extra attributes in meta to the Instrument object.
         # TODO(#1020): Change the way this kwarg is handled
-        if use_header or self.kwargs['load']['use_header']:
+        if use_header or ('use_header' in self.kwargs['load']
+                          and self.kwargs['load']['use_header']):
             self.meta.transfer_attributes_to_header()
         else:
             warnings.warn(''.join(['Meta now contains a class for global ',

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -327,7 +327,7 @@ class Instrument(object):
             default_kwargs = _get_supported_keywords(func)
 
             # Expand the dict to include method keywords for load.
-            # TODO(#1020): Remove this if statement for the 3.2.0+ release 
+            # TODO(#1020): Remove this if statement for the 3.2.0+ release
             if fkey == 'load':
                 meth = getattr(self, fkey)
                 default_kwargs.update(_get_supported_keywords(meth))
@@ -1419,6 +1419,10 @@ class Instrument(object):
         # Set default load_kwargs
         if load_kwargs is None:
             load_kwargs = self.kwargs['load']
+
+        # TODO(#1020): Remove after removing `use_header`
+        if 'use_header' in load_kwargs.keys():
+            del load_kwargs['use_header']
 
         date = pysat.utils.time.filter_datetime_input(date)
         if fid is not None:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3124,7 +3124,7 @@ class Instrument(object):
                                    'of global attributes to Instrument will ',
                                    'be Deprecated in pysat 3.2.0+. Set ',
                                    '`use_header=True` in this load call or ',
-                                   'on instrument instantiation to remove this',
+                                   'on Instrument instantiation to remove this',
                                    ' warning.']), DeprecationWarning,
                           stacklevel=2)
             self.meta.transfer_attributes_to_instrument(self)

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -46,7 +46,8 @@ class InstAccessTests(object):
         """Test Instrument object fully complete by self._init_rtn()."""
 
         # Create a base instrument to compare against
-        inst_copy = pysat.Instrument(inst_module=self.testInst.inst_module)
+        inst_copy = pysat.Instrument(inst_module=self.testInst.inst_module,
+                                     use_header=True)
 
         # Get instrument module and init funtcion
         inst_mod = self.testInst.inst_module
@@ -69,7 +70,7 @@ class InstAccessTests(object):
 
         # Instantiate instrument with test module which invokes needed test
         # code in the background
-        pysat.Instrument(inst_module=inst_mod)
+        pysat.Instrument(inst_module=inst_mod, use_header=True)
 
         # Restore nominal init function
         inst_mod.init = inst_mod_init

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -59,7 +59,8 @@ def initialize_test_inst_and_date(inst_dict):
                                  tag=inst_dict['tag'],
                                  inst_id=inst_dict['inst_id'],
                                  temporary_file_list=True,
-                                 update_files=True, **kwargs)
+                                 update_files=True, use_header=True,
+                                 **kwargs)
     test_dates = inst_dict['inst_module']._test_dates
     date = test_dates[inst_dict['inst_id']][inst_dict['tag']]
     return test_inst, date
@@ -236,7 +237,7 @@ class InstLibTests(object):
         for inst_id in module.inst_ids.keys():
             for tag in module.inst_ids[inst_id]:
                 inst = pysat.Instrument(inst_module=module, tag=tag,
-                                        inst_id=inst_id)
+                                        inst_id=inst_id, use_header=True)
 
                 # Test to see that the class parameters were passed in
                 self.assert_isinstance(inst, pysat.Instrument)

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -390,7 +390,8 @@ class InstPropertyTests(object):
                                     num_samples=10,
                                     clean_level='clean',
                                     update_files=True,
-                                    orbit_info=orbit_info)
+                                    orbit_info=orbit_info,
+                                    use_header=True)
 
         self.out = testInst.__str__()
 

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -31,7 +31,8 @@ class TestConstellationInitReg(TestWithRegistration):
 
         # Initalize the Constellation using the desired kwargs
         const = pysat.Constellation(
-            **{ikey: ivals[i] for i, ikey in enumerate(ikeys)})
+            **{ikey: ivals[i] for i, ikey in enumerate(ikeys)},
+            use_header=True)
 
         # Test that the appropriate number of Instruments were loaded. Each
         # fake Instrument has 5 tags and 1 inst_id.
@@ -59,7 +60,8 @@ class TestConstellationInitReg(TestWithRegistration):
         # Load the Constellation and capture log output
         with caplog.at_level(logging.WARNING, logger='pysat'):
             const = pysat.Constellation(platforms=['Executor', 'platname1'],
-                                        tags=[''])
+                                        tags=[''],
+                                        use_header=True)
 
         # Test the partial Constellation initialization
         assert len(const.instruments) == 2
@@ -99,7 +101,7 @@ class TestConstellationInit(object):
 
         if ikey is not None:
             self.in_kwargs[ikey] = ival
-        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
         assert len(self.const.instruments) == ilen
         return
 
@@ -140,7 +142,7 @@ class TestConstellationInit(object):
         """Test Constellation iteration through instruments attribute."""
 
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
         tst_get_inst = self.const[:]
         pysat.utils.testing.assert_lists_equal(self.instruments, tst_get_inst)
         return
@@ -149,7 +151,7 @@ class TestConstellationInit(object):
         """Test Constellation string output with instruments loaded."""
 
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
         out_str = self.const.__repr__()
 
         assert out_str.find("Constellation(instruments") >= 0
@@ -159,7 +161,7 @@ class TestConstellationInit(object):
         """Test Constellation string output with instruments loaded."""
 
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
         out_str = self.const.__str__()
 
         assert out_str.find("pysat Constellation ") >= 0
@@ -182,7 +184,7 @@ class TestConstellationInit(object):
         """Test Constellation string output with loaded data."""
 
         self.in_kwargs["common_index"] = common_index
-        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
         self.const.load(date=self.ref_time)
         out_str = self.const.__str__()
 
@@ -202,7 +204,7 @@ class TestConstellationInit(object):
 
         # Initialize the constellation
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
 
         # Add the custom function
         self.const.custom_attach(double_mlt, at_pos='end')
@@ -222,7 +224,7 @@ class TestConstellationFunc(object):
         """Set up the unit test environment for each method."""
 
         self.inst = list(constellations.testing.instruments)
-        self.const = pysat.Constellation(instruments=self.inst)
+        self.const = pysat.Constellation(instruments=self.inst, use_header=True)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.attrs = ["platforms", "names", "tags", "inst_ids", "instruments",
                       "bounds", "empty", "empty_partial", "index_res",
@@ -323,7 +325,8 @@ class TestConstellationFunc(object):
         """Test the empty index attribute."""
 
         # Test the attribute with loaded data
-        self.const = pysat.Constellation(instruments=self.inst, **ikwarg)
+        self.const = pysat.Constellation(instruments=self.inst, **ikwarg,
+                                         use_header=True)
         self.const.load(date=self.ref_time)
         assert isinstance(self.const.index, pds.Index)
         assert self.const.index[0] == self.ref_time

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -122,7 +122,8 @@ class TestBasics(object):
 
         self.testInst = pysat.Instrument(
             inst_module=pysat.instruments.pysat_testing, clean_level='clean',
-            temporary_file_list=self.temporary_file_list, update_files=True)
+            temporary_file_list=self.temporary_file_list, update_files=True,
+            use_header=True)
 
         # Create instrument directories in tempdir
         create_dir(self.testInst)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -51,6 +51,7 @@ class TestBasics(InstAccessTests, InstIntegrationTests, InstIterationTests,
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
+                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -76,6 +77,7 @@ class TestBasicsInstModule(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
+                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = imod._test_dates['']['']
         self.ref_doy = 1
@@ -102,6 +104,7 @@ class TestBasicsXarray(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
+                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = \
             pysat.instruments.pysat_testing_xarray._test_dates['']['']
@@ -128,6 +131,7 @@ class TestBasics2D(TestBasics):
                                          num_samples=50,
                                          clean_level='clean',
                                          update_files=True,
+                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = pysat.instruments.pysat_testing2d._test_dates['']['']
         self.ref_doy = 1
@@ -158,6 +162,7 @@ class TestBasics2DXarray(TestBasics):
                                          num_samples=10,
                                          clean_level='clean',
                                          update_files=True,
+                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = \
             pysat.instruments.pysat_testing2d_xarray._test_dates['']['']
@@ -270,6 +275,7 @@ class TestBasicsShiftedFileDates(TestBasics):
                                          update_files=True,
                                          mangle_file_dates=True,
                                          strict_time_flag=True,
+                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.ref_doy = 1
@@ -348,11 +354,11 @@ class TestInstGeneral(object):
 
         obj1 = pysat.Instrument(platform='pysat', name='testing',
                                 num_samples=10, clean_level='clean',
-                                update_files=True)
+                                update_files=True, use_header=True)
 
         obj2 = pysat.Instrument(platform='pysat', name='testing_xarray',
                                 num_samples=10, clean_level='clean',
-                                update_files=True)
+                                update_files=True, use_header=True)
         assert not (obj1 == obj2)
         return
 
@@ -393,7 +399,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(**self.in_kwargs)
+            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
             tinst.generic_meta_translator(tinst.meta)
 
         self.warn_msgs = np.array(["".join(["This function has been deprecated",
@@ -408,7 +414,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(**self.in_kwargs)
+            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
             tinst.download(start=self.ref_time, freq='D')
 
         self.warn_msgs = np.array(["".join(["`pysat.Instrument.download` kwarg",
@@ -434,7 +440,7 @@ class TestDeprecation(object):
 
         # Catch the warnings.
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(inst_module=inst_module)
+            tinst = pysat.Instrument(inst_module=inst_module, use_header=True)
 
         # Ensure attributes set properly.
         assert tinst._test_download_ci is False
@@ -448,7 +454,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(**self.in_kwargs)
+            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
             tinst.load(date=self.ref_time, use_header=True)
             mdata_dict = tinst.meta._data.to_dict()
             tinst._filter_netcdf4_metadata(mdata_dict,
@@ -470,7 +476,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(**self.in_kwargs)
+            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
             try:
                 tinst.to_netcdf4()
             except ValueError:
@@ -497,7 +503,7 @@ class TestDeprecation(object):
         """
 
         with warnings.catch_warnings(record=True) as self.war:
-            pysat.Instrument('pysat', 'testing', **kwargs)
+            pysat.Instrument('pysat', 'testing', use_header=True, **kwargs)
 
         self.warn_msgs = np.array(["".join(["The usage of None in `tag` and ",
                                             "`inst_id` has been deprecated ",
@@ -534,7 +540,7 @@ class TestDeprecation(object):
     def test_set_2d_pandas_data(self):
         """Check that setting 2d data for pandas raises a DeprecationWarning."""
 
-        test_inst = pysat.Instrument('pysat', 'testing2d')
+        test_inst = pysat.Instrument('pysat', 'testing2d', use_header=True)
         test_date = pysat.instruments.pysat_testing2d._test_dates['']['']
         test_inst.load(date=test_date)
         with warnings.catch_warnings(record=True) as war:

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -517,8 +517,10 @@ class TestDeprecation(object):
                                             'Default attachment of global ',
                                             'attributes to Instrument will be',
                                             ' Deprecated in pysat 3.2.0+. Set ',
-                                            '`use_header=True` to remove this ',
-                                            'warning.'])])
+                                            '`use_header=True` in this load ',
+                                            'call or on Instrument ',
+                                            'instantiation to remove this',
+                                            ' warning.'])])
 
         # Capture the warnings
         with warnings.catch_warnings(record=True) as self.war:

--- a/pysat/tests/test_instrument_custom.py
+++ b/pysat/tests/test_instrument_custom.py
@@ -43,7 +43,7 @@ class TestLogging(object):
 
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
                                          clean_level='clean',
-                                         update_files=False)
+                                         update_files=False, use_header=True)
         self.out = ''
         return
 
@@ -74,7 +74,7 @@ class TestBasics(object):
 
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
                                          clean_level='clean',
-                                         update_files=True)
+                                         update_files=True, use_header=True)
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.load(date=self.load_date)
         self.custom_args = [2]
@@ -235,7 +235,8 @@ class TestBasicsXarray(TestBasics):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
-                                         num_samples=10, clean_level='clean')
+                                         num_samples=10, clean_level='clean',
+                                         use_header=True)
         self.load_date = pysat.instruments.pysat_testing_xarray._test_dates
         self.load_date = self.load_date['']['']
         self.testInst.load(date=self.load_date)
@@ -258,7 +259,7 @@ class TestConstellationBasics(object):
         self.testConst = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
                              clean_level='clean',
-                             update_files=True)
+                             update_files=True, use_header=True)
             for i in range(5)])
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testConst.load(date=self.load_date)

--- a/pysat/tests/test_instrument_custom.py
+++ b/pysat/tests/test_instrument_custom.py
@@ -74,7 +74,8 @@ class TestBasics(object):
 
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
                                          clean_level='clean',
-                                         update_files=True, use_header=True)
+                                         update_files=True,
+                                         use_header=True)
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.load(date=self.load_date)
         self.custom_args = [2]
@@ -258,8 +259,8 @@ class TestConstellationBasics(object):
 
         self.testConst = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
-                             clean_level='clean',
-                             update_files=True, use_header=True)
+                             clean_level='clean', update_files=True,
+                             use_header=True)
             for i in range(5)])
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testConst.load(date=self.load_date)
@@ -370,7 +371,8 @@ class TestConstellationBasics(object):
                   {'function': mult_data, 'args': self.custom_args}]
         testConst2 = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
-                             clean_level='clean', custom=custom)
+                             clean_level='clean', custom=custom,
+                             use_header=True)
             for i in range(5)])
 
         # Ensure all instruments within both constellations have the same
@@ -398,7 +400,7 @@ class TestConstellationBasics(object):
                    'apply_inst': False}]
         testConst2 = pysat.Constellation(
             instruments=[pysat.Instrument('pysat', 'testing', num_samples=10,
-                                          clean_level='clean')
+                                          clean_level='clean', use_header=True)
                          for i in range(5)], custom=custom)
 
         # Ensure both constellations have the same custom_* attributes

--- a/pysat/tests/test_instrument_index.py
+++ b/pysat/tests/test_instrument_index.py
@@ -21,7 +21,8 @@ class TestMalformedIndex(object):
                                          clean_level='clean',
                                          malformed_index=True,
                                          update_files=True,
-                                         strict_time_flag=True)
+                                         strict_time_flag=True,
+                                         use_header=True)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         return
@@ -54,7 +55,8 @@ class TestMalformedIndexXArray(TestMalformedIndex):
                                          clean_level='clean',
                                          malformed_index=True,
                                          update_files=True,
-                                         strict_time_flag=True)
+                                         strict_time_flag=True,
+                                         use_header=True)
         self.ref_time = dt.datetime(2009, 1, 1)
         self.ref_doy = 1
         return

--- a/pysat/tests/test_instrument_padding.py
+++ b/pysat/tests/test_instrument_padding.py
@@ -26,12 +26,14 @@ class TestDataPaddingbyFile(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad={'minutes': 5},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
 
         self.rawInst = pysat.Instrument(platform='pysat', name='testing',
                                         clean_level='clean',
-                                        update_files=True)
+                                        update_files=True,
+                                        use_header=True)
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
         return
@@ -134,13 +136,15 @@ class TestDataPaddingbyFileXarray(TestDataPaddingbyFile):
                                          name='testing_xarray',
                                          clean_level='clean',
                                          pad={'minutes': 5},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
 
         self.rawInst = pysat.Instrument(platform='pysat',
                                         name='testing_xarray',
                                         clean_level='clean',
-                                        update_files=True)
+                                        update_files=True,
+                                        use_header=True)
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
         return
@@ -163,12 +167,14 @@ class TestOffsetRightFileDataPaddingBasics(TestDataPaddingbyFile):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.rawInst = pysat.Instrument(platform='pysat', name='testing',
                                         tag='',
                                         clean_level='clean',
                                         update_files=True,
-                                        sim_multi_file_right=True)
+                                        sim_multi_file_right=True,
+                                        use_header=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
@@ -193,12 +199,14 @@ class TestOffsetRightFileDataPaddingBasicsXarray(TestDataPaddingbyFile):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.rawInst = pysat.Instrument(platform='pysat',
                                         name='testing_xarray',
                                         clean_level='clean',
                                         update_files=True,
-                                        sim_multi_file_right=True)
+                                        sim_multi_file_right=True,
+                                        use_header=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
@@ -222,11 +230,13 @@ class TestOffsetLeftFileDataPaddingBasics(TestDataPaddingbyFile):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.rawInst = pysat.Instrument(platform='pysat', name='testing',
                                         clean_level='clean',
                                         update_files=True,
-                                        sim_multi_file_left=True)
+                                        sim_multi_file_left=True,
+                                        use_header=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
@@ -249,7 +259,8 @@ class TestDataPadding(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad={'minutes': 5},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
         self.delta = dt.timedelta(minutes=5)
@@ -289,7 +300,8 @@ class TestDataPadding(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad=pad,
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.eval_index_start_end()
         return
@@ -323,7 +335,8 @@ class TestDataPadding(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad={'days': 2},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
 
         testing.eval_bad_input(self.testInst.load, ValueError,
                                'Data padding window must be shorter than ',
@@ -454,7 +467,8 @@ class TestDataPaddingXArray(TestDataPadding):
                                          name='testing_xarray',
                                          clean_level='clean',
                                          pad={'minutes': 5},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
         self.delta = dt.timedelta(minutes=5)
@@ -478,7 +492,8 @@ class TestMultiFileRightDataPaddingBasics(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -504,7 +519,8 @@ class TestMultiFileRightDataPaddingBasicsXarray(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -530,7 +546,8 @@ class TestMultiFileLeftDataPaddingBasics(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -556,7 +573,8 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5})
+                                         pad={'minutes': 5},
+                                         use_header=True)
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -66,10 +66,11 @@ class TestInstruments(InstLibTests):
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         if kwarg:
             self.test_inst = pysat.Instrument(
-                inst_module=inst_dict['inst_module'], start_time=kwarg)
+                inst_module=inst_dict['inst_module'], start_time=kwarg,
+                use_header=True)
         else:
             self.test_inst = pysat.Instrument(
-                inst_module=inst_dict['inst_module'])
+                inst_module=inst_dict['inst_module'], use_header=True)
 
         self.test_inst.load(date=date)
 
@@ -85,7 +86,7 @@ class TestInstruments(InstLibTests):
         num = 10
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
-                                          num_samples=num)
+                                          num_samples=num, use_header=True)
         self.test_inst.load(date=date)
 
         assert len(self.test_inst['uts']) == num
@@ -100,7 +101,7 @@ class TestInstruments(InstLibTests):
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
                                           file_date_range=file_date_range,
-                                          update_files=True)
+                                          update_files=True, use_header=True)
         file_list = self.test_inst.files.files
 
         assert all(file_date_range == file_list.index)
@@ -111,7 +112,8 @@ class TestInstruments(InstLibTests):
         """Test operation of max_latitude keyword."""
 
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
-        self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'])
+        self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
+                                          use_header=True)
         if self.test_inst.name != 'testmodel':
             self.test_inst.load(date=date, max_latitude=10.)
             assert np.all(np.abs(self.test_inst['latitude']) <= 10.)
@@ -200,7 +202,8 @@ class TestDeprecation(object):
 
         with warnings.catch_warnings(record=True) as war:
             pysat.Instrument(inst_module=getattr(pysat.instruments,
-                                                 inst_module))
+                                                 inst_module),
+                             use_header=True)
 
         warn_msgs = [" ".join(["The instrument module",
                                "`{:}`".format(inst_module),

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -67,7 +67,7 @@ class TestMeta(object):
         """
         if inst_kwargs is not None:
             # Load the test Instrument
-            self.testInst = pysat.Instrument(**inst_kwargs)
+            self.testInst = pysat.Instrument(**inst_kwargs, use_header=True)
             stime = self.testInst.inst_module._test_dates['']['']
             self.testInst.load(date=stime)
 
@@ -1963,7 +1963,8 @@ class TestMetaMutable(object):
     def setup(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument(platform='pysat', name='testing')
+        self.testInst = pysat.Instrument(platform='pysat', name='testing',
+                                         use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         self.meta = self.testInst.meta
         self.meta.mutable = True
@@ -2165,7 +2166,8 @@ class TestToDict(object):
     def setup(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5)
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.load(date=self.stime)
 
@@ -2243,7 +2245,7 @@ class TestToDictXarray(TestToDict):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.stime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
         self.testInst.load(date=self.stime)
 
@@ -2260,7 +2262,7 @@ class TestToDictXarray2D(TestToDict):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'testing2d_xarray',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.stime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
         self.testInst.load(date=self.stime)
 
@@ -2277,7 +2279,7 @@ class TestToDictPandas2D(TestToDict):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'testing2d',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.stime = pysat.instruments.pysat_testing2d._test_dates['']['']
         self.testInst.load(date=self.stime)
 
@@ -2294,7 +2296,7 @@ class TestToDictXarrayModel(TestToDict):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'testmodel',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.stime = pysat.instruments.pysat_testmodel._test_dates['']['']
         self.testInst.load(date=self.stime)
 

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -92,7 +92,7 @@ class TestRemoveLeadText(object):
 
         # Load a test instrument
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12,
-                                         clean_level='clean')
+                                         clean_level='clean', use_header=True)
         self.testInst.load(2009, 1)
         self.npts = len(self.testInst['uts'])
         return
@@ -178,7 +178,8 @@ class TestRemoveLeadTextXarray(TestRemoveLeadText):
         # Load a test instrument
         self.testInst = pysat.Instrument('pysat', 'testing2d_xarray',
                                          num_samples=12,
-                                         clean_level='clean')
+                                         clean_level='clean',
+                                         use_header=True)
         self.testInst.load(2009, 1)
         self.npts = len(self.testInst['uts'])
         return
@@ -297,7 +298,7 @@ class TestDeprecation(object):
              "for generalized handling, deprecated",
              "function will be removed in pysat 3.2.0+"])]
 
-        test = pysat.Instrument('pysat', 'testing')
+        test = pysat.Instrument('pysat', 'testing', use_header=True)
         test.load(2009, 1)
         with warnings.catch_warnings(record=True) as war:
             gen.convert_timestamp_to_datetime(test, epoch_name='uts')

--- a/pysat/tests/test_methods_testing.py
+++ b/pysat/tests/test_methods_testing.py
@@ -16,7 +16,7 @@ class TestBasics(object):
     def setup(self):
         """Set up the unit test environment for each method."""
 
-        self.test_inst = pysat.Instrument('pysat', 'testing')
+        self.test_inst = pysat.Instrument('pysat', 'testing', use_header=True)
 
         # Get list of filenames.
         self.fnames = [self.test_inst.files.files.values[0]]

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -131,6 +131,7 @@ class TestOrbitsUserInterface(object):
         """Test orbit failure on iteration with orbit initialization."""
 
         self.in_kwargs['orbit_info'] = info
+        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
         self.testInst.load(date=self.stime)
 
@@ -158,6 +159,7 @@ class TestOrbitsUserInterface(object):
         """
 
         self.in_kwargs['orbit_info'] = info
+        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
 
         # Force index to None beforee loading and iterating
@@ -171,6 +173,7 @@ class TestOrbitsUserInterface(object):
         """Test the Orbit representation."""
 
         self.in_kwargs['orbit_info'] = {'index': 'mlt'}
+        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
         out_str = self.testInst.orbits.__repr__()
 
@@ -181,6 +184,7 @@ class TestOrbitsUserInterface(object):
         """Test the Orbit string representation with data."""
 
         self.in_kwargs['orbit_info'] = {'index': 'mlt'}
+        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
         self.testInst.load(date=self.stime)
         out_str = self.testInst.orbits.__str__()
@@ -199,7 +203,8 @@ class TestSpecificUTOrbits(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.inc_min = 97
         self.etime = None
@@ -359,7 +364,8 @@ class TestGeneralOrbitsMLT(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -559,7 +565,8 @@ class TestGeneralOrbitsMLTxarray(TestGeneralOrbitsMLT):
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
         return
 
@@ -586,7 +593,8 @@ class TestGeneralOrbitsNonStandardIteration(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.testInst.bounds = (self.testInst.files.files.index[0],
                                 self.testInst.files.files.index[11],
                                 '2D', dt.timedelta(days=3))
@@ -641,7 +649,8 @@ class TestGeneralOrbitsLong(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
                                                      'kind': 'longitude'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -662,7 +671,8 @@ class TestGeneralOrbitsLongXarray(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
                                                      'kind': 'longitude'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -683,7 +693,8 @@ class TestGeneralOrbitsOrbitNumber(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
                                                      'kind': 'orbit'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -704,7 +715,8 @@ class TestGeneralOrbitsOrbitNumberXarray(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
                                                      'kind': 'orbit'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
         return
 
@@ -725,7 +737,8 @@ class TestGeneralOrbitsLatitude(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
                                                      'kind': 'polar'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -746,7 +759,8 @@ class TestGeneralOrbitsLatitudeXarray(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
                                                      'kind': 'polar'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing_xarray._test_dates['']['']
         return
 
@@ -787,7 +801,8 @@ class TestOrbitsGappyData(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -819,7 +834,8 @@ class TestOrbitsGappyDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True)
+                                         update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -860,7 +876,8 @@ class TestOrbitsGappyData2(object):
 
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
-                                         orbit_info={'index': 'mlt'})
+                                         orbit_info={'index': 'mlt'},
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.custom_attach(filter_data, kwargs={'times': self.times})
         return
@@ -888,7 +905,8 @@ class TestOrbitsGappyData2Xarray(TestOrbitsGappyData2):
 
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          clean_level='clean',
-                                         orbit_info={'index': 'mlt'})
+                                         orbit_info={'index': 'mlt'},
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.custom_attach(filter_data, kwargs={'times': self.times})
         return
@@ -909,7 +927,8 @@ class TestOrbitsGappyLongData(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
-                                                     'kind': 'longitude'})
+                                                     'kind': 'longitude'},
+                                         use_header=True)
 
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
@@ -932,7 +951,8 @@ class TestOrbitsGappyLongDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
-                                                     'kind': 'longitude'})
+                                                     'kind': 'longitude'},
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -954,7 +974,8 @@ class TestOrbitsGappyOrbitNumData(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
-                                                     'kind': 'orbit'})
+                                                     'kind': 'orbit'},
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -976,7 +997,8 @@ class TestOrbitsGappyOrbitNumDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
-                                                     'kind': 'orbit'})
+                                                     'kind': 'orbit'},
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -998,7 +1020,8 @@ class TestOrbitsGappyOrbitLatData(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
-                                                     'kind': 'polar'})
+                                                     'kind': 'polar'},
+                                         use_header=True)
 
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
@@ -1021,7 +1044,8 @@ class TestOrbitsGappyOrbitLatDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
-                                                     'kind': 'polar'})
+                                                     'kind': 'polar'},
+                                         use_header=True)
 
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -68,7 +68,8 @@ class TestUpdateLon(object):
     def test_update_longitude(self, name):
         """Test `update_longitude` successful run."""
 
-        self.py_inst = pysat.Instrument(platform='pysat', name=name)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name,
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
 
         # Test instruments initially define longitude between 0-360 deg
@@ -85,7 +86,8 @@ class TestUpdateLon(object):
     def test_bad_lon_name_update_longitude(self):
         """Test update_longitude with a bad longitude name."""
 
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing")
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing",
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
 
         testing.eval_bad_input(coords.update_longitude, ValueError,
@@ -123,7 +125,7 @@ class TestCalcSLT(object):
 
         # Instantiate instrument and load data
         self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        num_samples=1)
+                                        num_samples=1, use_header=True)
         self.py_inst.load(date=self.inst_time)
 
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -147,7 +149,7 @@ class TestCalcSLT(object):
 
         # Instantiate instrument and load data
         self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        num_samples=1)
+                                        num_samples=1, use_header=True)
         self.py_inst.load(date=self.inst_time)
 
         # Apply solar local time method and capture logging output
@@ -166,7 +168,8 @@ class TestCalcSLT(object):
         """Test calc_solar_local_time with longitudes from -180 to 180 deg."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing")
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing",
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
 
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -184,7 +187,8 @@ class TestCalcSLT(object):
         """Test raises ValueError with a bad longitude name."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing")
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing",
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
 
         # Test that the correct Exception and error message are raised
@@ -201,7 +205,8 @@ class TestCalcSLT(object):
         """Test calc_solar_local_time with longitude coordinates."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name,
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
                                      slt_name='slt')
@@ -217,7 +222,8 @@ class TestCalcSLT(object):
         """Test non modulated solar local time output for a 2 day range."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name,
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time,
                           end_date=self.inst_time + dt.timedelta(days=2))
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -235,7 +241,8 @@ class TestCalcSLT(object):
         """Test non modulated SLT output for a 2 day range with a ref date."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name,
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time, end_date=self.inst_time
                           + dt.timedelta(days=2))
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -255,7 +262,8 @@ class TestCalcSLT(object):
         """Test SLT calc with longitude coordinates and no modulus."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name,
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
                                      slt_name='slt', apply_modulus=False)
@@ -270,7 +278,8 @@ class TestCalcSLT(object):
         """Test calc_solar_local_time with a single longitude value."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing_xarray")
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing_xarray",
+                                        use_header=True)
         self.py_inst.load(date=self.inst_time)
         lon_name = 'lon2'
 

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -152,13 +152,15 @@ class TestFileDirectoryTranslations(CICleanSetup):
         self.insts_kwargs = []
 
         # Data by day, ACE SIS data
-        self.insts.append(pysat.Instrument('ace', 'sis', tag='historic'))
+        self.insts.append(pysat.Instrument('ace', 'sis', tag='historic',
+                                           use_header=True))
         test_dates = pysatSpaceWeather.instruments.ace_sis._test_dates
         self.insts_dates.append([test_dates['']['historic']] * 2)
         self.insts_kwargs.append({})
 
         # Data with date mangling, regular F10.7 data, stored monthly
-        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic'))
+        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic',
+                                           use_header=True))
         test_dates = pysatSpaceWeather.instruments.sw_f107._test_dates
         self.insts_dates.append([test_dates['']['historic'],
                                  test_dates['']['historic']
@@ -260,7 +262,7 @@ class TestFileDirectoryTranslations(CICleanSetup):
             # Refresh inst with the old directory template set to get now 'old'
             # path information.
             inst2 = pysat.Instrument(inst.platform, inst.name, tag=inst.tag,
-                                     inst_id=inst.inst_id)
+                                     inst_id=inst.inst_id, use_header=True)
 
             # Check that directories with simpler platform org were NOT removed.
             assert os.path.isdir(inst2.files.data_path)
@@ -321,7 +323,7 @@ class TestFileUtils(CICleanSetup):
 
         self.testInst = pysat.Instrument(
             inst_module=pysat.instruments.pysat_testing, clean_level='clean',
-            update_files=True)
+            update_files=True, use_header=True)
 
         # Create instrument directories in tempdir
         pysat.utils.files.check_and_make_path(self.testInst.files.data_path)

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -35,7 +35,8 @@ class TestLoadNetCDF(object):
         pysat.params['data_dirs'] = self.tempdir.name
 
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=100, update_files=True)
+                                         num_samples=100, update_files=True,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.epoch_name = 'time'
 
@@ -179,7 +180,8 @@ class TestLoadNetCDF(object):
         # Load the written file directly into an Instrument
         netcdf_inst = pysat.Instrument(
             'pysat', 'netcdf', data_dir=file_path, update_files=True,
-            file_format=file_root, pandas_format=self.testInst.pandas_format)
+            file_format=file_root, pandas_format=self.testInst.pandas_format,
+            use_header=True)
 
         # Confirm data path is correct
         assert os.path.normpath(netcdf_inst.files.data_path) \
@@ -584,7 +586,8 @@ class TestLoadNetCDFXArray(TestLoadNetCDF):
 
         self.testInst = pysat.Instrument(platform='pysat',
                                          name='testing2d_xarray',
-                                         update_files=True, num_samples=100)
+                                         update_files=True, num_samples=100,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing2d_xarray._test_dates[
             '']['']
         self.epoch_name = 'time'
@@ -684,7 +687,8 @@ class TestLoadNetCDF2DPandas(TestLoadNetCDF):
         pysat.params['data_dirs'] = self.tempdir.name
 
         self.testInst = pysat.Instrument(platform='pysat', name='testing2d',
-                                         update_files=True, num_samples=100)
+                                         update_files=True, num_samples=100,
+                                         use_header=True)
         self.stime = pysat.instruments.pysat_testing2d._test_dates['']['']
         self.epoch_name = 'time'
 
@@ -730,7 +734,8 @@ class TestNetCDF4Integration(object):
 
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
-        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5)
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5,
+                                         use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
                            use_header=True)
         self.pformat = self.testInst.pandas_format
@@ -1192,7 +1197,7 @@ class TestNetCDF4IntegrationXarray(TestNetCDF4Integration):
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
                            use_header=True)
         self.pformat = self.testInst.pandas_format
@@ -1208,7 +1213,8 @@ class TestNetCDF4IntegrationPandas2D(TestNetCDF4Integration):
 
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
-        self.testInst = pysat.Instrument('pysat', 'testing2d', num_samples=5)
+        self.testInst = pysat.Instrument('pysat', 'testing2d', num_samples=5,
+                                         use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
                            use_header=True)
         self.pformat = self.testInst.pandas_format
@@ -1225,7 +1231,7 @@ class TestNetCDF4Integration2DXarray(TestNetCDF4Integration):
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
         self.testInst = pysat.Instrument('pysat', 'testing2d_xarray',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
                            use_header=True)
         self.pformat = self.testInst.pandas_format
@@ -1241,7 +1247,8 @@ class TestNetCDF4IntegrationXarrayModels(TestNetCDF4Integration):
 
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
-        self.testInst = pysat.Instrument('pysat', 'testmodel', num_samples=5)
+        self.testInst = pysat.Instrument('pysat', 'testmodel', num_samples=5,
+                                         use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
                            use_header=True)
         self.pformat = self.testInst.pandas_format
@@ -1258,7 +1265,7 @@ class TestXarrayIO(object):
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
         self.testInst = pysat.Instrument('pysat', 'testing_xarray',
-                                         num_samples=5)
+                                         num_samples=5, use_header=True)
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
                            use_header=True)
         self.epoch_name = 'time'
@@ -1379,7 +1386,8 @@ class TestMetaTranslation(object):
     def setup(self):
         """Create test environment."""
 
-        self.test_inst = pysat.Instrument('pysat', 'testing', num_samples=5)
+        self.test_inst = pysat.Instrument('pysat', 'testing', num_samples=5,
+                                          use_header=True)
         self.test_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.test_inst.load(date=self.test_date)
         self.meta_dict = self.test_inst.meta.to_dict()
@@ -1663,7 +1671,7 @@ class TestMetaTranslationXarray(TestMetaTranslation):
         """Create test environment."""
 
         self.test_inst = pysat.Instrument('pysat', 'testing_xarray',
-                                          num_samples=5)
+                                          num_samples=5, use_header=True)
         self.test_date = pysat.instruments.pysat_testing_xarray._test_dates
         self.test_date = self.test_date['']['']
         self.test_inst.load(date=self.test_date)
@@ -1687,7 +1695,7 @@ class TestMetaTranslation2DXarray(TestMetaTranslation):
         """Create test environment."""
 
         self.test_inst = pysat.Instrument('pysat', 'testing2d_xarray',
-                                          num_samples=5)
+                                          num_samples=5, use_header=True)
         self.test_date = pysat.instruments.pysat_testing_xarray._test_dates
         self.test_date = self.test_date['']['']
         self.test_inst.load(date=self.test_date)
@@ -1711,7 +1719,7 @@ class TestMetaTranslation2DPandas(TestMetaTranslation):
         """Create test environment."""
 
         self.test_inst = pysat.Instrument('pysat', 'testing2d',
-                                          num_samples=5)
+                                          num_samples=5, use_header=True)
         self.test_date = pysat.instruments.pysat_testing2d._test_dates['']['']
         self.test_inst.load(date=self.test_date)
         self.meta_dict = self.test_inst.meta.to_dict()
@@ -1734,7 +1742,7 @@ class TestMetaTranslationModel(TestMetaTranslation):
         """Create test environment."""
 
         self.test_inst = pysat.Instrument('pysat', 'testmodel',
-                                          num_samples=5)
+                                          num_samples=5, use_header=True)
         self.test_date = pysat.instruments.pysat_testmodel._test_dates['']['']
         self.test_inst.load(date=self.test_date)
         self.meta_dict = self.test_inst.meta.to_dict()


### PR DESCRIPTION
Allow users to specify the `use_header` load option at initialization of an instrument instead of just when loading.
Clean up of this kwarg is now captured in #1020.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import pysat
import datetime as dt

cindi = pysat.Instrument('cnofs', 'ivm', use_header=True)
stime = dt.datetime(2009, 4, 10)
cindi.load(date=stime)
```

No deprecation warnings should appear.
**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.8
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
