### PR TITLE
BUG: Use of slices to access xarray data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[3.0.4] - 2022-XX-XX
+--------------------
+* Bug Fix
+   * Improved compatibility with xarray 2022.06 when accessing data via slices.
+
 [3.0.3] - 2022-07-29
 --------------------
 * Maintenance
@@ -55,32 +60,32 @@ This project adheres to [Semantic Versioning](https://semver.org/).
      are immediately reflected by changes to Instrument object.
    * Added a test function for bad class/function/method input to reduce
      duplicate code and improve message test combliance
-   * Added support for filtering basic netCDF4 metadata when loading via 
+   * Added support for filtering basic netCDF4 metadata when loading via
      `pysat.utils.io.load_netcdf`.
    * Added support for user developed functions to filter metadata as it
      loaded from disk but before assignment to a `pysat.Meta` instance.
    * Added `meta.to_dict` to support creating more compliant
-     netCDF files. 
-   * Added `meta.default_to_netcdf_translation_table`, 
-     `default_from_netcdf_translation_table` and 
-     `apply_table_translation` to `pysat.utils.io` to support 
+     netCDF files.
+   * Added `meta.default_to_netcdf_translation_table`,
+     `default_from_netcdf_translation_table` and
+     `apply_table_translation` to `pysat.utils.io` to support
      improved compatability of pysat netcdf files without user code
      changes.
    * Added `drop_meta_labels` kwarg to `pysat.utils.io.load_netcdf` to
      support easy removal of unwanted metadata during loading.
    * Added support for `meta_processor` in `pysat.utils.io.load_netcdf`
-     and `pysat.utils.io.inst_to_netcdf` enabling developers to easily modify 
+     and `pysat.utils.io.inst_to_netcdf` enabling developers to easily modify
      metadata before it is loaded from/written to storage.
    * Intermediate missing directories are now created as needed when writing
      files using `pysat.utils.io.inst_to_netcdf`.
    * Condensed code present in both pandas and xarray into
      `pysat.utils.io.meta_array_expander`.
-   * Non-default Meta.labels are now retained by Instrument if defined by 
+   * Non-default Meta.labels are now retained by Instrument if defined by
      underlying support module.
    * Made test data more consistent across pysat testing instruments.
    * Added `pysat.Instrument.vars_no_time` function to return data variables
      excluding the main time index.
-   * Added support for additional metdata and other file handling options 
+   * Added support for additional metdata and other file handling options
      to general 'pysat', 'netcdf' instrument.
    * Added keyword `decode_times` to flag using xarray or pysat processing
      of times when loading a file via `pysat.utils.io.load_netcdf`.
@@ -156,12 +161,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
    * Moved function call for Instrument modules init function to end of
      pysat.Instrument instantiation to ensure Instrument is complete when passed
      to init.
-   * Refactored `pysat.Instrument.generic_meta_translator` to use 
+   * Refactored `pysat.Instrument.generic_meta_translator` to use
      `pysat.Meta.to_dict` and the latest metadata label standards.
    * Prevent stale data paths stored by pysat from being reassigned if
      path is no longer in `pysat.params['data_dirs']`.
    * Added missing metadata in testing instruments.
-   * Corrected identification of string data for xarray in 
+   * Corrected identification of string data for xarray in
      `pysat.Instrument._get_data_info`.
 * Maintenance
    * Added unit tests for deprecation warnings related to io_utils reorg.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,10 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [3.0.4] - 2022-XX-XX
 --------------------
+* Maintenance
+  * Removed version cap on xarray
 * Bug Fix
-   * Improved compatibility with xarray 2022.06 when accessing data via slices.
+   * Improved compatibility with xarray 2022.06 when accessing data via slices
 
 [3.0.3] - 2022-07-29
 --------------------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -904,7 +904,7 @@ class Instrument(object):
             try:
                 # Grab a particular variable by name
                 return self.data[key]
-            except (TypeError, KeyError):
+            except (TypeError, KeyError, ValueError):
                 # If that didn't work, likely need to use `isel` or `sel`
                 try:
                     # Try to get all data variables, but for a subset of time

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -868,9 +868,10 @@ class Instrument(object):
                         # Assume key[0] is an integer
                         new_data = self.data[self.variables[key[1]]]
                         return new_data.isel(**key_dict)
-                    except TypeError:
+                    except (KeyError, TypeError):
                         # key[0] is not an integer, switch to .sel
-                        # TypeError raised when key is datetime(s)
+                        # KeyError raised when key is single datetime
+                        # TypeError raised when key slice of datetimes
                         new_data = self.data[self.variables[key[1]]]
                         return new_data.sel(**key_dict)
                 else:
@@ -878,9 +879,10 @@ class Instrument(object):
                     try:
                         # Assume key[0] is an integer
                         return self.data.isel(**key_dict)[key[1]]
-                    except TypeError:
+                    except (KeyError, TypeError):
                         # key[0] is not an integer, switch to .sel
-                        # TypeError raised when key is datetime(s)
+                        # KeyError raised when key is single datetime
+                        # TypeError raised when key slice of datetimes
                         return self.data.sel(**key_dict)[key[1]]
                     except ValueError as verr:
                         # This may be multidimensional indexing, where the
@@ -927,7 +929,7 @@ class Instrument(object):
                     # Try to get all data variables, but for a subset of time
                     # using integer indexing
                     return self.data.isel(**key_dict)
-                except TypeError:
+                except (KeyError, TypeError):
                     # Try to get a subset of time, using label based indexing
                     return self.data.sel(**key_dict)
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -879,7 +879,7 @@ class Instrument(object):
                 except ValueError as verr:
                     # This may be multidimensional indexing, where the
                     # multiple dimensions are contained within an iterable
-                    # object
+                    # object.
                     var_name = key[-1]
 
                     # If this is not true, raise the original error

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -865,13 +865,14 @@ class Instrument(object):
                 else:
                     # Extract single variable before epoch selection.
                     data_subset = self.data[key[1]]
-                # if a tuple, key[0] must be indexed to the epoch.
+
+                # If the input is a tuple, `key[0]` must be linked to the epoch.
                 key_dict = {'indexers': {epoch_name: key[0]}}
                 try:
                     # Assume key[0] is an integer
                     return data_subset.isel(**key_dict)
                 except (KeyError, TypeError):
-                    # key[0] is not an integer, switch to .sel
+                    # Since `key[0]` is not an integer, use the `sel` method.
                     # KeyError raised when key is single datetime.
                     # TypeError raised when key is slice of datetimes.
                     return data_subset.sel(**key_dict)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ portalocker
 pytest
 scipy
 toolz
-xarray<2022.06.0
+xarray


### PR DESCRIPTION
# Description

Addresses #1026

Pysat allows users to access data a number of ways.  The `getitem` functions in the `pysat.Instrument` class pass these through to pandas and xarray using try/except statements.  Error types are monitored to infer the appropriate syntax.

xarray 2022.06 updates the default error when inputting a slice incorrectly from `TypeError` to `ValueError`, breaking pysat's assumptions for how to alter the syntax.  This fixes the problem, and additionally cleans up and documents the logic.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Existing unit tests pass.  The bug would manifest in the existing tests.

Also tested with the develop branch of pysatNASA.

**Test Configuration**:
* Operating system: Mac OS X Big Sur
* Version number: Python 3.8.11
* xarray 2022.03 and xarray 2022.06

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
