### PR TITLE
BUG: empty evaluation doesn't work with xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed `pysat.utils.io.apply_table_translation_to_file` check for duplicates
     in the meta translation table
   * Fixed an issue when passing dates through load_remote_files (#1022)
+  * Fixed a bug where data may not have any times, but still not be empty
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3240,7 +3240,7 @@ class Instrument(object):
                 # and xarray
                 self.data = self._next_data.copy()
                 self.data = self[temp_time:last_pad]
-                if not self.empty:
+                if len(self.index) > 0:
                     if (self.index[0] == temp_time):
                         self.data = self[1:]
                     self.concat_data(stored_data, prepend=True)

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -289,12 +289,12 @@ class TestBasicsNDXarray(TestBasics):
         """Test that xarray empty is False even if there is no time data."""
         # Load data and confirm it exists
         self.testInst.load(date=self.ref_time)
-        assert self.testInst.empty == False
+        assert not self.testInst.empty
 
         # Downselect to no time data
         self.testInst.data = self.testInst[self.ref_time + dt.timedelta(days=1):
                                            self.ref_time + dt.timedelta(days=2)]
-        assert self.testInst.empty == False
+        assert not self.testInst.empty
         assert len(self.testInst.index) == 0
         for dim in self.testInst.data.dims.keys():
             if dim != 'time':

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -285,6 +285,22 @@ class TestBasicsNDXarray(TestBasics):
         del self.testInst, self.out, self.ref_time, self.ref_doy
         return
 
+    def test_xarray_not_empty_notime(self):
+        """Test that xarray empty is False even if there is no time data."""
+        # Load data and confirm it exists
+        self.testInst.load(date=self.ref_time)
+        assert self.testInst.empty == False
+
+        # Downselect to no time data
+        self.testInst.data = self.testInst[self.ref_time + dt.timedelta(days=1):
+                                           self.ref_time + dt.timedelta(days=2)]
+        assert self.testInst.empty == False
+        assert len(self.testInst.index) == 0
+        for dim in self.testInst.data.dims.keys():
+            if dim != 'time':
+                assert len(self.testInst[dim]) > 0
+        return
+
     @pytest.mark.parametrize("index", [(0),
                                        ([0, 1, 2, 3]),
                                        (slice(0, 10)),
@@ -385,6 +401,7 @@ class TestBasicsNDXarray(TestBasics):
 
         self.testInst.data = data
         assert self.testInst.empty == target
+        return
 
     @pytest.mark.parametrize("val,warn_msg",
                              [([], "broadcast as NaN"),

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -410,10 +410,11 @@ def generate_instrument_list(inst_loc, user_info=None):
         Dictionary with keys 'names', 'download', 'no_download' that contain
         lists with different information for each key:
         'names' - list of platform_name combinations
-        'download' - dict containing 'inst_module', 'tag', and 'inst_id' for
-        instruments with download routines
-        'no_download' - dict containing 'inst_module', 'tag', and 'inst_id' for
-        instruments without download routines
+        'download' - list of dicts containing 'inst_module', 'tag', and
+        'inst_id' for instruments with download routines
+        'load_options' - list of dicts containing load and download options
+        'no_download' - list of dicts containing 'inst_module', 'tag', and
+        'inst_id' for instruments without download routines
 
     Note
     ----


### PR DESCRIPTION
# Description

When loading data that has an xarray format, it is possible to downselect data to a non-existent time range, but still have data that doesn't depend on time in the other dimensions.  In this case, because there's data, `instrument.empty` will be False.  However, there are no index values to select.  This causes pysat to Error.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
import pysatNASA

guvi = pysat.Instrument(inst_module=pysatNASA.instruments.timed_guvi, tag='sdr-imaging', inst_id='low_res'
stime = pysatNASA.instruments.timed_guvi._test_dates[guvi.inst_id][guvi.tag]
guvi.download(start=stime)
guvi.load(date=stime, use_header=True)

```

This will error on a different branch, but work with this one.

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant: timed_guvi branch of pysatNASA, develop will also work.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
