### PR TITLE
Change in children - bugfix 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,6 @@ jobs:
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
         pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
-        pip install "pandas<1.5.0"
 
     - name: Install standard dependencies and pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Install NEP29 dependencies
+      if: ${{ matrix.numpy_ver != 'latest'}}
+      run: |
+        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
+        pip install "pandas<1.5.0"
+
     - name: Install standard dependencies and pysat
       run: |
         python -m pip install --upgrade pip
@@ -35,11 +41,6 @@ jobs:
 
     - name: Install requirements for testing setup
       run: pip install -r test_requirements.txt
-
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.numpy_ver != 'latest'}}
-      run: |
-        pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
 
     - name: Set up pysat
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,7 +15,7 @@ jobs:
         numpy_ver: ["latest"]
         include:
           - python-version: "3.8"
-            numpy_ver: "1.19"
+            numpy_ver: "1.20"
             os: ubuntu-latest
 
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Update NEP29 minimum CI numpy version to 1.20
 * Bug Fix
    * Updated meta.py so that internal assignment of None to children is not 
-     converted to NaN
+     converted to NaN when using pandas>=1.5.0
 
 [3.0.4] - 2022-08-29
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 --------------------
 * Maintenance
   * Update usage of logger throughout code.
+* Bug Fix
+   * Updated meta.py so that internal assignment of None to children is not 
+     converted to NaN
 
 [3.0.4] - 2022-08-29
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 --------------------
 * Maintenance
   * Update usage of logger throughout code.
+  * Update NEP29 minimum CI numpy version to 1.20
 * Bug Fix
    * Updated meta.py so that internal assignment of None to children is not 
      converted to NaN

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -117,7 +117,7 @@ class Meta(object):
         meta2['var_name42'] = {'long_name': 'name2of4', 'units': 'Units2'}
         meta['var_name4'] = {'meta': meta2}
 
-        # An alternative method to acheive the same result is:
+        # An alternative method to achieve the same result is:
         meta['var_name4'] = meta2
         meta['var_name4'].children['name41']
         meta['var_name4'].children['name42']
@@ -650,8 +650,11 @@ class Meta(object):
                 if new_key in self.keys_nD():
                     meta_row.at['children'] = self.ho_data[new_key]  # .copy()
                 else:
-                    meta_row.at['children'] = None  # Return empty meta instance
-
+                    # Not higher order meta. Assign value of None. First, we
+                    # assign a string, and then None. Ensures column is not
+                    # a numeric data type.
+                    meta_row.at['children'] = ''
+                    meta_row.at['children'] = None
                 return meta_row
             else:
                 raise KeyError("Key '{:}' not found in MetaData".format(key))


### PR DESCRIPTION
# Description

Addresses #1044 

Addresses the change to 'None' assignment with pandas 1.5 by forcing the relevant column to a non-numeric state. This fix keeps None as None so no other changes by users or developers are needed. There may be a slightly more elegant solution, first I assign an empty string, then None. May be possible to do in one line but current fix appears effective.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide
instructions so we can reproduce. Please also list any relevant details for
your test configuration

- Ran test_meta locally. Using CI to check other versions.


**Test Configuration**:
* Operating system: Mac
* Version number: Python 3.10
* Installed today!

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
