### PR TITLE
ENH/TST: add partially empty constellation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     merge datasets (#1005)
   * Fixed a bug in testing for setting multiple optional load kwargs (#1097)
   * Fixed a bug when setting xarray data as a tuple
+  * Fixed a bug when loading constellations for partially empty instrument lists
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`
@@ -43,6 +44,11 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Additional unit tests for data padding when a data index is non-monotonic.
   * Deprecated the `malformed_index` kwarg in the test instruments.  This is
     replaced by `non_monotonic_index` and `non_unique_index`
+  * Set the `instruments.pysat_testing` tag='no_download' to return an empty
+    pandas DataFrame for `load`
+  * Added `constellations.testing_partial`, which loads a partially empty
+    constellation dataset
+  * Reduced default num_samples for constellation test objects
 
 [3.0.6] - 2022-12-21
 --------------------

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -426,41 +426,42 @@ class Constellation(object):
             out_res = None
 
             for inst in self.instruments:
-                if stime is None:
-                    # Initialize the start and stop time
-                    stime = inst.index[0]
-                    etime = inst.index[-1]
+                if not inst.empty:
+                    if stime is None:
+                        # Initialize the start and stop time
+                        stime = inst.index[0]
+                        etime = inst.index[-1]
 
-                    # If desired, determine the resolution
-                    if self.index_res is None:
-                        if inst.index.freq is None:
-                            out_res = pysat.utils.time.calc_res(inst.index)
-                        else:
-                            out_res = pysat.utils.time.freq_to_res(
-                                inst.index.freq)
-                else:
-                    # Adjust the start and stop time as appropriate
-                    if self.common_index:
-                        if stime < inst.index[0]:
-                            stime = inst.index[0]
-                        if etime > inst.index[-1]:
-                            etime = inst.index[-1]
+                        # If desired, determine the resolution
+                        if self.index_res is None:
+                            if inst.index.freq is None:
+                                out_res = pysat.utils.time.calc_res(inst.index)
+                            else:
+                                out_res = pysat.utils.time.freq_to_res(
+                                    inst.index.freq)
                     else:
-                        if stime > inst.index[0]:
-                            stime = inst.index[0]
-                        if etime < inst.index[-1]:
-                            etime = inst.index[-1]
-
-                    # If desired, determine the resolution
-                    if self.index_res is None:
-                        if inst.index.freq is None:
-                            new_res = pysat.utils.time.calc_res(inst.index)
+                        # Adjust the start and stop time as appropriate
+                        if self.common_index:
+                            if stime < inst.index[0]:
+                                stime = inst.index[0]
+                            if etime > inst.index[-1]:
+                                etime = inst.index[-1]
                         else:
-                            new_res = pysat.utils.time.freq_to_res(
-                                inst.index.freq)
+                            if stime > inst.index[0]:
+                                stime = inst.index[0]
+                            if etime < inst.index[-1]:
+                                etime = inst.index[-1]
 
-                        if new_res < out_res:
-                            out_res = new_res
+                        # If desired, determine the resolution
+                        if self.index_res is None:
+                            if inst.index.freq is None:
+                                new_res = pysat.utils.time.calc_res(inst.index)
+                            else:
+                                new_res = pysat.utils.time.freq_to_res(
+                                    inst.index.freq)
+
+                            if new_res < out_res:
+                                out_res = new_res
 
             # If a resolution in seconds was supplied, calculate the frequency
             if self.index_res is not None:

--- a/pysat/constellations/__init__.py
+++ b/pysat/constellations/__init__.py
@@ -4,7 +4,7 @@ Each instrument is contained within a subpackage of the pysat.instruments
 package.
 """
 
-__all__ = ['testing', 'testing_empty', 'single_test']
+__all__ = ['testing', 'testing_empty', 'testing_partial', 'single_test']
 
 for const in __all__:
     exec("from pysat.constellations import {:}".format(const))

--- a/pysat/constellations/single_test.py
+++ b/pysat/constellations/single_test.py
@@ -10,4 +10,4 @@ instruments : list
 import pysat
 
 instruments = [pysat.Instrument('pysat', 'testing', clean_level='clean',
-                                update_files=True)]
+                                num_samples=10, update_files=True)]

--- a/pysat/constellations/testing.py
+++ b/pysat/constellations/testing.py
@@ -5,16 +5,16 @@ Attributes
 instruments : list
     List of pysat.Instrument objects
 
+Note
+----
+Each instrument has a different sample size to test the common_index
+
 """
 import pysat
 
 instruments = [pysat.Instrument('pysat', 'testing', clean_level='clean',
                                 num_samples=10, use_header=True),
-               pysat.Instrument('pysat', 'testing2d', clean_level='clean',
-                                use_header=True),
                pysat.Instrument('pysat', 'ndtesting', clean_level='clean',
-                                use_header=True),
-               pysat.Instrument('pysat', 'testing_xarray', clean_level='clean',
-                                use_header=True),
+                                num_samples=16, use_header=True),
                pysat.Instrument('pysat', 'testmodel', clean_level='clean',
-                                use_header=True)]
+                                num_samples=18, use_header=True)]

--- a/pysat/constellations/testing_partial.py
+++ b/pysat/constellations/testing_partial.py
@@ -1,0 +1,14 @@
+"""Create a constellation where not all instruments have loadable data.
+
+Attributes
+----------
+instruments : list
+    List of pysat.Instrument objects
+
+"""
+import pysat
+
+instruments = [pysat.Instrument('pysat', 'testing', clean_level='clean',
+                                num_samples=10, use_header=True),
+               pysat.Instrument('pysat', 'testing', tag='no_download',
+                                clean_level='clean', use_header=True)]

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -187,6 +187,8 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
 
     if tag == 'default_meta':
         return data, pysat.Meta()
+    elif tag == 'no_download':
+        return pds.DataFrame(), pysat.Meta()
     else:
         return data, meta
 

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -341,8 +341,9 @@ class TestConstellationFunc(object):
     def test_empty_flag_data_empty_partial_load(self):
         """Test the status of the empty flag for partially loaded data."""
 
-        # Load only one instrument and test the status flag
-        self.const.instruments[0].load(date=self.ref_time, use_header=True)
+        self.const = pysat.Constellation(
+            const_module=constellations.testing_partial, use_header=True)
+        self.const.load(date=self.ref_time)
         assert self.const.empty_partial
         assert not self.const.empty
         return
@@ -350,8 +351,9 @@ class TestConstellationFunc(object):
     def test_empty_flag_data_not_empty_partial_load(self):
         """Test the alt status of the empty flag for partially loaded data."""
 
-        # Load only one instrument and test the status flag for alternate flag
-        self.const.instruments[0].load(date=self.ref_time, use_header=True)
+        self.const = pysat.Constellation(
+            const_module=constellations.testing_partial, use_header=True)
+        self.const.load(date=self.ref_time)
         assert not self.const._empty(all_inst=False)
         return
 

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -505,7 +505,7 @@ class TestConstellationFunc(object):
         # Redefine the Instrument and constellation
         self.inst = pysat.Instrument(
             inst_module=pysat.instruments.pysat_testing, use_header=True,
-            pad=pds.DateOffset(hours=1))
+            pad=pds.DateOffset(hours=1), num_samples=10)
         self.const = pysat.Constellation(instruments=[self.inst],
                                          use_header=True)
 
@@ -542,10 +542,10 @@ class TestConstellationFunc(object):
         pad = pds.DateOffset(hours=1)
         self.inst = [
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             use_header=True, pad=pad),
+                             use_header=True, pad=pad, num_samples=10),
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
                              use_header=True, pad=2 * pad,
-                             clean_level=clean_level)]
+                             clean_level=clean_level, num_samples=10)]
         self.const = pysat.Constellation(instruments=self.inst, use_header=True)
 
         # Load the Instrument and Constellation data


### PR DESCRIPTION
# Description

Addresses #798

Adds a partially empty constellation object for testing and uses this in the existing tests for a partially loaded constellation.

- Fixed a bug where `_index` attempts to construct the index from empty instruments
- Set the `instruments.pysat_testing` tag='no_download' to return an empty pandas DataFrame for `load`
- Added `constellations.testing_partial`, which loads a partially empty constellation dataset
- Reduced default num_samples for constellation test objects
- Removed deprecated instruments from constellation test objects

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

```
import pysat
from pysat import constellations

const = pysat.Constellation(const_module=constellations.testing_partial, use_header=True)
const.load(2009, 1)
```

`const[0]` returns data, `const[1]` is empty.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
