### PR TITLE
STY: Clean up manual installs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,14 +34,6 @@ jobs:
       if: ${{ matrix.numpy_ver != 'latest'}}
       run: |
         pip install --no-binary :numpy: numpy==${{ matrix.numpy_ver }}
-        # Need to force install versions compliant with NEP29
-        pip install "pandas<1.5"
-
-    - name: Install Operational dependencies
-      if: ${{ matrix.python-version == '3.6.8'}}
-      run: |
-        # Need to force install versions compliant with operations
-        pip install "netCDF4<1.6.2"
 
     - name: Install standard dependencies and pysat
       run: |


### PR DESCRIPTION
Looking over the logs, this is working as expected.

My thought on the netcdf4 install earlier was wrong.  Looks like the older version installs correctly after the latest fails.

Pandas has updated a new version (1.5.2) which fixes the nep29 issues, correctly installs an older version for the operational version.