### PR TITLE
BUG: linkcheck in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Improved the documentation in `pysat.utils.files`
   * Clarified documentation and tests for name slicing support in pandas
   * Clarified documentation for adding new instruments
+  * Fixed broken links in docs
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/docs/citing.rst
+++ b/docs/citing.rst
@@ -2,7 +2,7 @@ Citations in the pysat ecosystem
 ================================
 
 When referring to this software package, please cite the original paper by
-Stoneback et al [2018] `<https://onlinelibrary.wiley.com/doi/10.1029/2018JA025297>`_
+Stoneback et al [2018] `<https://ntrs.nasa.gov/citations/20190002337>`_
 as well as the package `<https://doi.org/10.5281/zenodo.1199703>`_. Note that
 this DOI will always point to the latest version of the code.  A list of DOIs
 for all versions can be found at the Zenodo page above.


### PR DESCRIPTION
# Description

Addresses #1080

Updates the "broken" link to Stoneback et al 2018 in the docs.  The root cause seems to be Wiley is now rejecting linkcheck.  Updates to the NTRS record, which includes publicly available pdf of paper.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
sphinx-build -b linkcheck docs dist/docs
```

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
