### PR TITLE
Range index error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Deprecated the Instrument kwarg `labels` in favor of `meta_kwargs` and
     replaced the `meta_labels` attribute with the `meta_kwargs` attribute
   * Deprecated the `labels` keyword arg in favor of `meta_kwargs` in the
-    netCDF I/O functions and Instrument sub-module    
+    netCDF I/O functions and Instrument sub-module
   * Deprecated the `malformed_index` kwarg in the test instruments.  This is
     replaced by `non_monotonic_index` and `non_unique_index`
 * Bug Fix
@@ -55,6 +55,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Fixed a bug when setting xarray data as a tuple
   * Fixed a bug when loading constellations for partially empty instrument lists
   * Fixed a bug when cleaning up temporary directories on windows during testing
+  * Fixed a bug in Instrument loading with a pad, where RangeIndex slicing no
+    longer works on an empty series
 * Maintenance
   * Added roadmap to readthedocs
   * Improved the documentation in `pysat.utils.files`

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3304,12 +3304,13 @@ class Instrument(object):
                 else:
                     self.data = stored_data
 
-            self.data = self[first_pad:last_pad]
+            if len(self.index) > 0:
+                self.data = self[first_pad:last_pad]
 
-            # Want exclusive end slicing behavior from above
-            if not self.empty:
-                if (self.index[-1] == last_pad) & (not want_last_pad):
-                    self.data = self[:-1]
+                # Want exclusive end slicing behavior from above
+                if not self.empty:
+                    if (self.index[-1] == last_pad) & (not want_last_pad):
+                        self.data = self[:-1]
 
         else:
             # If self.pad is False, load single day

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -132,8 +132,16 @@ class InstAccessTests(object):
         self.eval_successful_load()
         return
 
-    def test_basic_instrument_load_no_data(self, caplog):
-        """Test Instrument load with no data for appropriate log messages."""
+    @pytest.mark.parametrize('pad', [None, dt.timedelta(days=1)])
+    def test_basic_instrument_load_no_data(self, caplog, pad):
+        """Test Instrument load with no data for appropriate log messages.
+
+        Parameters
+        ----------
+        pad : dt.timedelta, pds.DateOffset, NoneType
+            Pad input for load call
+
+        """
 
         # Get a date that is not covered by an Instrument object.
         no_data_d = self.testInst.files.files.index[0] - dt.timedelta(weeks=10)
@@ -144,7 +152,7 @@ class InstAccessTests(object):
             # Test doesn't check against loading by filename since that produces
             # an error if there is no file. Loading by yr, doy no different
             # than date in this case.
-            self.testInst.load(date=no_data_d, use_header=True)
+            self.testInst.load(date=no_data_d, pad=pad, use_header=True)
 
         # Confirm by checking against caplog that metadata was
         # not assigned.


### PR DESCRIPTION
# Description

Addresses bug found and temporarily fixed in https://github.com/pysat/pysatSpaceWeather/issues/117, where loading data with a pad for a period where no data is available now causes an error when trying to slice the index.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a new unit test.  Couldn't get the error locally, but it's showing up here: https://github.com/pysat/pysatSpaceWeather/pull/116

**Test Configuration**:
* Operating system: GitHub Actions
* Version number: Python 3.6-3.10
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
