### PR TITLE
ENH: kwarg format for `print(inst)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added `to_inst` method to the Constellation class
   * Added `export_pysat_info` kwarg to `to_netcdf` routines to select whether
     pysat instrument info is writtent o files.
+  * Improved formatting of custom kwargs when running `print` on an instrument
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -682,11 +682,14 @@ class Instrument(object):
         output_str += '---------------\n'
         output_str += "Cleaning Level: '{:s}'\n".format(self.clean_level)
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
+        output_str += 'Keyword Arguments Passed: \n'
         for routine in self.kwargs.keys():
-            output_str += 'Keyword Arguments Passed to {:s}: \n'.format(routine)
-            for key in self.kwargs[routine].keys():
-                output_str += "    '{:s}': {:s}\n".format(
-                    key, str(self.kwargs[routine][key]))
+            # Only output for routine if kwargs are present.
+            if len(self.kwargs[routine].keys()) > 0:
+                output_str += "  To {:s}: \n".format(routine)
+                for key in self.kwargs[routine].keys():
+                    output_str += "    '{:s}': {:s}\n".format(
+                        key, str(self.kwargs[routine][key]))
 
         num_funcs = len(self.custom_functions)
         output_str += "Custom Functions: {:d} applied\n".format(num_funcs)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -682,14 +682,17 @@ class Instrument(object):
         output_str += '---------------\n'
         output_str += "Cleaning Level: '{:s}'\n".format(self.clean_level)
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
-        output_str += 'Keyword Arguments Passed: \n'
-        for routine in self.kwargs.keys():
-            # Only output for routine if kwargs are present.
-            if len(self.kwargs[routine].keys()) > 0:
-                output_str += "  To {:s}: \n".format(routine)
-                for key in self.kwargs[routine].keys():
-                    output_str += "    '{:s}': {:s}\n".format(
-                        key, str(self.kwargs[routine][key]))
+
+        if len(self.kwargs.keys()) > 0:
+            output_str += 'Keyword Arguments Passed: \n'
+
+            for routine in self.kwargs.keys():
+                # Only output for routine if kwargs are present.
+                if len(self.kwargs[routine].keys()) > 0:
+                    output_str += "  To {:s}: \n".format(routine)
+                    for key in self.kwargs[routine].keys():
+                        output_str += "    '{:s}': {:s}\n".format(
+                            key, str(self.kwargs[routine][key]))
 
         num_funcs = len(self.custom_functions)
         output_str += "Custom Functions: {:d} applied\n".format(num_funcs)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -683,7 +683,10 @@ class Instrument(object):
         output_str += "Cleaning Level: '{:s}'\n".format(self.clean_level)
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
 
-        if len(self.kwargs.keys()) > 0:
+        # Total kwargs passed to each routine.
+        num_kwargs = sum([len(ivm.kwargs[routine].keys())
+                          for routine in ivm.kwargs.keys()])
+        if num_kwargs > 0:
             output_str += 'Keyword Arguments Passed: \n'
 
             for routine in self.kwargs.keys():

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -683,8 +683,10 @@ class Instrument(object):
         output_str += "Cleaning Level: '{:s}'\n".format(self.clean_level)
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
         for routine in self.kwargs.keys():
-            output_str += 'Keyword Arguments Passed to {:s}: '.format(routine)
-            output_str += "{:s}\n".format(self.kwargs[routine].__str__())
+            output_str += 'Keyword Arguments Passed to {:s}: \n'.format(routine)
+            for key in self.kwargs[routine].keys():
+                output_str += "    '{:s}': {:s}\n".format(
+                    key, str(self.kwargs[routine][key]))
 
         num_funcs = len(self.custom_functions)
         output_str += "Custom Functions: {:d} applied\n".format(num_funcs)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -684,8 +684,8 @@ class Instrument(object):
         output_str += 'Data Padding: {:s}\n'.format(self.pad.__str__())
 
         # Total kwargs passed to each routine.
-        num_kwargs = sum([len(ivm.kwargs[routine].keys())
-                          for routine in ivm.kwargs.keys()])
+        num_kwargs = sum([len(self.kwargs[routine].keys())
+                          for routine in self.kwargs.keys()])
         if num_kwargs > 0:
             output_str += 'Keyword Arguments Passed: \n'
 


### PR DESCRIPTION
# Description

The current output of kwargs can be difficult to read, especially when multiple kwargs which include lengthy strings are used.  This makes it particularly difficult when comparing multiple instruments with different TLEs when using pysatMissions.

This parses each kwarg as a separate line when running `print(inst)`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import datetime as dt
import numpy as np
import pandas as pds
import pysat

from pysatMissions.instruments import missions_sgp4

# Use SPORT TLEs as an example
line1 = '1 55129U 98067UW  23039.82653086  .00049915  00000-0  78305-3 0  9991'
line2 = '2 55129  51.6397 243.8305 0001856 340.7022  19.3898 15.53177014  6499'


file_date_range = pds.date_range(dt.datetime(2022, 12, 30),
                                 dt.datetime(2023, 2, 28))

sport = pysat.Instrument(inst_module=missions_sgp4, tle1=line1, tle2=line2,
                         use_header=True, file_date_range=file_date_range)

print(sport)
```
in develop:
```
pysat Instrument object
-----------------------
Platform: 'missions'
Name: 'sgp4'
Tag: ''
Instrument id: ''

Data Processing
---------------
Cleaning Level: 'clean'
Data Padding: None
Keyword Arguments Passed to list_files: {'file_date_range': DatetimeIndex(['2022-12-30', '2022-12-31', '2023-01-01', '2023-01-02',
               '2023-01-03', '2023-01-04', '2023-01-05', '2023-01-06',
               '2023-01-07', '2023-01-08', '2023-01-09', '2023-01-10',
               '2023-01-11', '2023-01-12', '2023-01-13', '2023-01-14',
               '2023-01-15', '2023-01-16', '2023-01-17', '2023-01-18',
               '2023-01-19', '2023-01-20', '2023-01-21', '2023-01-22',
               '2023-01-23', '2023-01-24', '2023-01-25', '2023-01-26',
               '2023-01-27', '2023-01-28', '2023-01-29', '2023-01-30',
               '2023-01-31', '2023-02-01', '2023-02-02', '2023-02-03',
               '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07',
               '2023-02-08', '2023-02-09', '2023-02-10', '2023-02-11',
               '2023-02-12', '2023-02-13', '2023-02-14', '2023-02-15',
               '2023-02-16', '2023-02-17', '2023-02-18', '2023-02-19',
               '2023-02-20', '2023-02-21', '2023-02-22', '2023-02-23',
               '2023-02-24', '2023-02-25', '2023-02-26', '2023-02-27',
               '2023-02-28'],
              dtype='datetime64[ns]', freq='D')}
Keyword Arguments Passed to load: {'tle1': '1 55129U 98067UW  23039.82653086  .00049915  00000-0  78305-3 0  9991', 'tle2': '2 55129  51.6397 243.8305 0001856 340.7022  19.3898 15.53177014  6499', 'use_header': True, 'epoch': Timestamp('2022-12-30 00:00:00', freq='D')}
Keyword Arguments Passed to preprocess: {}
Keyword Arguments Passed to download: {}
Keyword Arguments Passed to list_remote_files: {}
Keyword Arguments Passed to clean: {}
Keyword Arguments Passed to init: {}
Custom Functions: 0 applied

Local File Statistics
---------------------
Number of files: 61
Date Range: 30 December 2022 --- 28 February 2023

Loaded Data Statistics
----------------------
No loaded data.

```

This branch:
```
pysat Instrument object
-----------------------
Platform: 'missions'
Name: 'sgp4'
Tag: ''
Instrument id: ''

Data Processing
---------------
Cleaning Level: 'clean'
Data Padding: None
Keyword Arguments Passed to list_files: 
    'file_date_range': DatetimeIndex(['2022-12-30', '2022-12-31', '2023-01-01', '2023-01-02',
               '2023-01-03', '2023-01-04', '2023-01-05', '2023-01-06',
               '2023-01-07', '2023-01-08', '2023-01-09', '2023-01-10',
               '2023-01-11', '2023-01-12', '2023-01-13', '2023-01-14',
               '2023-01-15', '2023-01-16', '2023-01-17', '2023-01-18',
               '2023-01-19', '2023-01-20', '2023-01-21', '2023-01-22',
               '2023-01-23', '2023-01-24', '2023-01-25', '2023-01-26',
               '2023-01-27', '2023-01-28', '2023-01-29', '2023-01-30',
               '2023-01-31', '2023-02-01', '2023-02-02', '2023-02-03',
               '2023-02-04', '2023-02-05', '2023-02-06', '2023-02-07',
               '2023-02-08', '2023-02-09', '2023-02-10', '2023-02-11',
               '2023-02-12', '2023-02-13', '2023-02-14', '2023-02-15',
               '2023-02-16', '2023-02-17', '2023-02-18', '2023-02-19',
               '2023-02-20', '2023-02-21', '2023-02-22', '2023-02-23',
               '2023-02-24', '2023-02-25', '2023-02-26', '2023-02-27',
               '2023-02-28'],
              dtype='datetime64[ns]', freq='D')
Keyword Arguments Passed to load: 
    'tle1': 1 55129U 98067UW  23039.82653086  .00049915  00000-0  78305-3 0  9991
    'tle2': 2 55129  51.6397 243.8305 0001856 340.7022  19.3898 15.53177014  6499
    'use_header': True
    'epoch': 2022-12-30 00:00:00
Keyword Arguments Passed to preprocess: 
Keyword Arguments Passed to download: 
Keyword Arguments Passed to list_remote_files: 
Keyword Arguments Passed to clean: 
Keyword Arguments Passed to init: 
Custom Functions: 0 applied

Local File Statistics
---------------------
Number of files: 61
Date Range: 30 December 2022 --- 28 February 2023

Loaded Data Statistics
----------------------
No loaded data.
```

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
