### PR TITLE
ENH: xarray io kwargs: `combine_by_coords` and `strict_dim_check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added Constellation class examples to the docs tutorial
   * Added links to the project standards repository to the docs
   * Improved formatting of custom kwargs when running `print` on an instrument
-  * Added `strict_dim_check` for loading xarray datasets through netCDF
+  * Added `strict_dim_check` for loading xarray Datasets through netCDF
   * Added `combine_by_coords` kwarg to `io.load_netcdf` for use on multi-file
-    xarray datasets
+    xarray Datasets
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added links to the project standards repository to the docs
   * Improved formatting of custom kwargs when running `print` on an instrument
   * Added `strict_dim_check` for loading xarray datasets through netCDF
-  * Added `combine` kwarg to `io.load_netcdf` for use on multi-file xarray
-    datasets
+  * Added `combine_by_coords` kwarg to `io.load_netcdf` for use on multi-file
+    xarray datasets
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added Constellation class examples to the docs tutorial
   * Added links to the project standards repository to the docs
   * Improved formatting of custom kwargs when running `print` on an instrument
+  * Added `strict_dim_check` for loading xarray datasets through netCDF
+  * Added `combine` kwarg to `io.load_netcdf` for use on multi-file xarray
+    datasets
 * Bug Fix
   * Allow `pysat.instruments.methods.general.list_files` to handle file
     cadences other than daily or monthly

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -416,7 +416,7 @@ class TestLoadNetCDF(object):
 
             self.out = caplog.text
             if strict_dim_check:
-                assert self.out.find(war_msg)
+                assert self.out.find(war_msg) >= 0
             else:
                 assert self.out.find(war_msg) < 0
         return

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -381,8 +381,9 @@ class TestLoadNetCDF(object):
 
     @pytest.mark.parametrize("write_epoch,war_msg", [('epoch',
                                                       'is not a dimension.')])
+    @pytest.mark.parametrize("strict_dim_check", [True, False])
     def test_read_netcdf4_epoch_not_xarray_dimension(self, caplog, write_epoch,
-                                                     war_msg):
+                                                     war_msg, strict_dim_check):
         """Test netCDF4 load `epoch_name` not a dimension.
 
         Parameters
@@ -391,6 +392,8 @@ class TestLoadNetCDF(object):
             Label used for datetime data when writing file.
         war_msg : str
             Warning message to test for.
+        strict_dim_check : bool
+            If True, raises warning. If False, does not raise warning.
 
         """
 
@@ -409,10 +412,13 @@ class TestLoadNetCDF(object):
 
                 io.load_netcdf(outfile, epoch_name='slt',
                                pandas_format=self.testInst.pandas_format,
-                               **tkwargs)
+                               strict_dim_check=strict_dim_check, **tkwargs)
 
             self.out = caplog.text
-            assert self.out.find(war_msg)
+            if strict_dim_check:
+                assert self.out.find(war_msg)
+            else:
+                assert self.out.find(war_msg) < 0
         return
 
     @pytest.mark.parametrize("wkwargs, lkwargs", [

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -701,7 +701,8 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
                         'max_val': ('value_max', np.float64),
                         'fill_val': ('fill', np.float64)},
                 meta_processor=None, meta_translation=None,
-                drop_meta_labels=None, decode_times=None):
+                drop_meta_labels=None, decode_times=None,
+                strict_dim_check=True):
     """Load netCDF-3/4 file produced by pysat.
 
     Parameters
@@ -776,6 +777,10 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         then `epoch_name` will be converted to datetime using `epoch_unit`
         and `epoch_origin`. If None, will be set to False for backwards
         compatibility. For xarray only. (default=None)
+    strict_dim_check : bool
+        Used for xarray data (`pandas_format` is False). If True, warn the user
+        that the desired epoch is not present in `xarray.dims`.  If False,
+        no warning is raised. (default=True)
 
     Returns
     -------
@@ -824,7 +829,8 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
                                         meta_processor=meta_processor,
                                         meta_translation=meta_translation,
                                         drop_meta_labels=drop_meta_labels,
-                                        decode_times=decode_times)
+                                        decode_times=decode_times,
+                                        strict_dim_check=strict_dim_check)
 
     return data, meta
 
@@ -1209,7 +1215,8 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
                                'max_val': ('value_max', np.float64),
                                'fill_val': ('fill', np.float64)},
                        meta_processor=None, meta_translation=None,
-                       drop_meta_labels=None, decode_times=False):
+                       drop_meta_labels=None, decode_times=False,
+                       strict_dim_check=True):
     """Load netCDF-3/4 file produced by pysat into an xarray Dataset.
 
     Parameters
@@ -1278,6 +1285,10 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
         then `epoch_name` will be converted to datetime using `epoch_unit`
         and `epoch_origin`. If None, will be set to False for backwards
         compatibility. (default=None)
+    strict_dim_check : bool
+        Used for xarray data (`pandas_format` is False). If True, warn the user
+        that the desired epoch is not present in `xarray.dims`.  If False,
+        no warning is raised. (default=True)
 
     Returns
     -------
@@ -1341,9 +1352,10 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
                 data = data.rename({epoch_name: 'time'})
             elif epoch_name in all_vars:
                 data = data.rename({epoch_name: 'time'})
-                wstr = ''.join(['Epoch label: "', epoch_name, '"',
-                                ' is not a dimension.'])
-                pysat.logger.warning(wstr)
+                if strict_dim_check:
+                    wstr = ''.join(['Epoch label: "', epoch_name, '"',
+                                    ' is not a dimension.'])
+                    pysat.logger.warning(wstr)
             else:
                 estr = ''.join(['Epoch label: "', epoch_name, '"',
                                 ' was not found in loaded dimensions [',

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -694,7 +694,7 @@ def meta_array_expander(meta_dict):
 
 def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
                 epoch_name=None, epoch_unit='ms', epoch_origin='unix',
-                pandas_format=True, decode_timedelta=False,
+                pandas_format=True, decode_timedelta=False, combine='by_coords',
                 labels={'units': ('units', str), 'name': ('long_name', str),
                         'notes': ('notes', str), 'desc': ('desc', str),
                         'min_val': ('value_min', np.float64),
@@ -742,6 +742,11 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
         Used for xarray data (`pandas_format` is False).  If True, variables
         with unit attributes that  are 'timelike' ('hours', 'minutes', etc) are
         converted to `np.timedelta64`. (default=False)
+    combine : str
+        Used for xarray data (`pandas_format` is False). When loading a
+        multi-file dataset, specifies whether to use `xarray.combine_by_coords`
+        or `xarray.combine_nested`. Accepts ["by_coords", "nested"].
+        (default='by_coords')
     labels : dict
         Dict where keys are the label attribute names and the values are tuples
         that have the label values and value types in that order.
@@ -814,6 +819,7 @@ def load_netcdf(fnames, strict_meta=False, file_format='NETCDF4',
                                         epoch_unit=epoch_unit,
                                         epoch_origin=epoch_origin,
                                         decode_timedelta=decode_timedelta,
+                                        combine=combine,
                                         labels=labels,
                                         meta_processor=meta_processor,
                                         meta_translation=meta_translation,
@@ -1195,7 +1201,7 @@ def load_netcdf_pandas(fnames, strict_meta=False, file_format='NETCDF4',
 
 def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
                        epoch_name='time', epoch_unit='ms', epoch_origin='unix',
-                       decode_timedelta=False,
+                       decode_timedelta=False, combine='by_coords',
                        labels={'units': ('units', str),
                                'name': ('long_name', str),
                                'notes': ('notes', str), 'desc': ('desc', str),
@@ -1238,6 +1244,11 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
     decode_timedelta : bool
         If True, variables with unit attributes that are 'timelike' ('hours',
         'minutes', etc) are converted to `np.timedelta64`. (default=False)
+    combine : str
+        Used for xarray data (`pandas_format` is False). When loading a
+        multi-file dataset, specifies whether to use `xarray.combine_by_coords`
+        or `xarray.combine_nested`. Accepts ["by_coords", "nested"].
+        (default='by_coords')
     labels : dict
         Dict where keys are the label attribute names and the values are tuples
         that have the label values and value types in that order.
@@ -1318,7 +1329,7 @@ def load_netcdf_xarray(fnames, strict_meta=False, file_format='NETCDF4',
                                decode_times=decode_times)
     else:
         data = xr.open_mfdataset(fnames, decode_timedelta=decode_timedelta,
-                                 combine='by_coords', decode_times=decode_times)
+                                 combine=combine, decode_times=decode_times)
 
     # Need to get a list of all variables, dimensions, and coordinates.
     all_vars = xarray_all_vars(data)


### PR DESCRIPTION
# Description

Addresses #923 & #1098

Adds quality of life kwargs to `utils.io.load_netcdf` for xarray datasets. Both required for upcoming pysatNASA pulls. Defaults to existing behavior.
- `combine_by_coords` allows users to specify use a nested combining multi-day datasets when coords are not set in the data files.
- `strict_dim_check` suppresses the warning message if the epoch is not listed in dims

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Tested against loading multiple days of GOLD instruments.

```
import datetime as dt
import pysat

gold = pysat.Instrument(platform='ses14', name='gold', tag='tlimb')
d0 = dt.datetime(2019, 9, 5)
dn = dt.datetime(2019, 9, 7)
gold.load(date=d0, end_date=dn)
```


**Test Configuration**:
* Operating system: Mac Monterrey
* Version number: Python 3.10.8
* Needs downstream branch from @landsito for pysatNASA: https://github.com/landsito/pysatNASA/blob/gold/pysatNASA/instruments/ses14_gold.py

Update lines 200-203 to be:
```
    data, meta = load_netcdf(fnames, pandas_format=pandas_format,
                             epoch_name=epoch_name, labels=labels,
                             meta_translation=meta_translation,
                             drop_meta_labels='FILLVAL',
                             combine_by_coords=False)
```
and remove the try/except notation.  This loads both days as expected.

* For testing`strict_dim_check`, use the develop branch of pysatNASA.  Update lines 302-304 to
```
        sdata, mdata = load_netcdf(fname, epoch_name=load_time, epoch_unit='s',
                                   labels=labels, pandas_format=pandas_format,
                                   strict_dim_check=False)
```
and then load a day of TIMED GUVI SDR data.  The pysat warning should be suppressed.
# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
