### PR TITLE
BUG: support for multiple load options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed a bug where data may not have any times, but still not be empty
   * Fixed a bug where a multi_file_day non-monotonic xarray index failed to
     merge datasets (#1005)
+  * Fixed a bug in testing for setting multiple optional load kwargs (#1097)
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -26,7 +26,7 @@ tags = {'': 'Regular testing data set',
 inst_ids = {'': [tag for tag in tags.keys()]}
 _test_dates = {'': {tag: dt.datetime(2009, 1, 1) for tag in tags.keys()}}
 _test_download = {'': {'no_download': False}}
-_test_load_opt = {'': {'': {'num_samples': 13}}}
+_test_load_opt = {'': {'': [{'num_samples': 13}, {'num_samples': 15}]}}
 
 # Init method
 init = mm_test.init

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -633,6 +633,37 @@ class TestGenerateInstList(object):
             assert ('user_info' not in inst.keys())
         return
 
+    def test_list_kwargs_passthrough(self):
+        """Test that kwargs are passed through to lists correctly."""
+
+        # Iterate over unique instruments gathered
+        for inst in self.inst_list['download']:
+            # kwargs should not be passed to download
+            assert ('kwargs' not in inst.keys())
+
+            # Construct list of tests with optional load kwargs for this
+            # instrument.
+            list_kwargs = []
+            for opt_inst in self.inst_list['load_options']:
+                if inst['inst_module'] == opt_inst['inst_module']:
+                    if 'kwargs' in opt_inst.keys():
+                        list_kwargs.append(opt_inst['kwargs'].copy())
+
+            # Check if instrument has optional load kwargs
+            if hasattr(inst['inst_module'], '_test_load_opt'):
+                load_opt = getattr(inst['inst_module'], '_test_load_opt')
+                try:
+                    load_opt = load_opt[inst['inst_id']][inst['tag']]
+                    # Check that options specified in module match generated
+                    # test list.
+                    utils.testing.assert_lists_equal(list_kwargs, load_opt)
+                except KeyError:
+                    # Optional load kwargs not defined for this tag / inst_id
+                    # combination.
+                    pass
+
+        return
+
 
 class TestDeprecation(object):
     """Unit test for deprecation warnings."""

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -475,7 +475,7 @@ def generate_instrument_list(inst_loc, user_info=None):
                     if not ci_skip:
                         # Check if instrument is configured for download tests.
                         if inst._test_download:
-                            instrument_download.append(in_dict)
+                            instrument_download.append(in_dict.copy())
                             if hasattr(module, '_test_load_opt'):
                                 # Add optional load tests
                                 try:

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -483,7 +483,9 @@ def generate_instrument_list(inst_loc, user_info=None):
                                     kw_list = pysat.utils.listify(kw_list)
                                     for kwargs in kw_list:
                                         in_dict['kwargs'] = kwargs
-                                        instrument_optional_load.append(in_dict)
+                                        # Append as copy so kwargs are unique.
+                                        instrument_optional_load.append(
+                                            in_dict.copy())
                                 except KeyError:
                                     # Option does not exist for tag/inst_id
                                     # combo

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -483,6 +483,7 @@ def generate_instrument_list(inst_loc, user_info=None):
                                     kw_list = pysat.utils.listify(kw_list)
                                     for kwargs in kw_list:
                                         in_dict['kwargs'] = kwargs
+
                                         # Append as copy so kwargs are unique.
                                         instrument_optional_load.append(
                                             in_dict.copy())


### PR DESCRIPTION
# Description

Addresses #1097

When generating a list of tests to run for multiple load options, the list is incorrectly set because elements are rewritten.  This attaches copies of the objects to the list of test cases so that the elements are not rewritten.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Pick an instrument in a supporting package (ie, timed_guvi).  Add multiple load options.
```
_test_load_opt = {iid: {tag: [{'combine_times': True}, {'combine_times': False}]
                        for tag in inst_ids[iid]} for iid in ['high_res',
                                                              'low_res']}
```
Now generate the instrument tests.
```
import pysatNASA

from pysat.tests.classes import cls_instrument_library as clslib

instruments = clslib.InstLibTests.initialize_test_package(
    clslib.InstLibTests, inst_loc=pysatNASA.instruments)
```
Inspecting the tests for load option (`instruments['load_options']) yields
```
 {'inst_module': <module 'pysatNASA.instruments.timed_guvi' from '/Users/jklenzin/code/core/pysatNASA/pysatNASA/instruments/timed_guvi.py'>,
  'tag': 'sdr-spectrograph',
  'inst_id': 'low_res',
  'kwargs': {'combine_times': True}},
 {'inst_module': <module 'pysatNASA.instruments.timed_guvi' from '/Users/jklenzin/code/core/pysatNASA/pysatNASA/instruments/timed_guvi.py'>,
  'tag': 'sdr-spectrograph',
  'inst_id': 'low_res',
  'kwargs': {'combine_times': False}}]
```
if the options are correctly set.  In `develop`, both of these test setups include `{'combine_times': False}` for the kwargs input, since the dictionary is rewritten later.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.8
* Modifications to `pysatNASA.instruments.timed_guvi` outlined above.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
