### PR TITLE
BUG: use of temporary directory in test package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [3.X.X] - 2022-??-??
 --------------------
+* Bug Fix
+  * Ensure pysat tests do not store temporary directory to file
 * Maintenance
   * Improved docstrings
 

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -111,13 +111,13 @@ class InstLibTests(object):
         # Use a temporary directory so that the user's setup is not altered.
         self.tempdir = tempfile.TemporaryDirectory()
         self.saved_path = pysat.params['data_dirs']
-        pysat.params['data_dirs'] = self.tempdir.name
+        pysat.params._set_data_dirs(path=self.tempdir.name, store=False)
         return
 
     def teardown_class(self):
         """Clean up downloaded files and parameters from tests."""
 
-        pysat.params['data_dirs'] = self.saved_path
+        pysat.params._set_data_dirs(self.saved_path, store=False)
         self.tempdir.cleanup()
         del self.saved_path, self.tempdir
         return


### PR DESCRIPTION
# Description

Addresses #1059

Uses the hidden `_set_data_dirs` method to set the temporary directory in the inheritable unit tests.  This allows the path to be set without writing to file, which will break a user's local setup until the tests restore the original path at the end.

The fix here will be inherited for tests in other packages.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Open the pysat_settings.json file in a text editor that updates live
- Run unit tests for a penumbra package (eg, pysatNASA)
- Look for data_dirs parameter to change

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
