### PR TITLE
Warnings

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1418,7 +1418,7 @@ class Instrument(object):
         """
         # Set default load_kwargs
         if load_kwargs is None:
-            load_kwargs = self.kwargs['load']
+            load_kwargs = copy.deepcopy(self.kwargs['load'])
 
         # Ensure that the local optional kwarg `use_header` is not passed
         # to the instrument routine.

--- a/pysat/constellations/testing.py
+++ b/pysat/constellations/testing.py
@@ -9,9 +9,12 @@ instruments : list
 import pysat
 
 instruments = [pysat.Instrument('pysat', 'testing', clean_level='clean',
-                                num_samples=10),
-               pysat.Instrument('pysat', 'testing2d', clean_level='clean'),
+                                num_samples=10, use_header=True),
+               pysat.Instrument('pysat', 'testing2d', clean_level='clean',
+                                use_header=True),
                pysat.Instrument('pysat', 'testing2d_xarray',
-                                clean_level='clean'),
-               pysat.Instrument('pysat', 'testing_xarray', clean_level='clean'),
-               pysat.Instrument('pysat', 'testmodel', clean_level='clean')]
+                                clean_level='clean', use_header=True),
+               pysat.Instrument('pysat', 'testing_xarray', clean_level='clean',
+                                use_header=True),
+               pysat.Instrument('pysat', 'testmodel', clean_level='clean',
+                                use_header=True)]

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -123,7 +123,7 @@ class TestConstellationInit(object):
 
         if ikey is not None:
             self.in_kwargs[ikey] = ival
-        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
+        self.const = pysat.Constellation(**self.in_kwargs)
         assert len(self.const.instruments) == ilen
         return
 
@@ -214,8 +214,8 @@ class TestConstellationInit(object):
         """
 
         self.in_kwargs["common_index"] = common_index
-        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
-        self.const.load(date=self.ref_time)
+        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const.load(date=self.ref_time, use_header=True)
         out_str = self.const.__str__()
 
         assert out_str.find("pysat Constellation ") >= 0
@@ -234,11 +234,11 @@ class TestConstellationInit(object):
 
         # Initialize the constellation
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
+        self.const = pysat.Constellation(**self.in_kwargs)
 
         # Add the custom function
         self.const.custom_attach(double_mlt, at_pos='end')
-        self.const.load(date=self.ref_time)
+        self.const.load(date=self.ref_time, use_header=True)
 
         # Test the added value
         for inst in self.const:
@@ -335,7 +335,7 @@ class TestConstellationFunc(object):
         """Test the status of the empty flag for partially loaded data."""
 
         # Load only one instrument and test the status flag
-        self.const.instruments[0].load(date=self.ref_time)
+        self.const.instruments[0].load(date=self.ref_time, use_header=True)
         assert self.const.empty_partial
         assert not self.const.empty
         return
@@ -344,7 +344,7 @@ class TestConstellationFunc(object):
         """Test the alt status of the empty flag for partially loaded data."""
 
         # Load only one instrument and test the status flag for alternate flag
-        self.const.instruments[0].load(date=self.ref_time)
+        self.const.instruments[0].load(date=self.ref_time, use_header=True)
         assert not self.const._empty(all_inst=False)
         return
 
@@ -352,7 +352,7 @@ class TestConstellationFunc(object):
         """Test the status of the empty flag for loaded data."""
 
         # Load data and test the status flag
-        self.const.load(date=self.ref_time)
+        self.const.load(date=self.ref_time, use_header=True)
         assert not self.const.empty
         return
 
@@ -362,9 +362,8 @@ class TestConstellationFunc(object):
         """Test the empty index attribute."""
 
         # Test the attribute with loaded data
-        self.const = pysat.Constellation(instruments=self.inst, **ikwarg,
-                                         use_header=True)
-        self.const.load(date=self.ref_time)
+        self.const = pysat.Constellation(instruments=self.inst, **ikwarg)
+        self.const.load(date=self.ref_time, use_header=True)
         assert isinstance(self.const.index, pds.Index)
         assert self.const.index[0] == self.ref_time
 
@@ -386,7 +385,7 @@ class TestConstellationFunc(object):
         """Test the date property when no data is loaded."""
 
         # Test the attribute with loaded data
-        self.const.load(date=self.ref_time)
+        self.const.load(date=self.ref_time, use_header=True)
 
         assert self.const.date == self.ref_time
         return
@@ -395,7 +394,7 @@ class TestConstellationFunc(object):
         """Test the variables property when no data is loaded."""
 
         # Test the attribute with loaded data
-        self.const.load(date=self.ref_time)
+        self.const.load(date=self.ref_time, use_header=True)
 
         assert len(self.const.variables) > 0
         assert 'uts_pysat_testing' in self.const.variables

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -697,7 +697,7 @@ class TestMeta(object):
                                    self.meta_labels[label][1])
 
         # Define new label
-        other_labels['new_label_label'] = ('new_data_label', np.int)
+        other_labels['new_label_label'] = ('new_data_label', np.int64)
 
         # Run function
         other_meta = pysat.Meta(labels=other_labels)

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -173,7 +173,10 @@ class TestFileDirectoryTranslations(CICleanSetup):
             ostr = ' '.join(('Downloading data for', inst.platform,
                              inst.name, inst.tag, inst.inst_id))
             print(ostr)
-            inst.download(start=dates[0], stop=dates[1], **kwargs)
+
+            # Support non-daily download frequencies
+            dates = pds.date_range(dates[0], dates[1], **kwargs)
+            inst.download(date_array=dates)
 
     def teardown(self):
         """Clean up the unit test environment after each method."""


### PR DESCRIPTION
# Description

Addresses # (issue)

Reduces warnings for `epoch_name` and a deprecation warning for `np.int`.

Fixes a bug in application of `use_header` at Instrument level.

Expands `use_header` to more areas to further reduce warnings.

Removes `decode_times` warnings.

Warnings down to ~15k

## Type of change

Please delete options that are not relevant.

- Warnings reduction

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Ran tests locally

**Test Configuration**:
* Operating system: Mac
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
