### PR TITLE
BUG: setting meta data type

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1003,9 +1003,8 @@ class Instrument(object):
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
 
-                if not np.isnan(new):
-                    self.meta._data_types[key[1]] = self.data[
-                        key[1]].values.dtype.type
+                self.meta._data_types[key[1]] = self.data[
+                    key[1]].values.dtype.type
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1003,8 +1003,9 @@ class Instrument(object):
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
 
-                self.meta._data_types[key[1]] = self.data[
-                    key[1]].values.dtype.type
+                if not np.isnan(new):
+                    self.meta._data_types[key[1]] = self.data[
+                        key[1]].values.dtype.type
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):

--- a/pysat/_meta.py
+++ b/pysat/_meta.py
@@ -189,8 +189,8 @@ class Meta(object):
         # Set the labels
         self.labels = MetaLabels(metadata=self, **labels)
 
-        # Set the data types, if provided
-        self._data_types = data_types
+        # Set the data types. If not provided, empty dict
+        self._data_types = data_types if data_types else {}
 
         # Initialize higher order (nD) data structure container, a dict
         self._ho_data = {}


### PR DESCRIPTION
# Description

Follows #1095

When data is set to new values, the meta types are updated accordingly.  However, in some cleaning routines, values are updated to `np.nan`.  This breaks the type update.

~~This bugfix only updates the type if the value is non a nan.~~

The source of the bug is that `meta._data_types` is initiated as `None` by default.  When new data is set, keys cannot be added to a `NoneType`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

By running pytest on pysatNASA.

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.9.7

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes -- bugfix to last pull

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
