### PR TITLE
Improved Instrument ValueError message for a bad tag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     clean method.
 * Maintenance
   * Update link redirects in docs.
+  * Improved Instrument ValueError messages.
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1396,10 +1396,12 @@ class Instrument(object):
             raise ValueError(estr)
 
         if self.tag not in self.inst_module.inst_ids[self.inst_id]:
-            tag_str = ', '.join([tkey.__repr__() for tkey
-                                 in self.inst_module.inst_ids[self.inst_id]])
+            tag_id_str = repr(self.inst_module.inst_ids[self.inst_id]).replace(
+                "{", "'inst ID': ['tag'] combinations are: ")
+            tag_id_str = tag_id_str.replace("}", "")
             estr = ''.join(("'", self.tag, "' is not one of the supported ",
-                            'tags. Supported tags are: ', tag_str, '.'))
+                            "tags for inst ID ['", self.inst_id, "']. ",
+                            'Supported ', tag_id_str))
             raise ValueError(estr)
 
         # Assign the Instrument methods

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -693,7 +693,7 @@ class InstPropertyTests(object):
         [({'inst_id': 'invalid_inst_id'},
           "'invalid_inst_id' is not one of the supported inst_ids."),
          ({'inst_id': '', 'tag': 'bad_tag'},
-          "'bad_tag' is not one of the supported tags.")])
+          "'bad_tag' is not one of the supported tags")])
     def test_error_bad_instrument_object(self, kwargs, estr):
         """Ensure instantiation with invalid inst_id or tag errors.
 


### PR DESCRIPTION
# Description

Sometimes a valid tag is used, but with the wrong inst_id.  The current ValueError message just tells you that you have a bad tag.  The new ValueError message tells you that you have a bad tag for the inst_id you used, and provides a list of the valid combinations.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
import pysatNASA

guvi = pysat.Instrument(inst_module=pysatNASA.instruments.timed_guvi, tag='sdr-imaging')
```

This will fail with a ValueError.  The old error reads: `ValueError: 'sdr-imaging' is not one of the supported tags for inst ID ['']. Supported ['edr-aur']`, the new error will be more informative about what you need to do to fix the call.

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant: develop branch of pysatNASA

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
