### PR TITLE
ENH/BUG: added a function to update fill values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added a core utility to update fill values consistently in the data and
     metadata
   * Adapted `check_and_make_path` to treat an empty path as the current dir
+  * Added `meta_kwargs` attribute and kwarg to Instrument, allowing full custom
+    specification of the Meta class on instantiation
+  * Expanded MetaLabels type defaults for 'max_val', 'min_val', and 'fill_val'
+    to include more common data types
+  * Added `data_types` input to Meta and certain MetaLabels methods, allowing
+    the default values to be set to the specified data type when multiple types
+    are allowed
+* Deprecations
+   * Deprecated the Instrument kwarg `labels` in favor of `meta_kwargs` and
+     replaced the `meta_labels` attribute with the `meta_kwargs` attribute
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed broken links in docs
   * Updated docstring header underline lengths and addressed documentation
     build errors and warnings
+  * Expanded MetaLabel default types for `min_val`, `max_val`, and `fill_val`
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,10 +22,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     to include more common data types
   * Added `data_types` input to Meta and certain MetaLabels methods, allowing
     the default values to be set to the specified data type when multiple types
-    are allowed
+    are allowed, ensure these are updated when adding new data to an Instrument
+  * Added `_update_label_types` to MetaLabels, expanding the Python float/int
+    types to include all numpy float/int types
 * Deprecations
    * Deprecated the Instrument kwarg `labels` in favor of `meta_kwargs` and
      replaced the `meta_labels` attribute with the `meta_kwargs` attribute
+   * Deprecated the `labels` keyword arg in favor of `meta_kwargs` in the
+     netCDF I/O functions and Instrument sub-module.
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added Constellation class examples to the docs tutorial
   * Added links to the project standards repository to the docs
   * Improved formatting of custom kwargs when running `print` on an instrument
+  * Added a core utility to update fill values consistently in the data and
+    metadata
+  * Adapted `check_and_make_path` to treat an empty path as the current dir
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly
@@ -25,6 +28,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     in the meta translation table
   * Fixed an issue when passing dates through load_remote_files (#1022)
   * Fixed a bug where data may not have any times, but still not be empty
+  * Fixed a bug where metadata with values of None are assigned as useful
+    attributes when attaching metadata to xarray objects
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1907,7 +1907,7 @@ class Instrument(object):
 
     @property
     def meta_labels(self):
-        """Deprecated attribute, returns `labels` specification for MetaLabels.
+        """Provide Meta input for labels kwarg, deprecated.
 
         Returns
         -------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1003,9 +1003,7 @@ class Instrument(object):
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
 
-                if len(self.data[key[1]].values) > 0:
-                    self.meta._data_types[key[1]] = type(
-                        self.data[key[1]].values[0])
+                self.meta._data_types[key[1]] = self.data[key[1]].values.dtype
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):
@@ -1042,8 +1040,11 @@ class Instrument(object):
 
             # Assign data and any extra metadata
             self.data[key] = in_data
-            if len(self.data[key].values) > 0:
-                self.meta._data_types[key] = type(self.data[key].values[0])
+
+            for lkey in pysat.utils.listify(key):
+                if not isinstance(lkey, slice) and key in self.variables:
+                    self.meta._data_types[lkey] = self.data[lkey].values.dtype
+
             self.meta[key] = new
 
         else:
@@ -1077,9 +1078,7 @@ class Instrument(object):
                     # Try loading indexed as integers
                     self.data[key[-1]][indict] = in_data
 
-                if len(self.data[key[-1]].values) > 0:
-                    self.meta._data_types[key[-1]] = type(
-                        self.data[key[-1]].values[0])
+                self.meta._data_types[key[-1]] = self.data[key[-1]].values.dtype
                 self.meta[key[-1]] = new
                 return
             elif isinstance(key, str):
@@ -1139,10 +1138,10 @@ class Instrument(object):
                 # individually.
                 for keyname in key:
                     self.data[keyname] = in_data[keyname]
+                    self.meta._data_types[keyname] = self.data[
+                        keyname].values.dtype
 
             # Attach metadata
-            if len(self.data[key].values) > 0:
-                self.meta._data_types[key] = type(self.data[key].values[0])
             self.meta[key] = new
 
         return

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1003,7 +1003,8 @@ class Instrument(object):
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
 
-                self.meta._data_types[key[1]] = self.data[key[1]].values.dtype
+                self.meta._data_types[key[1]] = self.data[
+                    key[1]].values.dtype.type
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):
@@ -1042,8 +1043,9 @@ class Instrument(object):
             self.data[key] = in_data
 
             for lkey in pysat.utils.listify(key):
-                if not isinstance(lkey, slice) and key in self.variables:
-                    self.meta._data_types[lkey] = self.data[lkey].values.dtype
+                if not isinstance(lkey, slice) and lkey in self.variables:
+                    self.meta._data_types[lkey] = self.data[
+                        lkey].values.dtype.type
 
             self.meta[key] = new
 
@@ -1078,7 +1080,8 @@ class Instrument(object):
                     # Try loading indexed as integers
                     self.data[key[-1]][indict] = in_data
 
-                self.meta._data_types[key[-1]] = self.data[key[-1]].values.dtype
+                self.meta._data_types[key[-1]] = self.data[
+                    key[-1]].values.dtype.type
                 self.meta[key[-1]] = new
                 return
             elif isinstance(key, str):
@@ -1139,7 +1142,7 @@ class Instrument(object):
                 for keyname in key:
                     self.data[keyname] = in_data[keyname]
                     self.meta._data_types[keyname] = self.data[
-                        keyname].values.dtype
+                        keyname].values.dtype.type
 
             # Attach metadata
             self.meta[key] = new

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1002,6 +1002,10 @@ class Instrument(object):
                     # for list, array. Assume key[0] is integer
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
+
+                if len(self.data[key[1]].values) > 0:
+                    self.meta._data_types[key[1]] = type(
+                        self.data[key[1]].values[0])
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):
@@ -1038,6 +1042,8 @@ class Instrument(object):
 
             # Assign data and any extra metadata
             self.data[key] = in_data
+            if len(self.data[key].values) > 0:
+                self.meta._data_types[key] = type(self.data[key].values[0])
             self.meta[key] = new
 
         else:
@@ -1071,6 +1077,9 @@ class Instrument(object):
                     # Try loading indexed as integers
                     self.data[key[-1]][indict] = in_data
 
+                if len(self.data[key[-1]].values) > 0:
+                    self.meta._data_types[key[-1]] = type(
+                        self.data[key[-1]].values[0])
                 self.meta[key[-1]] = new
                 return
             elif isinstance(key, str):
@@ -1135,6 +1144,8 @@ class Instrument(object):
                     self.data[keyname] = in_data[keyname]
 
             # Attach metadata
+            if len(self.data[key].values) > 0:
+                self.meta._data_types[key] = type(self.data[key].values[0])
             self.meta[key] = new
 
         return

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -90,13 +90,12 @@ class Instrument(object):
         of files found will be checked to ensure the filesizes are greater than
         zero. Empty files are removed from the stored list of files.
         (default=False)
-    labels : dict
+    labels : dict or NoneType
         Dict where keys are the label attribute names and the values are tuples
-        that have the label values and value types in that order.
-        (default={'units': ('units', str), 'name': ('long_name', str),
-        'notes': ('notes', str), 'desc': ('desc', str),
-        'min_val': ('value_min', float),
-        'max_val': ('value_max', float), 'fill_val': ('fill', float)})
+        that have the label values and value types in that order. If None uses
+        the Meta defaults. Deprecated, use `meta_kwargs` (default=None)
+    meta_kwargs : dict or NoneType
+        Dict to specify custom Meta initialization (default=None)
     custom : list or NoneType
         Input list containing dicts of inputs for `custom_attach` method inputs
         that may be applied or None (default=None)
@@ -148,8 +147,8 @@ class Instrument(object):
         day
     meta : pysat.Meta
         Class holding the instrument metadata
-    meta_labels : dict
-        Dict containing defaults for new Meta data labels
+    meta_kwargs : dict
+        Dict containing defaults for Meta data
     orbits : pysat.Orbits
         Interface to extracting data orbit-by-orbit
     pandas_format : bool
@@ -253,12 +252,7 @@ class Instrument(object):
                  orbit_info=None, inst_module=None, data_dir='',
                  directory_format=None, file_format=None,
                  temporary_file_list=False, strict_time_flag=True,
-                 ignore_empty_files=False,
-                 labels={'units': ('units', str), 'name': ('long_name', str),
-                         'notes': ('notes', str), 'desc': ('desc', str),
-                         'min_val': ('value_min', np.float64),
-                         'max_val': ('value_max', np.float64),
-                         'fill_val': ('fill', np.float64)},
+                 ignore_empty_files=False, labels=None, meta_kwargs=None,
                  custom=None, **kwargs):
         """Initialize `pysat.Instrument` object."""
 
@@ -429,8 +423,15 @@ class Instrument(object):
 
         # Create Meta instance with appropriate labels.  Meta class methods will
         # use Instrument definition of MetaLabels over the Metadata declaration.
-        self.meta_labels = labels
-        self.meta = pysat.Meta(labels=self.meta_labels)
+        self.meta_kwargs = {} if meta_kwargs is None else meta_kwargs
+
+        if labels is not None:
+            warnings.warn("".join(["`labels` is deprecated, use `meta_kwargs`",
+                                   "with the 'labels' key instead. Support ",
+                                   "for `labels` will be removed in v3.2.0+"]),
+                          DeprecationWarning, stacklevel=2)
+            self.meta_kwargs["labels"] = labels
+        self.meta = pysat.Meta(**self.meta_kwargs)
         self.meta.mutable = False
 
         # Nano-kernel processing variables. Feature processes data on each load.
@@ -1031,7 +1032,7 @@ class Instrument(object):
                         # subvariables.  Meta can filter out empty metadata as
                         # needed, the check above reduces the need to create
                         # Meta instances.
-                        ho_meta = pysat.Meta(labels=self.meta_labels)
+                        ho_meta = pysat.Meta(**self.meta_kwargs)
                         ho_meta[in_data[0].columns] = {}
                         self.meta[key] = ho_meta
 
@@ -1615,12 +1616,12 @@ class Instrument(object):
             except pds.errors.OutOfBoundsDatetime:
                 bad_datetime = True
                 data = self._null_data.copy()
-                mdata = pysat.Meta(labels=self.meta_labels)
+                mdata = pysat.Meta(**self.meta_kwargs)
 
         else:
             bad_datetime = False
             data = self._null_data.copy()
-            mdata = pysat.Meta(labels=self.meta_labels)
+            mdata = pysat.Meta(**self.meta_kwargs)
 
         output_str = '{platform} {name} {tag} {inst_id}'
         output_str = output_str.format(platform=self.platform,
@@ -1903,6 +1904,30 @@ class Instrument(object):
 
     # -----------------------------------------------------------------------
     # Define all accessible methods
+
+    @property
+    def meta_labels(self):
+        """Deprecated attribute, returns `labels` specification for MetaLabels.
+
+        Returns
+        -------
+        dict
+            Either Meta default provided locally or custom value provided
+            by user and stored in `meta_kwargs['labels']`
+
+        """
+        warnings.warn("".join(["Deprecated attribute, returns `meta_kwargs",
+                               "['labels']` or Meta defaults if not set. Will",
+                               " be removed in pysat 3.2.0+"]),
+                      DeprecationWarning, stacklevel=2)
+        if 'labels' in self.meta_kwargs.keys():
+            return self.meta_kwargs['labels']
+        else:
+            return {'units': ('units', str), 'name': ('long_name', str),
+                    'notes': ('notes', str), 'desc': ('desc', str),
+                    'min_val': ('value_min', (float, int)),
+                    'max_val': ('value_max', (float, int)),
+                    'fill_val': ('fill', (float, int, str))}
 
     @property
     def bounds(self):

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1862,7 +1862,10 @@ class MetaLabels(object):
                 if int in ltypes:
                     ltypes.extend([np.int64, np.int32, np.int16, np.int8, bool])
 
-                self.label_type[lkey] = tuple(set(ltypes))
+                # This may result in duplicate numpy types, but order is more
+                # important than carrying around a duplicate type, as the first
+                # type in the provided tuple is the default type
+                self.label_type[lkey] = tuple(ltypes)
         return
 
     def _eval_label_type(self, val_type):

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -34,13 +34,17 @@ class Meta(object):
         that have the label values and value types in that order.
         (default={'units': ('units', str), 'name': ('long_name', str),
         'notes': ('notes', str), 'desc': ('desc', str),
-        'min_val': ('value_min', float), 'max_val': ('value_max', float),
-        'fill_val': ('fill', float)})
+        'min_val': ('value_min', (float, int)),
+        'max_val': ('value_max', (float, int)),
+        'fill_val': ('fill', (float, int, str))})
     export_nan : list or NoneType
         List of labels that should be exported even if their value is NaN or
         None for an empty list. When used, metadata with a value of NaN will
         be excluded from export. Will always allow NaN export for labels of
         the float type. (default=None)
+    data_types : dict or NoneType
+        Dict of data types for variables names or None to disregard.
+        (default=None)
 
     Attributes
     ----------
@@ -163,9 +167,10 @@ class Meta(object):
     def __init__(self, metadata=None, header_data=None,
                  labels={'units': ('units', str), 'name': ('long_name', str),
                          'notes': ('notes', str), 'desc': ('desc', str),
-                         'min_val': ('value_min', float),
-                         'max_val': ('value_max', float),
-                         'fill_val': ('fill', float)}, export_nan=None):
+                         'min_val': ('value_min', (float, int)),
+                         'max_val': ('value_max', (float, int)),
+                         'fill_val': ('fill', (float, int, str))},
+                 export_nan=None, data_types=None):
         """Initialize `pysat.Meta` object."""
         # Set mutability of Meta attributes.  This flag must be set before
         # anything else, or `__setattr__` breaks.
@@ -182,6 +187,9 @@ class Meta(object):
 
         # Set the labels
         self.labels = MetaLabels(metadata=self, **labels)
+
+        # Set the data types, if provided
+        self._data_types = data_types
 
         # Initialize higher order (nD) data structure container, a dict
         self._ho_data = {}
@@ -366,11 +374,18 @@ class Meta(object):
             data_vars = self.var_case_name(data_vars)
             meta_vars = list(self.keys())
             def_vars = list()
+            data_var_types = None if self._data_types is None else list()
             for var in data_vars:
                 if var not in meta_vars:
                     def_vars.append(var)
+                    if data_var_types is not None:
+                        if var in self._data_types.keys():
+                            data_var_types.append(self._data_types[var])
+                        else:
+                            data_var_types.append(None)
+
             if len(def_vars) > 0:
-                self._insert_default_values(def_vars)
+                self._insert_default_values(def_vars, data_var_types)
 
             # Check if input dict empty.  If so, no metadata was assigned by
             # the user.  This is an empty call and we can head out,
@@ -774,28 +789,39 @@ class Meta(object):
     # -----------------------------------------------------------------------
     # Define the hidden methods
 
-    def _insert_default_values(self, data_var):
+    def _insert_default_values(self, data_var, data_type=None):
         """Set the default label values for a data variable.
 
         Parameters
         ----------
         data_var : str or list
             Single or multiple data variable name(s).
+        data_type : type, list, or NoneType
+            Type for the data value(s) or None if not specified (default=None)
 
         Note
         ----
         Sets NaN for all float values, -1 for all int values, 'data_var' for
         names labels, '' for all other str values, and None for any other
-        data type.
+        data type. If there are multiple data types, sets the data type (if
+        included).  Otherwise, chooses the first type in the tuple.
 
         """
         # Cycle through each label type to create a list of label names
         # and label default values
         labels = list()
+        lattrs = list()
         default_vals = list()
         name_idx = None
+        need_data_type = dict()
         for i, lattr in enumerate(self.labels.label_type.keys()):
             labels.append(getattr(self.labels, lattr))
+            lattrs.append(lattr)
+            if(isinstance(self.labels.label_type[lattr], tuple)
+               and data_type is not None):
+                need_data_type[lattr] = True
+            else:
+                need_data_type[lattr] = False
 
             if lattr in ['name']:
                 default_vals.append('')
@@ -805,10 +831,22 @@ class Meta(object):
 
         # Assign the default values to the DataFrame for this data variable(s).
         data_vars = pysat.utils.listify(data_var)
-        for var in data_vars:
+        if data_type is None:
+            var_types = [None for dvar in data_vars]
+        else:
+            var_types = pysat.utils.listify(data_type)
+
+        for i, var in enumerate(data_vars):
             if name_idx is not None:
                 default_vals[name_idx] = var
-            self._data.loc[var, labels] = default_vals
+
+            if not np.any(list(need_data_type.values())):
+                self._data.loc[var, labels] = default_vals
+            else:
+                data_default = [self.labels.default_values_from_attr(
+                    lattrs[j], var_types[i]) if need_data_type[lattrs[j]]
+                                else val for j, val in enumerate(default_vals)]
+                self._data.loc[var, labels] = data_default
 
         return
 
@@ -1627,13 +1665,13 @@ class MetaLabels(object):
         Description label name and value type(s) (default=('desc', str))
     min_val : tuple
         Minimum value label name and value type(s)
-        (default=('value_min', (int, float)))
+        (default=('value_min', (float, int)))
     max_val : tuple
         Maximum value label name and value type(s)
-        (default=('value_max', (int, float)))
+        (default=('value_max', (float, int)))
     fill_val : tuple
         Fill value label name and value type(s)
-        (default=('fill', (int, float, str)))
+        (default=('fill', (float, int, str)))
     kwargs : dict
         Dictionary containing optional label attributes, where the keys are the
         attribute names and the values are tuples containing the label name and
@@ -1699,9 +1737,9 @@ class MetaLabels(object):
 
     def __init__(self, metadata=None, units=('units', str),
                  name=('long_name', str), notes=('notes', str),
-                 desc=('desc', str), min_val=('value_min', (int, float)),
-                 max_val=('value_max', (int, float)),
-                 fill_val=('fill', (int, float, str)), **kwargs):
+                 desc=('desc', str), min_val=('value_min', (float, int)),
+                 max_val=('value_max', (float, int)),
+                 fill_val=('fill', (float, int, str)), **kwargs):
         """Initialize the MetaLabels class."""
 
         # Initialize the coupled metadata
@@ -1831,13 +1869,15 @@ class MetaLabels(object):
 
         return valid
 
-    def default_values_from_type(self, val_type):
+    def default_values_from_type(self, val_type, data_type=None):
         """Retrieve the default values for each label based on their type.
 
         Parameters
         ----------
         val_type : type
             Variable type for the value to be assigned to a MetaLabel
+        data_type : type or NoneType
+            Type for the data values or None if not specified (default=None)
 
         Returns
         -------
@@ -1846,6 +1886,12 @@ class MetaLabels(object):
             all str values, and None for any other data type
 
         """
+
+        if isinstance(val_type, tuple):
+            if data_type in val_type:
+                val_type = data_type
+            else:
+                val_type = val_type[0]
 
         # Perform some pre-checks on type, checks that could error with
         # unexpected input.
@@ -1889,13 +1935,15 @@ class MetaLabels(object):
 
         return default_val
 
-    def default_values_from_attr(self, attr_name):
+    def default_values_from_attr(self, attr_name, data_type=None):
         """Retrieve the default values for each label based on their type.
 
         Parameters
         ----------
         attr_name : str
             Label attribute name (e.g., max_val)
+        data_type : type or NoneType
+            Type for the data values or None if not specified (default=None)
 
         Returns
         -------
@@ -1920,7 +1968,7 @@ class MetaLabels(object):
             default_val = 'linear'
         else:
             default_val = self.default_values_from_type(
-                self.label_type[attr_name])
+                self.label_type[attr_name], data_type=data_type)
             if default_val is None:
                 mstr = ' '.join(('A problem may have been',
                                  'encountered with the user',

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -1618,19 +1618,22 @@ class MetaLabels(object):
     Parameters
     ----------
     units : tuple
-        Units label name and value type (default=('units', str))
+        Units label name and value type(s) (default=('units', str))
     name : tuple
-        Name label name and value type (default=('long_name', str))
+        Name label name and value type(s) (default=('long_name', str))
     notes : tuple
-        Notes label name and value type (default=('notes', str))
+        Notes label name and value type(s) (default=('notes', str))
     desc : tuple
-        Description label name and value type (default=('desc', str))
+        Description label name and value type(s) (default=('desc', str))
     min_val : tuple
-        Minimum value label name and value type (default=('value_min', float))
+        Minimum value label name and value type(s)
+        (default=('value_min', (int, float)))
     max_val : tuple
-        Maximum value label name and value type (default=('value_max', float))
+        Maximum value label name and value type(s)
+        (default=('value_max', (int, float)))
     fill_val : tuple
-        Fill value label name and value type (default=('fill', float))
+        Fill value label name and value type(s)
+        (default=('fill', (int, float, str)))
     kwargs : dict
         Dictionary containing optional label attributes, where the keys are the
         attribute names and the values are tuples containing the label name and
@@ -1696,9 +1699,9 @@ class MetaLabels(object):
 
     def __init__(self, metadata=None, units=('units', str),
                  name=('long_name', str), notes=('notes', str),
-                 desc=('desc', str), min_val=('value_min', float),
-                 max_val=('value_max', float), fill_val=('fill', float),
-                 **kwargs):
+                 desc=('desc', str), min_val=('value_min', (int, float)),
+                 max_val=('value_max', (int, float)),
+                 fill_val=('fill', (int, float, str)), **kwargs):
         """Initialize the MetaLabels class."""
 
         # Initialize the coupled metadata

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -843,9 +843,10 @@ class Meta(object):
             if not np.any(list(need_data_type.values())):
                 self._data.loc[var, labels] = default_vals
             else:
-                data_default = [self.labels.default_values_from_attr(
-                    lattrs[j], var_types[i]) if need_data_type[lattrs[j]]
-                                else val for j, val in enumerate(default_vals)]
+                data_default = [
+                    self.labels.default_values_from_attr(
+                        lattrs[j], var_types[i]) if need_data_type[lattrs[j]]
+                    else val for j, val in enumerate(default_vals)]
                 self._data.loc[var, labels] = data_default
 
         return

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -100,7 +100,12 @@ def initialize_test_meta(epoch_name, data_keys):
 
     """
     # Create standard metadata for all parameters
-    meta = pysat.Meta()
+    test_labels = {'units': ('units', str), 'name': ('long_name', str),
+                   'notes': ('notes', str), 'desc': ('desc', str),
+                   'min_val': ('value_min', (int, float)),
+                   'max_val': ('value_max', (int, float)),
+                   'fill_val': ('fill', (float, int, str))}
+    meta = pysat.Meta(labels=test_labels)
     meta['uts'] = {'units': 's', 'long_name': 'Universal Time',
                    'desc': 'Number of seconds since mindight UT',
                    'value_min': 0.0, 'value_max': 86400.0}

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -100,12 +100,14 @@ def initialize_test_meta(epoch_name, data_keys):
 
     """
     # Create standard metadata for all parameters
-    test_labels = {'units': ('units', str), 'name': ('long_name', str),
-                   'notes': ('notes', str), 'desc': ('desc', str),
-                   'min_val': ('value_min', (int, float)),
-                   'max_val': ('value_max', (int, float)),
-                   'fill_val': ('fill', (float, int, str))}
-    meta = pysat.Meta(labels=test_labels)
+    data_types = {'uts': float, 'mlt': float, 'slt': float, 'longitude': float,
+                  'latitude': float, 'altitude': float, 'orbit_num': int,
+                  'dummy1': int, 'dummy2': int, 'dummy3': int, 'dummy4': int,
+                  'unicode_dummy': str, 'string_dummy': str,
+                  'dummy_drifts': float, 'int8_dummy': int, 'int16_dummy': int,
+                  'int32_dummy': int, 'int64_dummy': int, 'profiles': int,
+                  'series_profiles': float}
+    meta = pysat.Meta(data_types=data_types)
     meta['uts'] = {'units': 's', 'long_name': 'Universal Time',
                    'desc': 'Number of seconds since mindight UT',
                    'value_min': 0.0, 'value_max': 86400.0}
@@ -176,6 +178,10 @@ def initialize_test_meta(epoch_name, data_keys):
 
     # Children metadata required for 2D pandas.
     # TODO(#789): Delete after removal of Meta children.
+    data_types = {'density': float, 'fraction': float, 'alt_profiles': float,
+                  'variable_profiles': float, 'profile_height': int,
+                  'variable_profile_height': int, 'images': int, 'x': int,
+                  'y': int, 'z': int, 'image_lat': float, 'image_lon': float}
     alt_profile_meta = pysat.Meta()
     alt_profile_meta['density'] = {'desc': 'Simulated density values.',
                                    'units': 'Log N/cc',

--- a/pysat/instruments/pysat_netcdf.py
+++ b/pysat/instruments/pysat_netcdf.py
@@ -132,16 +132,9 @@ def download(date_array, tag, inst_id, data_path=None):
 
 def load(fnames, tag='', inst_id='', strict_meta=False, file_format='NETCDF4',
          epoch_name=None, epoch_unit='ms', epoch_origin='unix',
-         pandas_format=True, decode_timedelta=False,
-         load_labels={'units': ('units', str), 'name': ('long_name', str),
-                      'notes': ('notes', str), 'desc': ('desc', str),
-                      'plot': ('plot_label', str), 'axis': ('axis', str),
-                      'scale': ('scale', str),
-                      'min_val': ('value_min', np.float64),
-                      'max_val': ('value_max', np.float64),
-                      'fill_val': ('fill', np.float64)},
-         meta_processor=None,
-         meta_translation=None, drop_meta_labels=None, decode_times=None):
+         pandas_format=True, decode_timedelta=False, meta_kwargs=None,
+         load_labels=None, meta_processor=None, meta_translation=None,
+         drop_meta_labels=None, decode_times=None):
     """Load pysat-created NetCDF data and meta data.
 
     Parameters
@@ -187,13 +180,13 @@ def load(fnames, tag='', inst_id='', strict_meta=False, file_format='NETCDF4',
         Used for xarray data (`pandas_format` is False).  If True, variables
         with unit attributes that  are 'timelike' ('hours', 'minutes', etc) are
         converted to `np.timedelta64`. (default=False)
-    load_labels : dict
+    meta_kwargs : dict or NoneType
+        Dict to specify custom Meta initialization or None to use Meta
+        defaults (default=None)
+    load_labels : dict or NoneType
         Dict where keys are the label attribute names and the values are tuples
-        that have the label values and value types in that order.
-        (default={'units': ('units', str), 'name': ('long_name', str),
-        'notes': ('notes', str), 'desc': ('desc', str),
-        'min_val': ('value_min', np.float64),
-        'max_val': ('value_max', np.float64), 'fill_val': ('fill', np.float64)})
+        that have the label values and value types in that order or None to use
+        Meta defaults. Deprecated, use `meta_kwargs` instead. (default=None)
     meta_processor : function or NoneType
         If not None, a dict containing all of the loaded metadata will be
         passed to `meta_processor` which should return a filtered version
@@ -234,6 +227,7 @@ def load(fnames, tag='', inst_id='', strict_meta=False, file_format='NETCDF4',
                                              epoch_origin=epoch_origin,
                                              pandas_format=pandas_format,
                                              decode_timedelta=decode_timedelta,
+                                             meta_kwargs=meta_kwargs,
                                              labels=load_labels,
                                              meta_processor=meta_processor,
                                              meta_translation=meta_translation,

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -631,7 +631,7 @@ class TestDeprecation(object):
         self.eval_warnings()
 
         # Evaluate the performance
-        assert tinst.meta.labels.label_type['fill_val'] in [float]
+        assert float in tinst.meta.labels.label_type['fill_val']
         return
 
     def test_instrument_meta_labels(self):

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -634,13 +634,22 @@ class TestDeprecation(object):
         assert float in tinst.meta.labels.label_type['fill_val']
         return
 
-    def test_instrument_meta_labels(self):
-        """Test deprecation of `meta_labels` attribute in Instrument."""
-        self.in_kwargs['meta_kwargs'] = {'labels': {
-            'units': ('units', str), 'name': ('long_name', str),
-            'notes': ('notes', str), 'desc': ('desc', str),
-            'min_val': ('value_min', float), 'max_val': ('value_max', float),
-            'fill_val': ('fill', float)}}
+    @pytest.mark.parametrize('use_kwargs', [(True, False)])
+    def test_instrument_meta_labels(self, use_kwargs):
+        """Test deprecation of `meta_labels` attribute in Instrument.
+
+        Parameters
+        ----------
+        use_kwargs : bool
+            If True, specify labels on input.  If False, use defaults.
+
+        """
+        if use_kwargs:
+            self.in_kwargs['meta_kwargs'] = {'labels': {
+                'units': ('units', str), 'name': ('long_name', str),
+                'notes': ('notes', str), 'desc': ('desc', str),
+                'min_val': ('value_min', float),
+                'max_val': ('value_max', float), 'fill_val': ('fill', float)}}
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
@@ -653,6 +662,13 @@ class TestDeprecation(object):
         self.eval_warnings()
 
         # Evaluate the performance
+        if not use_kwargs:
+            self.in_kwargs['meta_kwargs'] = {'labels': {
+                'units': ('units', str), 'name': ('long_name', str),
+                'notes': ('notes', str), 'desc': ('desc', str),
+                'min_val': ('value_min', float),
+                'max_val': ('value_max', float), 'fill_val': ('fill', float)}}
+
         assert labels == self.in_kwargs['meta_kwargs']['labels']
         return
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -605,6 +605,49 @@ class TestDeprecation(object):
         testing.eval_warnings(self.war, self.warn_msgs)
         return
 
+    def test_instrument_labels(self):
+        """Test deprecation of `labels` kwarg in Instrument."""
+        self.in_kwargs['labels'] = {
+            'units': ('units', str), 'name': ('long_name', str),
+            'notes': ('notes', str), 'desc': ('desc', str),
+            'min_val': ('value_min', float), 'max_val': ('value_max', float),
+            'fill_val': ('fill', float)}
+        
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as self.war:
+            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
+
+        self.warn_msgs = np.array(["`labels` is deprecated, use `meta_kwargs`"])
+
+        # Evaluate the warning output
+        self.eval_warnings()
+
+        # Evaluate the performance
+        assert tinst.meta.labels.label_type['fill_val'] in [float]
+        return
+
+    def test_instrument_meta_labels(self):
+        """Test deprecation of `meta_labels` attribute in Instrument."""
+        self.in_kwargs['meta_kwargs'] = {'labels': {
+            'units': ('units', str), 'name': ('long_name', str),
+            'notes': ('notes', str), 'desc': ('desc', str),
+            'min_val': ('value_min', float), 'max_val': ('value_max', float),
+            'fill_val': ('fill', float)}}
+        
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as self.war:
+            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
+            labels = tinst.meta_labels
+
+        self.warn_msgs = np.array(["Deprecated attribute, returns `meta_kwarg"])
+
+        # Evaluate the warning output
+        self.eval_warnings()
+
+        # Evaluate the performance
+        assert labels == self.in_kwargs['meta_kwargs']['labels']
+        return
+
     def test_generic_meta_translator(self):
         """Test deprecation of `generic_meta_translator`."""
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -634,7 +634,7 @@ class TestDeprecation(object):
         assert float in tinst.meta.labels.label_type['fill_val']
         return
 
-    @pytest.mark.parametrize('use_kwargs', [(True, False)])
+    @pytest.mark.parametrize('use_kwargs', [True, False])
     def test_instrument_meta_labels(self, use_kwargs):
         """Test deprecation of `meta_labels` attribute in Instrument.
 
@@ -666,8 +666,9 @@ class TestDeprecation(object):
             self.in_kwargs['meta_kwargs'] = {'labels': {
                 'units': ('units', str), 'name': ('long_name', str),
                 'notes': ('notes', str), 'desc': ('desc', str),
-                'min_val': ('value_min', float),
-                'max_val': ('value_max', float), 'fill_val': ('fill', float)}}
+                'min_val': ('value_min', (float, int)),
+                'max_val': ('value_max', (float, int)),
+                'fill_val': ('fill', (float, int, str))}}
 
         assert labels == self.in_kwargs['meta_kwargs']['labels']
         return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -612,7 +612,7 @@ class TestDeprecation(object):
             'notes': ('notes', str), 'desc': ('desc', str),
             'min_val': ('value_min', float), 'max_val': ('value_max', float),
             'fill_val': ('fill', float)}
-        
+
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
             tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
@@ -633,7 +633,7 @@ class TestDeprecation(object):
             'notes': ('notes', str), 'desc': ('desc', str),
             'min_val': ('value_min', float), 'max_val': ('value_max', float),
             'fill_val': ('fill', float)}}
-        
+
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
             tinst = pysat.Instrument(use_header=True, **self.in_kwargs)

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -1023,7 +1023,6 @@ class TestMeta(object):
             set_dict[slabel] = vals[i]
 
         # Initialize the Meta data using the new data type
-        
         self.testInst[self.dval] = set_dict
         self.meta = self.testInst.meta
 

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -33,9 +33,9 @@ class TestMeta(object):
                             'name': ('Long_Name', str),
                             'desc': ('Desc', str),
                             'notes': ('Notes', str),
-                            'min_val': ('Minimum', np.float64),
-                            'max_val': ('Maximum', np.float64),
-                            'fill_val': ('Fill_Value', np.float64)}
+                            'min_val': ('Minimum', (float, int)),
+                            'max_val': ('Maximum', (float, int)),
+                            'fill_val': ('Fill_Value', (float, int, str))}
         self.dval = None
         self.default_name = ['long_name']
         self.default_nan = ['fill', 'value_min', 'value_max']
@@ -79,8 +79,15 @@ class TestMeta(object):
                 self.meta.mutable = self.mutable
         return
 
-    def eval_meta_settings(self):
-        """Test the Meta settings for a specified value."""
+    def eval_meta_settings(self, isfloat=True):
+        """Test the Meta settings for a specified value.
+
+        Parameters
+        ----------
+        isfloat : bool
+            True if data type is float, False if it is int, str, or other
+
+        """
         # Test the Meta data for the data value, self.dval
         for lkey in self.default_name:
             assert self.meta[self.dval, lkey] == self.dval, \
@@ -1015,7 +1022,8 @@ class TestMeta(object):
             self.default_val[slabel] = vals[i]
             set_dict[slabel] = vals[i]
 
-        # Initialize the Meta data
+        # Initialize the Meta data using the new data type
+        
         self.testInst[self.dval] = set_dict
         self.meta = self.testInst.meta
 
@@ -1974,9 +1982,9 @@ class TestMetaImmutable(TestMeta):
                             'name': ('Long_Name', str),
                             'desc': ('Desc', str),
                             'notes': ('Notes', str),
-                            'min_val': ('Minimum', np.float64),
-                            'max_val': ('Maximum', np.float64),
-                            'fill_val': ('Fill_Value', np.float64)}
+                            'min_val': ('Minimum', (float, int)),
+                            'max_val': ('Maximum', (float, int)),
+                            'fill_val': ('Fill_Value', (float, int, str))}
         self.dval = None
         self.default_name = ['long_name']
         self.default_nan = ['fill', 'value_min', 'value_max']

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -388,7 +388,7 @@ class TestMeta(object):
         assert 'Metadata with type' in str(war[0].message)
         assert 'Dropping input' in str(war[0].message)
 
-        # Check that meta is blank
+        # Check that meta is set to the expected default
         assert np.isnan(self.meta['fake_var']['value_max'])
         return
 

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -35,8 +35,7 @@ class TestUpdateFill(object):
         del self.ref_time, self.new_fill_val
         return
 
-    @pytest.mark.parametrize("name", ["ndtesting", "testing", "testing_xarray",
-                                      "testmodel"])
+    @pytest.mark.parametrize("name", ["ndtesting", "testing", "testmodel"])
     @pytest.mark.parametrize("variables", [('mlt'), (['mlt'])])
     def test_update_fill_values_numbers(self, name, variables):
         """Test `update_fill_values` for the desired behaviour.
@@ -71,8 +70,7 @@ class TestUpdateFill(object):
                 "filled data values not updated for {:}".format(var)
         return
 
-    @pytest.mark.parametrize("name", ["ndtesting", "testing", "testing_xarray",
-                                      "testmodel"])
+    @pytest.mark.parametrize("name", ["ndtesting", "testing", "testmodel"])
     def test_update_fill_values_by_type(self, name):
         """Test `update_fill_values` for the desired behaviour.
 

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -21,6 +21,109 @@ from pysat.tests.classes.cls_registration import TestWithRegistration
 from pysat import utils
 
 
+class TestUpdateFill(object):
+    """Tests for the core utility `update_fill_values`."""
+
+    def setup_method(self):
+        """Set up the test enviroment."""
+        self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
+        self.new_fill_val = -47.0
+        return
+
+    def teardown_method(self):
+        """Clean up the test environment."""
+        del self.ref_time, self.new_fill_val
+        return
+
+    @pytest.mark.parametrize("name", ["ndtesting", "testing", "testing_xarray",
+                                      "testmodel"])
+    @pytest.mark.parametrize("variables", [('mlt'), (['mlt'])])
+    def test_update_fill_values_numbers(self, name, variables):
+        """Test `update_fill_values` for the desired behaviour.
+
+        Parameters
+        ----------
+        name : str
+            Instrument name
+        variables : str or list-like
+            Variables to update (should be int or float type)
+
+        """
+
+        # Initalize the instrument
+        inst = pysat.Instrument('pysat', name, use_header=True)
+        inst.load(date=self.ref_time)
+
+        # Ensure there are fill values to check
+        test_vars = pysat.utils.listify(variables)
+        for var in test_vars:
+            inst[var].values[0] = inst.meta[var, inst.meta.labels.fill_val]
+
+        # Update the fill values
+        pysat.utils.update_fill_values(inst, variables, self.new_fill_val)
+
+        # Ensure the fill values are updated
+        for var in test_vars:
+            assert inst.meta[var,
+                             inst.meta.labels.fill_val] == self.new_fill_val, \
+                "meta fill value not updated for {:}".format(var)
+            assert np.all(inst[var].values[0] == self.new_fill_val), \
+                "filled data values not updated for {:}".format(var)
+        return
+
+    @pytest.mark.parametrize("name", ["ndtesting", "testing", "testing_xarray",
+                                      "testmodel"])
+    def test_update_fill_values_by_type(self, name):
+        """Test `update_fill_values` for the desired behaviour.
+
+        Parameters
+        ----------
+        name : str
+            Instrument name
+
+        """
+
+        # Initalize the instrument
+        inst = pysat.Instrument('pysat', name, use_header=True)
+        inst.load(date=self.ref_time)
+
+        # Ensure there are fill values to check
+        num_types = [int, float, np.float64, np.int64]
+        num_vars = [var for var in inst.variables if var in inst.meta.keys()
+                    and inst[var].dtype in num_types
+                    and inst.meta[var, inst.meta.labels.fill_val] is not None]
+        str_vars = [var for var in inst.variables if var in inst.meta.keys()
+                    and isinstance(inst[var].values[0], str)
+                    and inst.meta[var, inst.meta.labels.fill_val] is not None]
+        for var in num_vars:
+            inst[var].values[0] = inst.meta[var, inst.meta.labels.fill_val]
+
+        for var in str_vars:
+            inst[var].values[0] = str(inst.meta[var, inst.meta.labels.fill_val])
+
+        # Update and check the numeric fill values
+        pysat.utils.update_fill_values(inst, num_vars, self.new_fill_val)
+
+        for var in num_vars:
+            assert inst.meta[var,
+                             inst.meta.labels.fill_val] == self.new_fill_val, \
+                "meta fill value not updated for {:}".format(var)
+            assert np.all(inst[var].values[0] == self.new_fill_val), \
+                "filled data values not updated for {:}".format(var)
+
+        # Update and check the string fill values
+        self.new_fill_val = 'fill'
+        pysat.utils.update_fill_values(inst, str_vars, self.new_fill_val)
+
+        for var in str_vars:
+            assert inst.meta[var,
+                             inst.meta.labels.fill_val] == self.new_fill_val, \
+                "meta fill value not updated for {:}".format(var)
+            assert np.all(inst[var].values[0] == self.new_fill_val), \
+                "filled data values not updated for {:}".format(var)
+        return
+
+
 class TestCIonly(object):
     """Tests where we mess with local settings.
 

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -86,13 +86,22 @@ class TestUpdateFill(object):
         inst.load(date=self.ref_time)
 
         # Ensure there are fill values to check
-        num_types = [int, float, np.float64, np.int64]
-        num_vars = [var for var in inst.variables if var in inst.meta.keys()
-                    and inst[var].dtype in num_types
-                    and inst.meta[var, inst.meta.labels.fill_val] is not None]
         str_vars = [var for var in inst.variables if var in inst.meta.keys()
                     and isinstance(inst[var].values[0], str)
                     and inst.meta[var, inst.meta.labels.fill_val] is not None]
+        num_types = [int, float, np.float64, np.int64]
+        if inst.pandas_format:
+            num_vars = [var for var in inst.variables if var in inst.meta.keys()
+                        and inst[var].dtype.type in num_types
+                        and inst.meta[var, inst.meta.labels.fill_val]
+                        is not None]
+        else:
+            num_vars = [var for var in inst.variables if var in inst.meta.keys()
+                        and var not in inst.data.coords.keys()
+                        and inst[var].dtype.type in num_types
+                        and inst.meta[var, inst.meta.labels.fill_val]
+                        is not None]
+
         for var in num_vars:
             inst[var].values[0] = inst.meta[var, inst.meta.labels.fill_val]
 

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -374,18 +374,30 @@ class TestFileUtils(CICleanSetup):
 
         return
 
-    def test_check_and_make_path_exists(self):
-        """Test successful pass at creating existing directory."""
+    @pytest.mark.parametrize("use_cwd", [True, False])
+    def test_check_and_make_path_exists(self, use_cwd):
+        """Test successful pass at creating existing directory.
 
-        # Create a temporary directory
-        tempdir = tempfile.TemporaryDirectory()
-        assert os.path.isdir(tempdir.name)
+        Parameters
+        ----------
+        use_cwd : bool
+            Use current working directory or a temporary directory
+
+        """
+        if use_cwd:
+            dir_name = ""
+        else:
+            # Create a temporary directory
+            tempdir = tempfile.TemporaryDirectory()
+            dir_name = tempdir.name
+            assert os.path.isdir(tempdir.name)
 
         # Assert check_and_make_path does not re-create the directory
-        assert not pysat.utils.files.check_and_make_path(tempdir.name)
+        assert not pysat.utils.files.check_and_make_path(dir_name)
 
-        # Clean up temporary directory
-        tempdir.cleanup()
+        if not use_cwd:
+            # Clean up temporary directory
+            tempdir.cleanup()
         return
 
     @pytest.mark.parametrize("trailer", [None, '', 'extra',

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -1883,3 +1883,69 @@ class TestMetaTranslationModel(TestMetaTranslation):
         del self.test_inst, self.test_date, self.out, self.meta_dict
 
         return
+
+
+class TestIODeprecation(object):
+    """Unit tests for deprecation warnings in `utils.io`."""
+
+    def setup_method(self):
+        """Set up the test environment."""
+
+        # Create temporary directory
+        self.tempdir = tempfile.TemporaryDirectory()
+        self.saved_path = pysat.params['data_dirs']
+        pysat.params['data_dirs'] = self.tempdir.name
+        
+        self.outfile = os.path.join(self.tempdir.name,
+                               'pysat_test_ncdf.nc')
+        self.in_kwargs = {'labels': {
+            'units': ('units', str), 'name': ('long_name', str),
+            'notes': ('notes', str), 'desc': ('desc', str),
+            'min_val': ('value_min', float), 'max_val': ('value_max', float),
+            'fill_val': ('fill', float)}}
+
+        return
+
+    def teardown_method(self):
+        """Clean up the test environment."""
+
+        pysat.params['data_dirs'] = self.saved_path
+
+        # Remove the temporary directory
+        self.tempdir.cleanup()
+
+        # Clear the attributes
+        del self.tempdir, self.saved_path, self.outfile, self.in_kwargs
+        return
+
+    @pytest.mark.parametrize("inst_name,load_func", [
+        ("testing", io.load_netcdf_pandas),
+        ("ndtesting", io.load_netcdf_xarray)])
+    def test_load_netcdf_labels(self, inst_name, load_func):
+        """Test deprecation of `labels` kwarg in different load functions.
+
+        Parameters
+        ----------
+        inst_name : str
+            Instrument name for test Instrument
+        load_func : function
+            NetCDF load method with deprecation warning
+
+        """
+
+        # Create a test file
+        testInst = pysat.Instrument(platform='pysat', name=inst_name,
+                                    num_samples=100, update_files=True,
+                                    use_header=True)
+        testInst.load(date=testInst.inst_module._test_dates[''][''])
+        io.inst_to_netcdf(testInst, fname=self.outfile)
+
+        # Catch the warnings
+        with warnings.catch_warnings(record=True) as war:
+            load_func(self.outfile, **self.in_kwargs)
+
+        # Test the warnings
+        assert len(war) >= 1
+        testing.eval_warnings(war,
+                              ["`labels` is deprecated, use `meta_kwargs`"])
+        return

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -1895,9 +1895,8 @@ class TestIODeprecation(object):
         self.tempdir = tempfile.TemporaryDirectory()
         self.saved_path = pysat.params['data_dirs']
         pysat.params['data_dirs'] = self.tempdir.name
-        
-        self.outfile = os.path.join(self.tempdir.name,
-                               'pysat_test_ncdf.nc')
+
+        self.outfile = os.path.join(self.tempdir.name, 'pysat_test_ncdf.nc')
         self.in_kwargs = {'labels': {
             'units': ('units', str), 'name': ('long_name', str),
             'notes': ('notes', str), 'desc': ('desc', str),

--- a/pysat/utils/__init__.py
+++ b/pysat/utils/__init__.py
@@ -16,6 +16,7 @@ from pysat.utils._core import load_netcdf4
 from pysat.utils._core import NetworkLock
 from pysat.utils._core import scale_units
 from pysat.utils._core import stringify
+from pysat.utils._core import update_fill_values
 from pysat.utils import coords
 from pysat.utils import files
 from pysat.utils import io

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -689,6 +689,11 @@ def update_fill_values(inst, variables=None, new_fill_val=np.nan):
     new_fill_val : any
         New fill value to use (default=np.nan)
 
+    Note
+    ----
+    On Windows OS, this function may not work for data variables that are also
+    xarray coordinates.
+
     """
 
     if not inst.empty:

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -672,6 +672,43 @@ def display_available_instruments(inst_loc=None, show_inst_mod=None,
     return
 
 
+def update_fill_values(inst, variables=None, new_fill_val=np.nan):
+    """Update Instrument data so that the fill value is consistent with Meta.
+
+    Parameters
+    ----------
+    inst : pysat.Instrument
+        Instrument object with data loaded
+    variables : str, list, or NoneType
+        List of variables to update or None to update all (default=None)
+    new_fill_val : any
+        New fill value to use (default=np.nan)
+
+    """
+
+    if not inst.empty:
+        # Get the variables (if needed) and ensure they are list-like
+        if variables is None:
+            variables = list(inst.variables)
+        else:
+            variables = listify(variables)
+
+        for var in variables:
+            # Get the old fill value
+            old_fill_val = inst.meta[var, inst.meta.labels.fill_val]
+
+            # Update the Meta data
+            inst.meta[var] = {inst.meta.labels.fill_val: new_fill_val}
+
+            # Update the variable data
+            ifill = np.where(inst[var].values == old_fill_val)
+
+            if len(ifill[0]) > 0:
+                inst[var].values[ifill] = new_fill_val
+
+    return
+
+
 class NetworkLock(Lock):
     """Unit tests for NetworkLock manager."""
 
@@ -709,6 +746,7 @@ class NetworkLock(Lock):
 
         super(NetworkLock, self).__init__(timeout=timeout,
                                           *args, **kwargs)
+        return
 
     def release(self):
         """Release the Lock from the file system.
@@ -729,3 +767,4 @@ class NetworkLock(Lock):
             pass
 
         super(NetworkLock, self).release()
+        return

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -694,17 +694,24 @@ def update_fill_values(inst, variables=None, new_fill_val=np.nan):
             variables = listify(variables)
 
         for var in variables:
-            # Get the old fill value
-            old_fill_val = inst.meta[var, inst.meta.labels.fill_val]
+            if var in inst.meta.keys():
+                # Get the old fill value
+                old_fill_val = inst.meta[var, inst.meta.labels.fill_val]
 
-            # Update the Meta data
-            inst.meta[var] = {inst.meta.labels.fill_val: new_fill_val}
+                # Update the Meta data
+                inst.meta[var] = {inst.meta.labels.fill_val: new_fill_val}
 
-            # Update the variable data
-            ifill = np.where(inst[var].values == old_fill_val)
+                # Update the variable data
+                try:
+                    if np.isnan(old_fill_val):
+                        ifill = np.where(np.isnan(inst[var].values))
+                    else:
+                        ifill = np.where(inst[var].values == old_fill_val)
+                except TypeError:
+                    ifill = np.where(inst[var].values == old_fill_val)
 
-            if len(ifill[0]) > 0:
-                inst[var].values[ifill] = new_fill_val
+                if len(ifill[0]) > 0:
+                    inst[var].values[ifill] = new_fill_val
 
     return
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -152,7 +152,12 @@ def listify(iterable):
     """
 
     # Cast as an array-like object
-    arr_iter = np.asarray(iterable)
+    try:
+        arr_iter = np.asarray(iterable)
+    except ValueError:
+        # This is necessary for Python 3.6 compatibility when using listify
+        # on slices
+        arr_iter = np.asarray([iterable])
 
     # Treat output differently based on the array shape
     if arr_iter.shape == ():

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -781,6 +781,10 @@ def check_and_make_path(path, expand_path=False):
         path = os.path.expanduser(path)
         path = os.path.expandvars(path)
 
+    if len(path) == 0:
+        # The user wants to write to the current directory
+        path = os.getcwd()
+
     # Set the output
     made_dir = not os.path.exists(path)
 

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -1250,7 +1250,8 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
     combine_by_coords : bool
         Used for xarray data (`pandas_format` is False) when loading a
         multi-file dataset. If True, uses `xarray.combine_by_coords`. If False,
-        uses `xarray.combine_nested`. (default=True)    meta_kwargs : dict or NoneType
+        uses `xarray.combine_nested`. (default=True)
+    meta_kwargs : dict or NoneType
         Dict to specify custom Meta initialization or None to use Meta
         defaults (default=None)
     labels : dict or NoneType

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -51,9 +51,10 @@ def pysat_meta_to_xarray_attr(xr_data, pysat_meta, epoch_name):
 
                 # Cycle through all the pysat MetaData labels and transfer
                 for meta_key in pysat_meta[data_key].keys():
-                    # Assign attributes
-                    xr_data[xarr_vars[i]].attrs[meta_key] = pysat_meta[
-                        data_key][meta_key]
+                    # Assign attributes with values that are not None
+                    if pysat_meta[data_key][meta_key] is not None:
+                        xr_data[xarr_vars[i]].attrs[meta_key] = pysat_meta[
+                            data_key][meta_key]
 
             else:
                 wstr = ''.join(['Did not find data for metadata variable ',
@@ -64,9 +65,10 @@ def pysat_meta_to_xarray_attr(xr_data, pysat_meta, epoch_name):
     # MetaData labels and transfer.
     if epoch_name in pysat_meta.keys():
         for meta_key in pysat_meta[epoch_name].keys():
-            # Assign attributes
-            xr_data[epoch_name].attrs[meta_key] = pysat_meta[epoch_name][
-                meta_key]
+            # Assign attributes that are not None
+            if pysat_meta[epoch_name][meta_key] is not None:
+                xr_data[epoch_name].attrs[meta_key] = pysat_meta[epoch_name][
+                    meta_key]
 
     return
 


### PR DESCRIPTION
# Description

Potentially addresses #707 by adding a core utility to consistently update fill values in the metadata and data simultaneously.  Also fixes issues found when testing that this worked as desired when printing netCDF files.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import pysat

inst = pysat.Instrument('pysat', 'testing', use_header=True)
inst.load(2009, 1)

print(inst.meta['mlt', inst.meta.labels.fill_val])  # Should be np.nan
pysat.utils.update_fill_values(inst, 'mlt', -1.0)
print(inst.meta['mlt', inst.meta.labels.fill_val])  # Should be -1.0
```

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
