### PR TITLE
BUG: fix meta values in test instruments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed broken links in docs
   * Updated docstring header underline lengths and addressed documentation
     build errors and warnings
+  * Added standard test for `to_netcdf` for instrument libraries
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,7 +72,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added `constellations.testing_partial`, which loads a partially empty
     constellation dataset
   * Reduced default num_samples for constellation test objects
-  * Added standard test for `to_netcdf` for instrument libraries
+  * Improved consistency in metadata for test instruments
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -164,8 +164,10 @@ def load(fnames, tag='', inst_id='', start_time=None, num_samples=96,
     # Adjust metadata from overall defaults
     meta['dummy1'] = {'value_min': -2**32 + 2, 'value_max': 2**32 - 1,
                       'fill': -2**32 + 1}
-    meta['dummy2'] = {'value_min': -2**32 + 2, 'value_max': 2**32 - 1,
-                      'fill': -2**32 + 1}
+    if tag == '':
+        # Assign metadata unique to default tag
+        meta['dummy2'] = {'value_min': -2**32 + 2, 'value_max': 2**32 - 1,
+                          'fill': -2**32 + 1}
 
     if tag == 'pressure_levels':
         # Assigning new metadata for altitude since it differs from default info
@@ -180,14 +182,15 @@ def load(fnames, tag='', inst_id='', start_time=None, num_samples=96,
 
         # Assigning metadata for meridional ion drifts since it differs from
         # default info.
-        meta['iv_mer'] = {meta.labels.units: 'm/s',
-                          meta.labels.name: 'Meridional Ion Drift',
-                          meta.labels.min_val: -250.,
-                          meta.labels.max_val: 250.,
-                          meta.labels.desc: ' '.join(('Non-physical meridional',
-                                                      'ion drifts.')),
-                          meta.labels.notes: '',
-                          meta.labels.fill_val: np.nan}
+        meta['dummy_drifts'] = {meta.labels.units: 'm/s',
+                                meta.labels.name: 'Meridional Ion Drift',
+                                meta.labels.min_val: -250.,
+                                meta.labels.max_val: 250.,
+                                meta.labels.desc: ' '.join(('Non-physical',
+                                                            'meridional',
+                                                            'ion drifts.')),
+                                meta.labels.notes: '',
+                                meta.labels.fill_val: np.nan}
 
         # Assign metadata for the new coordinate axis here, `lev` and `ilev`.
         meta['lev'] = {meta.labels.units: '',

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -373,6 +373,8 @@ class InstLibTests(object):
         """
 
         test_inst, date = initialize_test_inst_and_date(inst_dict)
+        if test_inst.platform == 'pysat' and test_inst.name == 'testing2d':
+            pytest.skip('Not maintaining deprecated module')
         if len(test_inst.files.files) > 0:
             self.load_data(test_inst, date)
 
@@ -384,7 +386,11 @@ class InstLibTests(object):
             data, meta = pysat.utils.io.load_netcdf(
                 fpath, pandas_format=test_inst.pandas_format)
 
-            assert data.equals(test_inst.data)
+            if test_inst.pandas_format:
+                # Convert to xarray tp sort variable names
+                assert data.to_xarray().equals(test_inst.data.to_xarray())
+            else:
+                assert data.equals(test_inst.data)
             assert meta == test_inst.meta
 
         else:

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -32,6 +32,7 @@ Examples
 
 import datetime as dt
 from importlib import import_module
+import os
 import tempfile
 import warnings
 
@@ -354,6 +355,41 @@ class InstLibTests(object):
             pytest.skip("Download data not available")
 
         return
+
+    @pytest.mark.second
+    @pytest.mark.download
+    def test_to_netcdf(self, inst_dict):
+        """Test that to_netcdf accurately writes data.
+
+        Parameters
+        ----------
+        inst_dict : dict
+            Dictionary containing info to instantiate a specific instrument.
+            Set automatically from instruments['download'] when
+            `initialize_test_package` is run.
+
+        """
+
+        test_inst, date = initialize_test_inst_and_date(inst_dict)
+        if len(test_inst.files.files) > 0:
+            self.load_data(test_inst, date)
+
+            # Write data to tempdir
+            fpath = os.path.join(self.tempdir.name, 'test_data.nc')
+            test_inst.to_netcdf4(fpath)
+
+            # Load from netcdf
+            data, meta = pysat.utils.io.load_netcdf(
+                fpath, pandas_format=test_inst.pandas_format)
+
+            assert data.equals(test_inst.data)
+            assert meta == test_inst.meta
+
+        else:
+            pytest.skip("Download data not available")
+
+        return
+
 
     @pytest.mark.download
     def test_remote_file_list(self, inst_dict):

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -373,8 +373,11 @@ class InstLibTests(object):
         """
 
         test_inst, date = initialize_test_inst_and_date(inst_dict)
+
+        # TODO(#913): Can remove the skip lines once this module is removed.
         if test_inst.platform == 'pysat' and test_inst.name == 'testing2d':
             pytest.skip('Not maintaining deprecated module')
+
         if len(test_inst.files.files) > 0:
             self.load_data(test_inst, date)
 

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -188,6 +188,8 @@ class InstLibTests(object):
         return instruments
 
     def load_data(self, inst, date):
+        """Load data even if strict_time is not maintained."""
+
         try:
             inst.load(date=date, use_header=True)
         except ValueError as verr:

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -401,7 +401,6 @@ class InstLibTests(object):
 
         return
 
-
     @pytest.mark.download
     def test_remote_file_list(self, inst_dict):
         """Test if optional list_remote_files routine exists and is callable.

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -1435,7 +1435,7 @@ def return_epoch_metadata(inst, epoch_name):
     basic_labels = [inst.meta.labels.units]
 
     for label in basic_labels:
-        if label not in new_dict or len(new_dict[label]) == 0:
+        if label not in new_dict or new_dict[label] == '':
             new_dict[label] = epoch_label
 
     # Assign name

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -2037,7 +2037,8 @@ def inst_to_netcdf(inst, fname, base_instrument=None, epoch_name=None,
                            * 1.0E-6).astype(np.int64)
 
         # Update 'time' dimension to `epoch_name`
-        xr_data = xr_data.rename({'time': epoch_name})
+        if epoch_name != 'time':
+            xr_data = xr_data.rename({'time': epoch_name})
 
         # Transfer metadata
         pysat_meta_to_xarray_attr(xr_data, export_meta, epoch_name)


### PR DESCRIPTION
# Description

Preparation for #585

Bugs fixed:
- Mismatch between meta and data in `pysat_testmodel`.  Meta values without data will not be written to file.
- Bad check for empty meta value (detailed in #585)
- Renaming 'time' as 'time' prompts an xarray warning, now checks that epoch name is not 'time'

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

writing a netcdf from the test instruments.  A mismatch between meta and data will result in values being dropped.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
