### PR TITLE
BUG: fractional times for test instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Removed version cap on xarray
 * Bug Fix
    * Improved compatibility with xarray 2022.06 when accessing data via slices
+   * Fixed a bug for fractional seconds in `methods.generate_times`.
 
 [3.0.3] - 2022-07-29
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Removed version cap on xarray
 * Bug Fix
    * Improved compatibility with xarray 2022.06 when accessing data via slices
-   * Fixed a bug for fractional seconds in `methods.generate_times`.
+   * Fixed a bug for fractional seconds in `methods.testing.generate_times`.
 
 [3.0.3] - 2022-07-29
 --------------------

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -511,7 +511,7 @@ def generate_times(fnames, num, freq='1S', start_time=None):
         index = index[0:num]
         indices.extend(index)
         uts.extend(index.hour * 3600 + index.minute * 60 + index.second
-                   + 86400. * loop)
+                   + index.microsecond * 1e-6 + 86400. * loop)
 
     # Combine index times together
     index = pds.DatetimeIndex(indices)

--- a/pysat/tests/test_methods_testing.py
+++ b/pysat/tests/test_methods_testing.py
@@ -52,7 +52,8 @@ class TestMethodsTesting(object):
                               (10, {'start_time': dt.timedelta(hours=1),
                                     'freq': '10s'},
                                [3600.0, 3690.0]),
-                              (87000, {}, [0.0, 86399.0])])
+                              (87000, {}, [0.0, 86399.0]),
+                              (10, {'freq': '10mS'}, [0.0, 0.09])])
     def test_generate_times_kwargs(self, num, kwargs, output):
         """Test use of kwargs in generate_times, including default behavior.
 


### PR DESCRIPTION
# Description

Addresses #1036

`pysat.instruments.methods.testing.generate_times` currently does not work for high-frequency values (<1s).  The returned index is correct, but the `uts` will return only integer seconds.

This impacts other projects such as `pysatMissions` that use this function.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
from pysat.instruments.methods import testing as ps_meth
uts, index, dates = ps_meth.generate_times(['2018-01-01.no_file'], 5400, freq='10mS')
```
Inspect `uts` and `index`. In develop, `uts` will be zero for all points, in this branch, it will have fractional values.

**Test Configuration**:
* Operating system: Mac OS X Big Sur
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
