### PR TITLE
BUG: check for user-supplied kwargs in list_remote_files

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3269,11 +3269,11 @@ class Instrument(object):
         return a subset of available files.
 
         """
-
-        # Add the function kwargs
-        if 'start' not in kwargs.keys():
+        # Add the method kwargs if they are not set to defaults
+        if start is not None:
             kwargs["start"] = start
-        if 'stop' not in kwargs.keys():
+
+        if stop is not None:
             kwargs["stop"] = stop
 
         # Add the user-supplied kwargs

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3271,8 +3271,10 @@ class Instrument(object):
         """
 
         # Add the function kwargs
-        kwargs["start"] = start
-        kwargs["stop"] = stop
+        if 'start' not in kwargs.keys():
+            kwargs["start"] = start
+        if 'stop' not in kwargs.keys():
+            kwargs["stop"] = stop
 
         # Add the user-supplied kwargs
         rtn_key = 'list_remote_files'

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -7,6 +7,7 @@ Base class stored here, but tests inherited by test_instrument.py
 """
 
 import datetime as dt
+import functools
 from importlib import reload
 import logging
 import numpy as np
@@ -17,6 +18,7 @@ import pytest
 import xarray as xr
 
 import pysat
+from pysat.instruments.methods import testing as ps_meth
 from pysat.utils import testing
 from pysat.utils.time import filter_datetime_input
 
@@ -145,6 +147,21 @@ class InstPropertyTests(object):
         assert filter_datetime_input(self.out[0]) == self.ref_time
         assert filter_datetime_input(self.out[-1]) == stop
         return
+
+    def test_remote_file_list_with_default_dates(self):
+        """Test setting the start / stop dates as default kwargs."""
+
+        # Set new defaults for kwargs
+        start=dt.datetime(2018, 1, 1)
+        stop=dt.datetime(2018, 2, 1)
+
+        # Update remote_file_list default dates
+        self.testInst._list_remote_files_rtn = functools.partial(
+            ps_meth.list_remote_files, start=start, stop=stop)
+
+        files = self.testInst.remote_file_list()
+        assert files.index[0] == start
+        assert files.index[-1] == stop
 
     @pytest.mark.parametrize("no_remote_files", [True, False])
     @pytest.mark.parametrize("download_keys", [

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -152,16 +152,16 @@ class InstPropertyTests(object):
         """Test setting the start / stop dates as default kwargs."""
 
         # Set new defaults for kwargs
-        start=dt.datetime(2018, 1, 1)
-        stop=dt.datetime(2018, 2, 1)
+        start = dt.datetime(2018, 1, 1)
+        stop = dt.datetime(2018, 2, 1)
 
         # Update remote_file_list default dates
         self.testInst._list_remote_files_rtn = functools.partial(
             ps_meth.list_remote_files, start=start, stop=stop)
 
         files = self.testInst.remote_file_list()
-        assert files.index[0] == start
-        assert files.index[-1] == stop
+        assert filter_datetime_input(files.index[0]) == start
+        assert filter_datetime_input(files.index[-1]) == stop
 
     @pytest.mark.parametrize("no_remote_files", [True, False])
     @pytest.mark.parametrize("download_keys", [


### PR DESCRIPTION
# Description

Addresses #1022

Allows default `start` and `stop` times to be set for libraries.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Can test against: https://github.com/pysat/pysatMadrigal/pull/82

Alternatively,
```
import datetime as dt
import functools
import pysat
from pysat.instruments.methods import testing as ps_meth

inst = pysat.Instrument('pysat', 'testing')

# Check default dates
inst.remote_file_list()

# Modify list_remote_files routine
inst._list_remote_files_rtn = functools.partial(
    ps_meth.list_remote_files, 
    start=dt.datetime(2018, 1, 1), stop=dt.datetime(2018, 12, 31))

#  Check that new dates are retrieved
inst.remote_file_list()
```

The first instance should yield dates between 2008 and 2010. After attaching a new routine with different default start and stop dates, the new date range (2018) is retrieved. When on `develop`, the 2nd instance will fail.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
