### PR TITLE
BUG: Constellation Index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed a bug where data may not have any times, but still not be empty
   * Fixed a bug where a multi_file_day non-monotonic xarray index failed to
     merge datasets (#1005)
+  * Fixed a bug when loading a constellation where data partially exists.
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -106,6 +106,7 @@ from pysat._meta import Meta
 from pysat._meta import MetaHeader
 from pysat._meta import MetaLabels
 from pysat._orbits import Orbits
+from pysat import constellations
 from pysat import instruments
 from pysat import utils
 

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -106,7 +106,6 @@ from pysat._meta import Meta
 from pysat._meta import MetaHeader
 from pysat._meta import MetaLabels
 from pysat._orbits import Orbits
-from pysat import constellations
 from pysat import instruments
 from pysat import utils
 

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -426,41 +426,42 @@ class Constellation(object):
             out_res = None
 
             for inst in self.instruments:
-                if stime is None:
-                    # Initialize the start and stop time
-                    stime = inst.index[0]
-                    etime = inst.index[-1]
+                if not inst.empty:
+                    if stime is None:
+                        # Initialize the start and stop time
+                        stime = inst.index[0]
+                        etime = inst.index[-1]
 
-                    # If desired, determine the resolution
-                    if self.index_res is None:
-                        if inst.index.freq is None:
-                            out_res = pysat.utils.time.calc_res(inst.index)
-                        else:
-                            out_res = pysat.utils.time.freq_to_res(
-                                inst.index.freq)
-                else:
-                    # Adjust the start and stop time as appropriate
-                    if self.common_index:
-                        if stime < inst.index[0]:
-                            stime = inst.index[0]
-                        if etime > inst.index[-1]:
-                            etime = inst.index[-1]
+                        # If desired, determine the resolution
+                        if self.index_res is None:
+                            if inst.index.freq is None:
+                                out_res = pysat.utils.time.calc_res(inst.index)
+                            else:
+                                out_res = pysat.utils.time.freq_to_res(
+                                    inst.index.freq)
                     else:
-                        if stime > inst.index[0]:
-                            stime = inst.index[0]
-                        if etime < inst.index[-1]:
-                            etime = inst.index[-1]
-
-                    # If desired, determine the resolution
-                    if self.index_res is None:
-                        if inst.index.freq is None:
-                            new_res = pysat.utils.time.calc_res(inst.index)
+                        # Adjust the start and stop time as appropriate
+                        if self.common_index:
+                            if stime < inst.index[0]:
+                                stime = inst.index[0]
+                            if etime > inst.index[-1]:
+                                etime = inst.index[-1]
                         else:
-                            new_res = pysat.utils.time.freq_to_res(
-                                inst.index.freq)
+                            if stime > inst.index[0]:
+                                stime = inst.index[0]
+                            if etime < inst.index[-1]:
+                                etime = inst.index[-1]
 
-                        if new_res < out_res:
-                            out_res = new_res
+                        # If desired, determine the resolution
+                        if self.index_res is None:
+                            if inst.index.freq is None:
+                                new_res = pysat.utils.time.calc_res(inst.index)
+                            else:
+                                new_res = pysat.utils.time.freq_to_res(
+                                    inst.index.freq)
+
+                            if new_res < out_res:
+                                out_res = new_res
 
             # If a resolution in seconds was supplied, calculate the frequency
             if self.index_res is not None:

--- a/pysat/constellations/__init__.py
+++ b/pysat/constellations/__init__.py
@@ -4,7 +4,7 @@ Each instrument is contained within a subpackage of the pysat.instruments
 package.
 """
 
-__all__ = ['testing', 'testing_empty', 'single_test']
+__all__ = ['testing', 'testing_empty', 'testing_partial', 'single_test']
 
 for const in __all__:
     exec("from pysat.constellations import {:}".format(const))

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -177,6 +177,8 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
 
     if tag == 'default_meta':
         return data, pysat.Meta()
+    elif tag == 'no_download':
+        return pds.DataFrame(), pysat.Meta()
     else:
         return data, meta
 

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -247,6 +247,27 @@ class TestConstellationInit(object):
             assert (inst['double_mlt'] == 2.0 * inst['mlt']).all()
         return
 
+    @pytest.mark.parametrize(
+        "in_kwargs", [{"instruments":
+                       constellations.testing_partial.instruments},
+                      {"const_module": constellations.testing_partial}])
+    def test_load_constellation_partial(self, in_kwargs):
+        """Test that constellation with partial data coverage loads.
+
+        Parameters
+        ----------
+        in_kwargs : dict
+            Dictionary of kwargs to initialize constellation.
+
+        """
+
+        self.const = pysat.Constellation(**self.in_kwargs)
+        self.const.load(date=self.ref_time, use_header=True)
+
+        out = self.const.__str__()
+
+        assert out.find('Some')
+
 
 class TestConstellationFunc(object):
     """Test the Constellation class attributes and methods."""


### PR DESCRIPTION
# Description

Addresses #798

Sometimes a constellation has only partial data.  Currently, the index checks for the common index whether an instrument has loaded data or not.  This fixes the index check to make sure data exists.
- Adds a partially empty constellation object
- Updates the pysat_testing `no_download` instrument to also return an empty dataset

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat

ivma = pysat.Instrument('icon', 'ivm', inst_id='a')
ivmb = pysat.Instrument('icon', 'ivm', inst_id='b')
const = pysat.Constellation(instruments=[ivma, ivmb])
const.load(2020, 1)
print(const)
```
Both instruments will not have data at the same time.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.8
* pysatNASA installed and registered, ICON IVM data downloaded

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
