### PR TITLE
BUG: xarray coords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 [3.Y.Y] - 2023-??-??
 --------------------
 * Bug Fix
-  * Fixed an issue with single variables in xarray coords (#988)
+  * Fixed an issue with setting single variables in xarray coords (#988)
 * Maintenance
   * Added roadmap to readthedocs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [3.Y.Y] - 2023-??-??
 --------------------
+* Bug Fix
+  * Fixed an issue with single variables in xarray coords (#988)
 * Maintenance
   * Added roadmap to readthedocs
 

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -2,10 +2,10 @@ Citations in the pysat ecosystem
 ================================
 
 When referring to this software package, please cite the original paper by
-Stoneback et al [2018] `<https://doi.org/10.1029/2018JA025297>`_ as well as the
-package `<https://doi.org/10.5281/zenodo.1199703>`_. Note that this DOI will
-always point to the latest version of the code.  A list of DOIs for all
-versions can be found at the Zenodo page above.
+Stoneback et al [2018] `<https://onlinelibrary.wiley.com/doi/10.1029/2018JA025297>`_
+as well as the package `<https://doi.org/10.5281/zenodo.1199703>`_. Note that
+this DOI will always point to the latest version of the code.  A list of DOIs
+for all versions can be found at the Zenodo page above.
 
 Example for citation in BibTex for a generalized version:
 

--- a/docs/tutorial/tutorial_basics.rst
+++ b/docs/tutorial/tutorial_basics.rst
@@ -324,18 +324,14 @@ the data at the :py:class:`pysat.Instrument` level that behaves the same whether
     # Convenient data assignment
     dmsp['ti'] = new_array
 
+    # Data broadcasting assignment for new variables, sets a single value to all times
+    dmsp['ti'] = single_value
+
     # Assignment through index slicing
     dmsp[0:10, 'ti'] = sub_array
 
     # Assignment through datetime slicing
     dmsp[start:stop, 'ti'] = sub_array
-
-Note that a :py:class:`pandas.DataFrame` will hold to a strict time index, 
-meaning that all variables must be the same length.  Assigning a single 
-value to an array will broadcast that value over all coordinates, resulting 
-in a constant value as a function of time. To allow for multiple dimensions, 
-the :py:class:`xarray.Dataset` allows more flexibility.  If a single value is 
-assigned to a new variable, it will be sent to the coords.
 
 Note that :py:func:`np.where` may be used to select a subset of data using
 either the convenient access or standard pandas or xarray selection methods.

--- a/docs/tutorial/tutorial_basics.rst
+++ b/docs/tutorial/tutorial_basics.rst
@@ -324,15 +324,18 @@ the data at the :py:class:`pysat.Instrument` level that behaves the same whether
     # Convenient data assignment
     dmsp['ti'] = new_array
 
-    # Convenient data broadcasting assignment, sets a single value to all times
-    dmsp['ti'] = single_value
-
     # Assignment through index slicing
     dmsp[0:10, 'ti'] = sub_array
 
     # Assignment through datetime slicing
     dmsp[start:stop, 'ti'] = sub_array
 
+Note that a pandas data objects will hold to a strict time index, meaning that
+all variables must be the same length.  Assigning a single value to an array
+will broadcast that value over all coordinates, resulting in a constant value
+as a function of time. To allow for multiple dimensions, the xarray data object
+allows more flexibility.  If a single value is assigned to a new variable, it
+will be sent to the coords.
 
 Note that :py:func:`np.where` may be used to select a subset of data using
 either the convenient access or standard pandas or xarray selection methods.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1066,16 +1066,41 @@ class Instrument(object):
                         self.data[key] = (epoch_name, in_data)
                     elif len(in_data) == 1:
                         # Only provided a single number in iterable.
-                        # Assign as coord.
-                        self.data.coords[key] = (key, [in_data[0]])
+                        if key in self.variables:
+                            # If it already exists, assign as defined.
+                            self.data[key] = in_data
+                        else:
+                            # Otherwise broadcast over time.
+                            pysat.logger.warning(
+                                ' '.join(('Input for {:} is a'.format(key),
+                                          'single value. Broadcast over',
+                                          'epoch.')))
+                            self.data[key] = (epoch_name,
+                                              [in_data] * len(self.index))
                     elif len(in_data) == 0:
                         # Provided an empty iterable, make everything NaN
+                        pysat.logger.warning(
+                            ' '.join(('Input for {:} is empty.'.format(key),
+                                      'Setting to NaN broadcast over epoch.')))
                         self.data[key] = (epoch_name,
                                           [np.nan] * len(self.index))
+                    else:
+                        raise ValueError(
+                            ' '.join(('Input for {:}'.format(key),
+                                      'does not match expected',
+                                      'dimensions. Value not set.')))
                 elif len(np.shape(in_data)) == 0:
                     # Not an iterable input, but a single number.
-                    # Assign as coord.
-                    self.data.coords[key] = (key, [in_data])
+                    if key in self.variables:
+                        # If it exists, assign as coord.
+                        self.data[key] = in_data
+                    else:
+                        # Otherwise broadcast over time.
+                        pysat.logger.warning(
+                            ' '.join(('Input for {:} is a'.format(key),
+                                      'value. Broadcast over epoch.')))
+                        self.data[key] = (epoch_name,
+                                          [in_data] * len(self.index))
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -957,6 +957,10 @@ class Instrument(object):
             If tuple not used when assigning dimensions for new multidimensional
             data.
 
+        Warnings
+        --------
+        If a single new value is set, the value will be broadcast over time.
+
         Note
         ----
         If no metadata provided and if metadata for 'name' not already stored

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1071,24 +1071,23 @@ class Instrument(object):
                             self.data[key] = in_data
                         else:
                             # Otherwise broadcast over time.
-                            pysat.logger.warning(
-                                ' '.join(('Input for {:} is a'.format(key),
-                                          'single value. Broadcast over',
-                                          'epoch.')))
+                            warnings.warn(' '.join(('Input for {:}'.format(key),
+                                                    'is a single value.',
+                                                    'Broadcast over epoch.')))
                             self.data[key] = (epoch_name,
                                               [in_data] * len(self.index))
                     elif len(in_data) == 0:
                         # Provided an empty iterable, make everything NaN
-                        pysat.logger.warning(
-                            ' '.join(('Input for {:} is empty.'.format(key),
-                                      'Setting to NaN broadcast over epoch.')))
+                        warnings.warn(' '.join(('Input for {:} is'.format(key),
+                                                'empty. Setting to broadcast',
+                                                'as NaN over epoch.')))
                         self.data[key] = (epoch_name,
                                           [np.nan] * len(self.index))
                     else:
-                        raise ValueError(
-                            ' '.join(('Input for {:}'.format(key),
-                                      'does not match expected',
-                                      'dimensions. Value not set.')))
+                        raise ValueError(' '.join(('Input for {:}'.format(key),
+                                                   'does not match expected',
+                                                   'dimensions. Value not',
+                                                   'set.')))
                 elif len(np.shape(in_data)) == 0:
                     # Not an iterable input, but a single number.
                     if key in self.variables:
@@ -1096,9 +1095,9 @@ class Instrument(object):
                         self.data[key] = in_data
                     else:
                         # Otherwise broadcast over time.
-                        pysat.logger.warning(
-                            ' '.join(('Input for {:} is a'.format(key),
-                                      'value. Broadcast over epoch.')))
+                        warnings.warn(' '.join(('Input for {:} is'.format(key),
+                                                'a single value. Broadcast',
+                                                'over epoch.')))
                         self.data[key] = (epoch_name,
                                           [in_data] * len(self.index))
                 else:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1091,7 +1091,7 @@ class Instrument(object):
                 elif len(np.shape(in_data)) == 0:
                     # Not an iterable input, but a single number.
                     if key in self.variables:
-                        # If it exists, assign as coord.
+                        # If it exists, assign to existing value.
                         self.data[key] = in_data
                     else:
                         # Otherwise broadcast over time.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1067,7 +1067,7 @@ class Instrument(object):
                     elif len(in_data) == 1:
                         # Only provided a single number in iterable.
                         # Assign as coord.
-                        self.data.coords[key] = (key, in_data[0])
+                        self.data.coords[key] = (key, [in_data[0]])
                     elif len(in_data) == 0:
                         # Provided an empty iterable, make everything NaN
                         self.data[key] = (epoch_name,
@@ -1075,7 +1075,7 @@ class Instrument(object):
                 elif len(np.shape(in_data)) == 0:
                     # Not an iterable input, rather a single number.
                     # Assign as coord.
-                    self.data.coords[key] = (key, in_data)
+                    self.data.coords[key] = (key, [in_data])
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1061,25 +1061,33 @@ class Instrument(object):
                 if isinstance(in_data, xr.DataArray):
                     # If xarray input, take as is
                     self.data[key] = in_data
-                elif len(np.shape(in_data)) == 1:
+                elif len(np.shape(in_data)) <= 1:
                     # If not an xarray input, but still iterable, then we
                     # go through to process the 1D input
-                    if len(in_data) == len(self.index):
+                    if np.shape(in_data) == np.shape(self.index):
                         # 1D input has the correct length for storage along
-                        # 'Epoch'
+                        # 'Epoch'.
                         self.data[key] = (epoch_name, in_data)
-                    elif len(in_data) == 1:
-                        # Only provided a single number in iterable.
+                    elif len(np.shape(in_data)) == 0 or len(in_data) == 1:
+                        # Only a single number, or single in iterable.
                         if key in self.variables:
                             # If it already exists, assign as defined.
-                            self.data[key] = in_data
+                            in_data = np.squeeze(in_data)
+                            if np.shape(self.data[key]) == np.shape(in_data):
+                                self.data[key] = in_data
+                            else:
+                                raise ValueError(' '.join(('Shape of input',
+                                                           'does not match',
+                                                           'existing shape of',
+                                                           key)))
                         else:
                             # Otherwise broadcast over time.
                             warnings.warn(' '.join(('Input for {:}'.format(key),
                                                     'is a single value.',
                                                     'Broadcast over epoch.')))
+                            in_data = pysat.utils.listify(in_data)
                             self.data[key] = (epoch_name,
-                                              [in_data] * len(self.index))
+                                              in_data * len(self.index))
                     elif len(in_data) == 0:
                         # Provided an empty iterable, make everything NaN
                         warnings.warn(' '.join(('Input for {:} is'.format(key),
@@ -1092,18 +1100,6 @@ class Instrument(object):
                                                    'does not match expected',
                                                    'dimensions. Value not',
                                                    'set.')))
-                elif len(np.shape(in_data)) == 0:
-                    # Not an iterable input, but a single number.
-                    if key in self.variables:
-                        # If it exists, assign to existing value.
-                        self.data[key] = in_data
-                    else:
-                        # Otherwise broadcast over time.
-                        warnings.warn(' '.join(('Input for {:} is'.format(key),
-                                                'a single value. Broadcast',
-                                                'over epoch.')))
-                        self.data[key] = (epoch_name,
-                                          [in_data] * len(self.index))
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1065,18 +1065,17 @@ class Instrument(object):
                         # 'Epoch'
                         self.data[key] = (epoch_name, in_data)
                     elif len(in_data) == 1:
-                        # Only provided a single number in iterable, make that
-                        # the input for all times
-                        self.data[key] = (epoch_name,
-                                          [in_data[0]] * len(self.index))
+                        # Only provided a single number in iterable.
+                        # Assign as coord.
+                        self.data.coords[key] = (key, in_data[0])
                     elif len(in_data) == 0:
                         # Provided an empty iterable, make everything NaN
                         self.data[key] = (epoch_name,
                                           [np.nan] * len(self.index))
                 elif len(np.shape(in_data)) == 0:
-                    # Not an iterable input, rather a single number.  Make
-                    # that number the input for all times.
-                    self.data[key] = (epoch_name, [in_data] * len(self.index))
+                    # Not an iterable input, rather a single number.
+                    # Assign as coord.
+                    self.data.coords[key] = (key, in_data)
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1073,7 +1073,7 @@ class Instrument(object):
                         self.data[key] = (epoch_name,
                                           [np.nan] * len(self.index))
                 elif len(np.shape(in_data)) == 0:
-                    # Not an iterable input, rather a single number.
+                    # Not an iterable input, but a single number.
                     # Assign as coord.
                     self.data.coords[key] = (key, [in_data])
                 else:

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -766,6 +766,12 @@ class InstAccessTests(object):
         self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
         self.testInst['doubleMLT'] = 2.
         assert np.all(self.testInst['doubleMLT'] == 2.)
+        if self.testInst.pandas_format:
+            # Pandas will broadcast to time array
+            assert len(self.testInst['doubleMLT']) == len(self.testInst.index)
+        else:
+            # Xarray will assign as coordinate
+            assert len(self.testInst['doubleMLT']) == 1
 
         self.testInst['nanMLT'] = np.nan
         assert np.all(np.isnan(self.testInst['nanMLT']))

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -766,12 +766,7 @@ class InstAccessTests(object):
         self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
         self.testInst['doubleMLT'] = 2.
         assert np.all(self.testInst['doubleMLT'] == 2.)
-        if self.testInst.pandas_format:
-            # Pandas will broadcast to time array
-            assert len(self.testInst['doubleMLT']) == len(self.testInst.index)
-        else:
-            # Xarray will assign as a coordinate
-            assert len(self.testInst['doubleMLT']) == 1
+        assert len(self.testInst['doubleMLT']) == len(self.testInst.index)
 
         self.testInst['nanMLT'] = np.nan
         assert np.all(np.isnan(self.testInst['nanMLT']))

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -278,6 +278,41 @@ class TestBasicsNDXarray(TestBasics):
         self.testInst.data = data
         assert self.testInst.empty == target
 
+    @pytest.mark.parametrize("val,warn_msg",
+                             [([], "broadcast as NaN"),
+                              (27., "Broadcast over epoch")])
+    def test_set_xarray_single_value_warnings(self, val, warn_msg):
+        """Check for warning messages when setting xarray values.
+
+        Parameters
+        ----------
+        val : float or empty list
+            Value to be added as a new data variable.
+        warn_msg : str
+            Excerpt from expected warning message.
+
+        """
+
+        warnings.simplefilter("always")
+
+        self.testInst.load(date=self.ref_time, use_header=True)
+
+        with warnings.catch_warnings(record=True) as self.war:
+            self.testInst["new_val"] = val
+        testing.eval_warnings(self.war, warn_msg, warn_type=UserWarning)
+
+    def test_set_xarray_single_value_broadcast(self):
+        """Check that single values are correctly broadcast."""
+
+        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.data = self.testInst.data.assign_coords(
+            {'preset_val': 1.0})
+
+        self.testInst['preset_val'] = 3.0
+        self.testInst['new_val'] = 3.0
+        assert len(self.testInst['preset_val']) == 1
+        assert len(self.testInst['new_val']) == len(self.testInst.index)
+
 
 class TestBasicsShiftedFileDates(TestBasics):
     """Basic tests for pandas `pysat.Instrument` with shifted file dates."""

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -301,15 +301,23 @@ class TestBasicsNDXarray(TestBasics):
             self.testInst["new_val"] = val
         testing.eval_warnings(self.war, warn_msg, warn_type=UserWarning)
 
-    def test_set_xarray_single_value_broadcast(self):
-        """Check that single values are correctly broadcast."""
+    @pytest.mark.parametrize("new_val", [3.0, np.array(3.0)])
+    def test_set_xarray_single_value_broadcast(self, new_val):
+        """Check that single values are correctly broadcast.
+
+        Parameters
+        ----------
+        new_val : float or iterable
+            Should be a single value, potentially an array with one element.
+
+        """
 
         self.testInst.load(date=self.ref_time, use_header=True)
         self.testInst.data = self.testInst.data.assign_coords(
             {'preset_val': 1.0})
 
-        self.testInst['preset_val'] = 3.0
-        self.testInst['new_val'] = 3.0
+        self.testInst['preset_val'] = new_val
+        self.testInst['new_val'] = new_val
         # Existing coords should be not be broadcast
         assert self.testInst['preset_val'].size == 1
         # New variables broadcast over time

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -310,8 +310,8 @@ class TestBasicsNDXarray(TestBasics):
 
         self.testInst['preset_val'] = 3.0
         self.testInst['new_val'] = 3.0
-        assert len(self.testInst['preset_val']) == 1
         # Existing coords should be not be broadcast
+        assert self.testInst['preset_val'].size == 1
         # New variables broadcast over time
         assert len(self.testInst['new_val']) == len(self.testInst.index)
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -281,7 +281,7 @@ class TestBasicsNDXarray(TestBasics):
     @pytest.mark.parametrize("val,warn_msg",
                              [([], "broadcast as NaN"),
                               (27., "Broadcast over epoch"),
-                              (np.array(27.), "Broadcast over epoch")])
+                              (np.array([27.]), "Broadcast over epoch")])
     def test_set_xarray_single_value_warnings(self, val, warn_msg):
         """Check for warning messages when setting xarray values.
 
@@ -302,7 +302,30 @@ class TestBasicsNDXarray(TestBasics):
             self.testInst["new_val"] = val
         testing.eval_warnings(self.war, warn_msg, warn_type=UserWarning)
 
-    @pytest.mark.parametrize("new_val", [3.0, np.array(3.0)])
+    def test_set_xarray_single_value_errors(self):
+        """Check for warning messages when setting xarray values.
+
+        Parameters
+        ----------
+        val : float or iterable
+            Value to be added as a new data variable.
+        warn_msg : str
+            Excerpt from expected warning message.
+
+        """
+
+        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.data = self.testInst.data.assign_coords(
+            {'preset_val': np.array([1.0, 2.0])})
+
+        with pytest.raises(ValueError) as verr:
+            self.testInst['preset_val'] = 1.0
+
+        estr = 'Shape of input does not match'
+        assert str(verr).find(estr) > 0
+        return
+
+    @pytest.mark.parametrize("new_val", [3.0, np.array([3.0])])
     def test_set_xarray_single_value_broadcast(self, new_val):
         """Check that single values are correctly broadcast.
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -280,13 +280,14 @@ class TestBasicsNDXarray(TestBasics):
 
     @pytest.mark.parametrize("val,warn_msg",
                              [([], "broadcast as NaN"),
-                              (27., "Broadcast over epoch")])
+                              (27., "Broadcast over epoch"),
+                              (np.array(27.), "Broadcast over epoch")])
     def test_set_xarray_single_value_warnings(self, val, warn_msg):
         """Check for warning messages when setting xarray values.
 
         Parameters
         ----------
-        val : float or empty list
+        val : float or iterable
             Value to be added as a new data variable.
         warn_msg : str
             Excerpt from expected warning message.

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -311,6 +311,8 @@ class TestBasicsNDXarray(TestBasics):
         self.testInst['preset_val'] = 3.0
         self.testInst['new_val'] = 3.0
         assert len(self.testInst['preset_val']) == 1
+        # Existing coords should be not be broadcast
+        # New variables broadcast over time
         assert len(self.testInst['new_val']) == len(self.testInst.index)
 
 


### PR DESCRIPTION
# Description

Addresses #988

When setting a single value, xarray broadcasts data unneccessarily. This maps a single value to coords.
**EDIT: If the variable is new, it will still broadcast over time and warn the user.**

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Loading an xarray object and assigning it a new variable.

**Test Configuration**:
* Operating system: Monterrey 12.6.1
* Version number: Python 3.8.11

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
