### PR TITLE
BUG: windows `tempdir` cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     merge datasets (#1005)
   * Fixed a bug in testing for setting multiple optional load kwargs (#1097)
   * Fixed a bug when setting xarray data as a tuple
+  * Fixed a bug when cleaning up temporary directories on windows during testing
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`


### PR DESCRIPTION
# Description

Addresses #974 (partial)

pysatNASA is seeing fails to properly clean up the temporary directory on windows: https://github.com/pysat/pysatNASA/pull/159

This is only happening for this pull, but it happens consistently.  It could just be we've hit a critical mass of instruments with the latest additions.

Fix based on the one implemented in test_utils_io.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

this needs a version at test pypi to properly test, or a modified github actions job to install from this branch.

**Test Configuration**:
* Operating system: ???
* Version number: Python 3.10
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
