### PR TITLE
BUG: fix meta type before preprocess / clean

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -988,6 +988,12 @@ class Instrument(object):
 
         new = copy.deepcopy(new_data)
 
+        if self.meta._data_types is None:
+            mutable = self.meta.mutable
+            self.meta.mutable = True
+            self.meta._data_types = {}
+            self.meta.mutable = mutable
+
         # Add data to main pandas.DataFrame, depending upon the input
         # slice, and a name
         if self.pandas_format:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1010,10 +1010,7 @@ class Instrument(object):
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
 
-                for lkey in pysat.utils.listify(key[1]):
-                    if not isinstance(lkey, slice) and lkey in self.variables:
-                        self.meta._data_types[lkey] = self.data[
-                            lkey].values.dtype.type
+                self._update_data_types(key[1])
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):
@@ -1050,11 +1047,7 @@ class Instrument(object):
 
             # Assign data and any extra metadata
             self.data[key] = in_data
-
-            for lkey in pysat.utils.listify(key):
-                if not isinstance(lkey, slice) and lkey in self.variables:
-                    self.meta._data_types[lkey] = self.data[
-                        lkey].values.dtype.type
+            self._update_data_types(key)
 
             self.meta[key] = new
 
@@ -3846,6 +3839,21 @@ class Instrument(object):
                                       export_pysat_info=export_pysat_info,
                                       unlimited_time=unlimited_time)
 
+        return
+
+    def _update_data_types(self, key):
+        """Update the data types in pysat.Meta object.
+
+        Parameters
+        ----------
+        key : str or list
+            key or list of keys to update.
+
+        """
+
+        for lkey in pysat.utils.listify(key):
+            if not isinstance(lkey, slice) and lkey in self.variables:
+                self.meta._data_types[lkey] = self.data[lkey].values.dtype.type
         return
 
 

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -988,6 +988,7 @@ class Instrument(object):
 
         new = copy.deepcopy(new_data)
 
+        # Initialize as empty dict.
         if self.meta._data_types is None:
             mutable = self.meta.mutable
             self.meta.mutable = True

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1003,8 +1003,10 @@ class Instrument(object):
                     # (including list or slice).
                     self.data.loc[self.data.index[key[0]], key[1]] = new
 
-                self.meta._data_types[key[1]] = self.data[
-                    key[1]].values.dtype.type
+                for lkey in pysat.utils.listify(key[1]):
+                    if not isinstance(lkey, slice) and lkey in self.variables:
+                        self.meta._data_types[lkey] = self.data[
+                            lkey].values.dtype.type
                 self.meta[key[1]] = {}
                 return
             elif not isinstance(new, dict):

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1082,8 +1082,7 @@ class Instrument(object):
                     # Try loading indexed as integers
                     self.data[key[-1]][indict] = in_data
 
-                self.meta._data_types[key[-1]] = self.data[
-                    key[-1]].values.dtype.type
+                self._update_data_types(key[-1])
                 self.meta[key[-1]] = new
                 return
             elif isinstance(key, str):


### PR DESCRIPTION
# Description

Addresses #1109

Updates meta data type after load is run. If instruments have clean or preprocess routines that modify data, the data type needs to exist in `inst.meta._data_types` before it is modified by `setitem`.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

running pytest on various pysat library packages

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.8

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
Packages tested
- [ ] pysatCDAAC
- [x] pysatMadrigal
- [x] pysatMissions
- [x] pysatModels
- [x] pysatNASA
- [x] pysatSpaceWeather

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
