### PR TITLE
BUG/DOC: Clarify instructions for adding new instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`
   * Clarified documentation and tests for name slicing support in pandas
+  * Clarified documentation for adding new instruments
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -41,7 +41,7 @@ be instantiated with the instrument's platform and name:
 
 .. code-block:: python
 
-  inst = Instrument('myplatform', 'myname')
+  inst = pysat.Instrument('myplatform', 'myname')
 
 
 .. _rst_new_inst-libs:
@@ -125,7 +125,7 @@ be lowercase when defined in the instrument module.
           'fancy': 'A higher-level processing of the data.'}
 
   # Dictionary keyed by inst_id with a list of supported tags for each key
-  inst_ids = {'A': ['', 'fancy'], 'B': ['', 'fancy'], 'C': ['']}
+  inst_ids = {'a': ['', 'fancy'], 'b': ['', 'fancy'], 'c': ['']}
 
 Note that the possible tags that can be invoked are '' and 'fancy'.  The tags
 dictionary includes a short description for each of these tags.  A blank tag
@@ -135,7 +135,7 @@ The supported inst_ids should also be stored in a dictionary.  Each key name
 here points to a list of the possible tags that can be associated with that
 particular :py:attr:`inst_id`. Note that not all satellites in the example
 support every level of processing. In this case the 'fancy' processing is
-available for satellites A and B, but not C.
+available for satellites 'a' and 'b', but not 'c'.
 
 For a dataset that does not need multiple levels of tags and inst_ids, an empty
 string can be used. The code below only supports loading a single data set.
@@ -176,18 +176,18 @@ acknowledgements and references for an instrument.  These are simply defined as
 strings at the instrument level.  In the most basic case, these can be defined
 with the data information at the top.
 
-pysat also requires that a logger handle be defined and instrumentment
+pysat also requires that a logger handle be defined and instrument
 information pertaining to acknowledgements and references be included.  These
 ensure that people using the data know who to contact with questions and what
 they should reference when publishing their results.  The logging handle should
-be assigned to the pysat logger handle, while the references and acknowedgements
-are defined as instrument attributes within the initalization method.
+be assigned to the pysat logger handle, while the references and acknowledgments
+are defined as instrument attributes within the initialization method.
 
 .. code:: python
 
   platform = 'your_platform_name'
   name = 'name_of_instrument'
-  tags = {'tag1': 'tag1 Descripton',
+  tags = {'tag1': 'tag1 Description',
           'tag2': 'tag2 Description'}
   inst_ids = {'': [tag for tag in tags.keys()]}
 

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -112,7 +112,8 @@ Naming Requirements in Instrument Module
 
 Each instrument file must include the platform and name as variables at the
 top-code-level of the file.  Additionally, the tags and inst_ids supported by
-the module must be stored as dictionaries.
+the module must be stored as dictionaries. Note that all required names should
+be lowercase when defined in the instrument module.
 
 .. code:: python
 


### PR DESCRIPTION
# Description

The current examples for adding a new instrument include upper case tags as examples.  This will break as `pysat.Instrument` will convert all input to lowercase values, which cannot be matched to uppercase instruments.

Additional correction of typos in doc.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Inspection of docs.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
