### PR TITLE
BUG: xarray and tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed a bug where data may not have any times, but still not be empty
   * Fixed a bug where a multi_file_day non-monotonic xarray index failed to
     merge datasets (#1005)
+  * Fixed a bug when setting xarray data as a tuple
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1119,9 +1119,12 @@ class Instrument(object):
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.
-                    raise ValueError(' '.join(('Must provide dimensions',
-                                               'for xarray multidim',
-                                               'data using input tuple.')))
+                    try:
+                        self.data[key] = in_data
+                    except BaseException:
+                        raise ValueError(' '.join(('Must provide dimensions',
+                                                   'for xarray multidim',
+                                                   'data using input tuple.')))
 
             elif hasattr(key, '__iter__'):
                 # Multiple input strings (keys) are provided, but not in tuple

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1119,12 +1119,9 @@ class Instrument(object):
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.
-                    try:
-                        self.data[key] = in_data
-                    except BaseException:
-                        raise ValueError(' '.join(('Must provide dimensions',
-                                                   'for xarray multidim',
-                                                   'data using input tuple.')))
+                    # Passes the data through to get appropriate error from
+                    # xarray.
+                    self.data[key] = in_data
 
             elif hasattr(key, '__iter__'):
                 # Multiple input strings (keys) are provided, but not in tuple

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1074,8 +1074,8 @@ class Instrument(object):
                 return
             elif isinstance(key, str):
                 # Assigning basic variables
-                if isinstance(in_data, xr.DataArray):
-                    # If xarray input, take as is
+                if isinstance(in_data, (xr.DataArray, tuple)):
+                    # If xarray or tuple input, take as is
                     self.data[key] = in_data
                 elif len(np.shape(in_data)) <= 1:
                     # If not an xarray input, but still iterable, then we
@@ -1119,12 +1119,9 @@ class Instrument(object):
                 else:
                     # Multidimensional input that is not an xarray.  The user
                     # needs to provide everything that is required for success.
-                    if isinstance(in_data, tuple):
-                        self.data[key] = in_data
-                    else:
-                        raise ValueError(' '.join(('Must provide dimensions',
-                                                   'for xarray multidim',
-                                                   'data using input tuple.')))
+                    raise ValueError(' '.join(('Must provide dimensions',
+                                               'for xarray multidim',
+                                               'data using input tuple.')))
 
             elif hasattr(key, '__iter__'):
                 # Multiple input strings (keys) are provided, but not in tuple

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -285,6 +285,14 @@ class TestBasicsNDXarray(TestBasics):
         del self.testInst, self.out, self.ref_time, self.ref_doy
         return
 
+    def test_setting_data_as_tuple(self):
+        """Test setting data by name."""
+
+        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst['doubleMLT'] = ('time', 2. * self.testInst['mlt'].values)
+        assert np.all(self.testInst['doubleMLT'] == 2. * self.testInst['mlt'])
+        return
+
     def test_xarray_not_empty_notime(self):
         """Test that xarray empty is False even if there is no time data."""
         # Load data and confirm it exists

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -286,7 +286,7 @@ class TestBasicsNDXarray(TestBasics):
         return
 
     def test_setting_data_as_tuple(self):
-        """Test setting data by name."""
+        """Test setting data as a tuple."""
 
         self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
         self.testInst['doubleMLT'] = ('time', 2. * self.testInst['mlt'].values)


### PR DESCRIPTION
# Description

#1074 is out of date with other pulls approved.  This should fix the issue noted.  Adds a test in the xarray tests.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import numpy as np
import pysat

inst = pysat.Instrument('pysat', 'ndtesting', use_header=True)
inst.load(2009, 1)
inst['new_val'] = ('time', np.ones(864))
```
This fails in develop, but succeeds here.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
