### PR TITLE
BUG/DOC: file_format description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,18 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[3.X.X] - 2022-??-??
+--------------------
+* Maintenance
+  * Improved docstrings
+
 [3.0.5] - 2022-10-14
 --------------------
 * Maintenance
   * Update usage of logger throughout code.
   * Update NEP29 minimum CI numpy version to 1.20
 * Bug Fix
-   * Updated meta.py so that internal assignment of None to children is not 
+   * Updated meta.py so that internal assignment of None to children is not
      converted to NaN when using pandas>=1.5.0
 
 [3.0.4] - 2022-08-29

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -77,7 +77,7 @@ class Instrument(object):
         in the instrument `list_files` routine. See
         `pysat.files.parse_delimited_filenames` and
         `pysat.files.parse_fixed_width_filenames` for more information.
-        The value will be None If not specified by the user at instantiation.
+        The value will be None if not specified by the user at instantiation.
         (default=None)
     temporary_file_list : bool
         If true, the list of Instrument files will not be written to disk

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -77,7 +77,7 @@ class Instrument(object):
         in the instrument `list_files` routine. See
         `pysat.files.parse_delimited_filenames` and
         `pysat.files.parse_fixed_width_filenames` for more information.
-        If unspecified, will be None.
+        The value will be None If not specified by the user at instantiation.
         (default=None)
     temporary_file_list : bool
         If true, the list of Instrument files will not be written to disk

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -73,10 +73,11 @@ class Instrument(object):
     file_format : str or NoneType
         File naming structure in string format.  Variables such as `year`,
         `month`, `day`, etc. will be filled in as needed using python
-        string formatting.  The default file format structure is supplied in the
-        instrument `list_files` routine. See
+        string formatting.  The default file format structure is supplied
+        in the instrument `list_files` routine. See
         `pysat.files.parse_delimited_filenames` and
         `pysat.files.parse_fixed_width_filenames` for more information.
+        If unspecified, will be None.
         (default=None)
     temporary_file_list : bool
         If true, the list of Instrument files will not be written to disk


### PR DESCRIPTION
# Description

Closes #1032

Adds somedescription to the use of file_format in the docstring.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

unit tests.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
