### PR TITLE
DEP/STY: Deprecate `malformed_index`, add `non_unique_index` kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated docstring header underline lengths and addressed documentation
     build errors and warnings
   * Additional unit tests for data padding when a data index is non-monotonic.
+  * Deprecated the `malformed_index` kwarg in the test instruments.  This is
+    replaced by `non_monotonic_index` and `non_unique_index`
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -702,3 +702,13 @@ def non_unique_index(index):
     new_index = pds.to_datetime(new_index)
 
     return new_index
+
+
+def _warn_malformed_kwarg():
+    """Warn user that kwarg has been deprecated."""
+
+    dstr = ' '.join(['The kwarg malformed_index has been deprecated and',
+                     'will be removed in pysat 3.2.0+. Please use',
+                     'non_monotonic_index or non_unique_index to specify',
+                     'desired behaviour.'])
+    warnings.warn(dstr, DeprecationWarning, stacklevel=2)

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -31,8 +31,8 @@ preprocess = mm_test.preprocess
 
 
 def load(fnames, tag='', inst_id='', non_monotonic_index=False,
-         malformed_index=False, start_time=None, num_samples=864,
-         test_load_kwarg=None, max_latitude=90.):
+         non_unique_index=False, malformed_index=False, start_time=None,
+         num_samples=864, test_load_kwarg=None, max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -47,8 +47,11 @@ def load(fnames, tag='', inst_id='', non_monotonic_index=False,
         This input is nominally provided by pysat itself. (default='')
     non_monotonic_index : bool
         If True, time index will be non-monotonic (default=False)
+    non_unique_index : bool
+        If True, time index will be non-unique (default=False)
     malformed_index : bool
-        If True, the time index will be non-unique and non-monotonic.
+        If True, the time index will be non-unique and non-monotonic. Deprecated
+        as of pysat 3.1.0.
         (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data
@@ -83,10 +86,15 @@ def load(fnames, tag='', inst_id='', non_monotonic_index=False,
     # Using 100s frequency for compatibility with seasonal analysis unit tests
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',
                                                start_time=start_time)
-
-    if malformed_index or non_monotonic_index:
-        index = mm_test.non_monotonic_index(index)
     if malformed_index:
+        # Warn that kwarg is deprecated and set new kwargs.
+        mm_test._warn_malformed_kwarg()
+        non_monotonic_index = True
+        non_unique_index = True
+
+    if non_monotonic_index:
+        index = mm_test.non_monotonic_index(index)
+    if non_unique_index:
         index = mm_test.non_unique_index(index)
 
     data = xr.Dataset({'uts': ((epoch_name), uts)},

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -51,7 +51,7 @@ def load(fnames, tag='', inst_id='', non_monotonic_index=False,
         If True, time index will be non-unique (default=False)
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic. Deprecated
-        as of pysat 3.1.0.
+        and scheduled for removal in pysat 3.2.0.
         (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -86,6 +86,7 @@ def load(fnames, tag='', inst_id='', non_monotonic_index=False,
     # Using 100s frequency for compatibility with seasonal analysis unit tests
     uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='100S',
                                                start_time=start_time)
+    # TODO(#1094): Remove in pysat 3.2.0
     if malformed_index:
         # Warn that kwarg is deprecated and set new kwargs.
         mm_test._warn_malformed_kwarg()

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -40,8 +40,8 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, non_monotonic_index=False,
-         malformed_index=False, start_time=None, num_samples=86400,
-         test_load_kwarg=None, max_latitude=90.):
+         non_unique_index=False, malformed_index=False, start_time=None,
+         num_samples=86400, test_load_kwarg=None, max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -65,8 +65,12 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
         (default=None)
     non_monotonic_index : bool
         If True, time index will be non-monotonic (default=False)
+    non_unique_index : bool
+        If True, time index will be non-unique (default=False)
     malformed_index : bool
-        If True, time index will be non-unique and non-monotonic (default=False)
+        If True, the time index will be non-unique and non-monotonic. Deprecated
+        as of pysat 3.1.0.
+        (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data
         will begin at midnight. (default=None)
@@ -161,12 +165,18 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     data['int32_dummy'] = np.ones(len(data), dtype=np.int32)
     data['int64_dummy'] = np.ones(len(data), dtype=np.int64)
 
+    if malformed_index:
+        # Warn that kwarg is deprecated and set new kwargs.
+        mm_test._warn_malformed_kwarg()
+        non_monotonic_index = True
+        non_unique_index = True
+
     # Activate if non-monotonic index is needed.
-    if np.any([non_monotonic_index, malformed_index, (tag == 'non_strict')]):
+    if np.any([non_monotonic_index, (tag == 'non_strict')]):
         index = mm_test.non_monotonic_index(index)
 
     # Activate if non-unique index is needed.
-    if np.any([malformed_index, (tag == 'non_strict')]):
+    if np.any([non_unique_index, (tag == 'non_strict')]):
         index = mm_test.non_unique_index(index)
 
     data.index = index

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -69,8 +69,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
         If True, time index will be non-unique (default=False)
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic. Deprecated
-        and scheduled for removal in pysat 3.2.0.
-        (default=False)
+        and scheduled for removal in pysat 3.2.0. (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data
         will begin at midnight. (default=None)

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -165,6 +165,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     data['int32_dummy'] = np.ones(len(data), dtype=np.int32)
     data['int64_dummy'] = np.ones(len(data), dtype=np.int64)
 
+    # TODO(#1094): Remove in pysat 3.2.0
     if malformed_index:
         # Warn that kwarg is deprecated and set new kwargs.
         mm_test._warn_malformed_kwarg()

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -69,7 +69,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
         If True, time index will be non-unique (default=False)
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic. Deprecated
-        as of pysat 3.1.0.
+        and scheduled for removal in pysat 3.2.0.
         (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -152,6 +152,7 @@ def load(fnames, tag='', inst_id='', malformed_index=False,
     data['int64_dummy'] = np.ones(len(data), dtype=np.int64)
 
     if malformed_index:
+        mm_test._warn_malformed_kwarg()
         index = mm_test.non_monotonic_index(index)
         index = mm_test.non_unique_index(index)
 

--- a/pysat/instruments/pysat_testing2d.py
+++ b/pysat/instruments/pysat_testing2d.py
@@ -176,8 +176,8 @@ def load(fnames, tag='', inst_id='', malformed_index=False,
     series_profiles = []
 
     # Frame indexed by date times
-    frame = pds.DataFrame({'density': data.loc[data.index[0:num_profiles],
-                                               'mlt'].values.copy(),
+    frame = pds.DataFrame({'density':
+                           data.iloc[0:num_profiles]['mlt'].values.copy(),
                            'dummy_str': ['test'] * num_profiles,
                            'dummy_ustr': [u'test'] * num_profiles},
                           index=data.index[0:num_profiles],

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -88,8 +88,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
         If True, time index will be non-unique (default=False)
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic. Deprecated
-        and scheduled for removal in pysat 3.2.0.
-        (default=False)
+        and scheduled for removal in pysat 3.2.0. (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data
         will begin at midnight. (default=None)

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -62,8 +62,8 @@ preprocess = mm_test.preprocess
 
 def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
          sim_multi_file_left=False, non_monotonic_index=False,
-         malformed_index=False, start_time=None, num_samples=86400,
-         test_load_kwarg=None, max_latitude=90.):
+         non_unique_index=False, malformed_index=False, start_time=None,
+         num_samples=86400, test_load_kwarg=None, max_latitude=90.):
     """Load the test files.
 
     Parameters
@@ -84,8 +84,12 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
         `root_date`. (default=False)
     non_monotonic_index : bool
         If True, time index will be non-monotonic (default=False)
+    non_unique_index : bool
+        If True, time index will be non-unique (default=False)
     malformed_index : bool
-        If True, time index will be non-unique and non-monotonic.
+        If True, the time index will be non-unique and non-monotonic. Deprecated
+        as of pysat 3.1.0.
+        (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data
         will begin at midnight. (default=None)
@@ -126,9 +130,15 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     else:
         root_date = dt.datetime(2009, 1, 1)
 
-    if malformed_index or non_monotonic_index:
-        index = mm_test.non_monotonic_index(index)
     if malformed_index:
+        # Warn that kwarg is deprecated and set new kwargs.
+        mm_test._warn_malformed_kwarg()
+        non_monotonic_index = True
+        non_unique_index = True
+
+    if non_monotonic_index:
+        index = mm_test.non_monotonic_index(index)
+    if non_unique_index:
         index = mm_test.non_unique_index(index)
 
     data = xr.Dataset({'uts': ((epoch_name), uts)},

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -130,6 +130,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     else:
         root_date = dt.datetime(2009, 1, 1)
 
+    # TODO(#1094): Remove in pysat 3.2.0
     if malformed_index:
         # Warn that kwarg is deprecated and set new kwargs.
         mm_test._warn_malformed_kwarg()

--- a/pysat/instruments/pysat_testing_xarray.py
+++ b/pysat/instruments/pysat_testing_xarray.py
@@ -88,7 +88,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
         If True, time index will be non-unique (default=False)
     malformed_index : bool
         If True, the time index will be non-unique and non-monotonic. Deprecated
-        as of pysat 3.1.0.
+        and scheduled for removal in pysat 3.2.0.
         (default=False)
     start_time : dt.timedelta or NoneType
         Offset time of start time since midnight UT. If None, instrument data

--- a/pysat/tests/test_instrument_index.py
+++ b/pysat/tests/test_instrument_index.py
@@ -106,6 +106,7 @@ class TestDeprecation(object):
         testing.eval_warnings(self.war, self.warn_msgs)
         return
 
+    # TODO(#1094): Remove in pysat 3.2.0, potentially with class
     @pytest.mark.parametrize('name', ['testing', 'ndtesting', 'testing_xarray',
                                       'testing2d'])
     def test_kwarg_malformed_index(self, name):


### PR DESCRIPTION
# Description

Addresses #1094

Deprecates `malformed_index` for test instruments.  This is replaced by `non_monotonic_index` and `non_unique_index`, allowing these two functions to be changed independently.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import pysat
inst = pysat.Instrument('pysat', 'testing', non_monotonic_index=True)
inst.load(2009, 1)
```
etc.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
