### PR TITLE
BUG: ci_skip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * Bug Fix
    * Improved compatibility with xarray 2022.06 when accessing data via slices
    * Fixed a bug for fractional seconds in `methods.testing.generate_times`.
+   * Fixed a bug for testing FTP instruments in a CI environment.
 
 [3.0.3] - 2022-07-29
 --------------------

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -465,7 +465,7 @@ def generate_instrument_list(inst_loc, user_info=None):
                                             inst_id=iid,
                                             temporary_file_list=True)
                     # Set flag to skip tests on a CI environment.
-                    # To test CI config on a local system, change first line
+                    # To test CI config on a local system, change first
                     # condition to (os.environ.get('CI') is None).
                     ci_skip = ((os.environ.get('CI') == 'true')
                                and not inst._test_download_ci)

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -469,11 +469,11 @@ def generate_instrument_list(inst_loc, user_info=None):
                     # condition to (os.environ.get('CI') is None).
                     ci_skip = ((os.environ.get('CI') == 'true')
                                and not inst._test_download_ci)
-                    # Check if instrument is configured for download tests.
-                    if inst._test_download:
-                        # Some instruments will be skipped in CI but run
-                        # locally. Check for this flag.
-                        if not ci_skip:
+                    # Some instruments will be skipped in CI but run
+                    # locally. Check for this flag.
+                    if not ci_skip:
+                        # Check if instrument is configured for download tests.
+                        if inst._test_download:
                             instrument_download.append(in_dict)
                             if hasattr(module, '_test_load_opt'):
                                 # Add optional load tests
@@ -488,11 +488,11 @@ def generate_instrument_list(inst_loc, user_info=None):
                                     # combo
                                     pass
 
-                    elif not inst._password_req:
-                        # We don't want to test download for this combo, but
-                        # we do want to test the download warnings for
-                        # instruments without a password requirement
-                        instrument_no_download.append(in_dict)
+                        elif not inst._password_req:
+                            # We don't want to test download for this combo, but
+                            # we do want to test the download warnings for
+                            # instruments without a password requirement
+                            instrument_no_download.append(in_dict)
 
     # load options requires all downloaded instruments plus additional options
     output = {'names': instrument_names,

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -467,10 +467,11 @@ def generate_instrument_list(inst_loc, user_info=None):
                     # Set flag to skip tests on a CI environment
                     ci_skip = ((os.environ.get('CI') == 'true')
                                and not inst._test_download_ci)
+                    # Check if instrument is configured for download tests.
                     if inst._test_download:
+                        # Some instruments will be skipped in CI but run
+                        # locally. Check for this flag.
                         if not ci_skip:
-                            # Some instruments will be skipped in CI but not
-                            # locally.
                             instrument_download.append(in_dict)
                             if hasattr(module, '_test_load_opt'):
                                 # Add optional load tests

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -464,7 +464,9 @@ def generate_instrument_list(inst_loc, user_info=None):
                                             tag=tag,
                                             inst_id=iid,
                                             temporary_file_list=True)
-                    # Set flag to skip tests on a CI environment
+                    # Set flag to skip tests on a CI environment.
+                    # To test CI config on a local system, change first line
+                    # condition to (os.environ.get('CI') is None).
                     ci_skip = ((os.environ.get('CI') == 'true')
                                and not inst._test_download_ci)
                     # Check if instrument is configured for download tests.


### PR DESCRIPTION
# Description

Addresses #1039

This fixes a bug introduced in pysat 3.0.2 in the unit tests that are inherited by the ecosystem packages.  Downloads from FTP instruments are skipped in the CI environment, but run locally.  The bug mistakenly assigns the `no_download` suite of tests, which check for a warning message is downloads are not supported.

This is affecting the unit tests in pysatSpaceWeather since the release of pysat 3.0.2.  Recommend we add the fix into the RC and test a branch there against the new RC.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

In pysat.utils._core.py, replace `(os.environ.get('CI') == 'true')` on line 470 with `(os.environ.get('CI') is None)` to simulate a True response while on a local system.  Then run:
```
import pysat
import pysatSpaceWeather
inst_list = pysat.utils.generate_instrument_list(pysatSpaceWeather.instruments)
inst_list['no_download']
```

This should provide an empty list.  When the same procedure is done in pysat develop, it lists the three FTP instruments in pysatSpaceWeather.

**Test Configuration**:
* Operating system: Mac OS X Big Sur
* Version number: Python 3.8.11
* Tweaks to pysat described above to simulate being in a CI environment.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
