### PR TITLE
ENH: added `include` kwarg to `concat_data`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     clean method.
   * Added loading test with padding for Instruments.
   * Allow Instruments to define custom `concat_data` methods.
+  * Added `include` kwarg to `Instrument.concat_data` to expand allowed inputs.
   * Added data kwarg to the Instrument class `__getitem__` method and reduced
     memory usage in the `load` method.
   * Added a hidden method the Instrument class `_get_epoch_name_from_data` to

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2469,7 +2469,7 @@ class Instrument(object):
         # Order the data to be concatenated in a list
         if not isinstance(new_data, list):
             new_data = [new_data]
-            
+
         if include is None:
             if prepend:
                 new_data.append(self.data)

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2427,7 +2427,7 @@ class Instrument(object):
 
         return inst_copy
 
-    def concat_data(self, new_data, prepend=False, **kwargs):
+    def concat_data(self, new_data, prepend=False, include=None, **kwargs):
         """Concatonate data to self.data for xarray or pandas as needed.
 
         Parameters
@@ -2437,6 +2437,9 @@ class Instrument(object):
         prepend : bool
             If True, assign new data before existing data; if False append new
             data (default=False)
+        include : int or NoneType
+            Index at which `self.data` should be included in `new_data` or None
+            to use `prepend` (default=None)
         **kwargs : dict
             Optional keyword arguments passed to pds.concat or xr.concat
 
@@ -2450,6 +2453,13 @@ class Instrument(object):
         For xarray, `dim=Instrument.index.name` is passed along to xarray.concat
         except if the user includes a value for dim as a keyword argument.
 
+        Examples
+        --------
+        ::
+
+            # Concatonate data before and after the existing Instrument data
+            inst.concat_data([prev_data, next_data], include=1)
+
         """
         # Add any concat_data kwargs
         for ckey in self.kwargs['concat_data'].keys():
@@ -2459,11 +2469,14 @@ class Instrument(object):
         # Order the data to be concatenated in a list
         if not isinstance(new_data, list):
             new_data = [new_data]
-
-        if prepend:
-            new_data.append(self.data)
+            
+        if include is None:
+            if prepend:
+                new_data.append(self.data)
+            else:
+                new_data.insert(0, self.data)
         else:
-            new_data.insert(0, self.data)
+            new_data.insert(include, self.data)
 
         if self._concat_data_rtn.__name__.find('_pass_method') == 0:
             # There is no custom concat function, use the pysat standard method.
@@ -3380,8 +3393,10 @@ class Instrument(object):
                                            "by file.")))
 
             # Pad data based upon passed parameter
+            cdata = list()
+            include = None
             if not self._empty(self._prev_data) and not self.empty:
-                # __getitem__ used to handle any pandas/xarray differences in
+                # __getitem__ is used to handle any pandas/xarray differences in
                 # data slicing
                 pdata = self.__getitem__(slice(first_pad, self.index[0]),
                                          data=self._prev_data)
@@ -3391,11 +3406,11 @@ class Instrument(object):
                     if len(pindex) > 0:
                         if pindex[-1] == self.index[0]:
                             pdata = self.__getitem__(slice(-1), data=pdata)
-                        self.concat_data(pdata, prepend=True)
-                del pdata
+                        cdata.append(pdata)
+                        include = 1
 
             if not self._empty(self._next_data) and not self.empty:
-                # __getitem__ used to handle any pandas/xarray differences in
+                # __getitem__ is used to handle any pandas/xarray differences in
                 # data slicing
                 ndata = self.__getitem__(slice(self.index[-1], last_pad),
                                          data=self._next_data)
@@ -3407,8 +3422,13 @@ class Instrument(object):
                             ndata = self.__getitem__(
                                 slice(1, len(ndata[self.index.name])),
                                 data=ndata)
-                        self.concat_data(ndata, prepend=False)
-                del ndata
+                        cdata.append(ndata)
+                        if include is None:
+                            include = 0
+
+            # Concatonate the current, previous, and next data
+            if len(cdata) > 0:
+                self.concat_data(cdata, include=include)
 
             if len(self.index) > 0:
                 self.data = self[first_pad:last_pad]

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -574,7 +574,8 @@ class InstAccessTests(object):
 
     @pytest.mark.parametrize("prepend, sort_dim_toggle",
                              [(True, True), (True, False), (False, False)])
-    def test_concat_data(self, prepend, sort_dim_toggle):
+    @pytest.mark.parametrize("include", [True, False])
+    def test_concat_data(self, prepend, sort_dim_toggle, include):
         """Test `pysat.Instrument.data` concatenation.
 
         Parameters
@@ -586,6 +587,8 @@ class InstAccessTests(object):
             If True, sort variable names in pandas before concatenation.  If
             False, do not sort for pandas objects.  For xarray objects, rename
             the epoch if True.
+        include : bool
+            Use `include` kwarg instead of `prepend` for the same behaviour.
 
         """
 
@@ -611,6 +614,9 @@ class InstAccessTests(object):
                 data2 = data2.rename({self.xarray_epoch_name: 'Epoch2'})
                 self.testInst.data = self.testInst.data.rename(
                     {self.xarray_epoch_name: 'Epoch2'})
+        if include:
+            # To prepend new data, put existing data at end and vice versa
+            kwargs['include'] = 1 if prepend else 0
 
         # Concat together
         self.testInst.concat_data(data2, **kwargs)


### PR DESCRIPTION
# Description

Addresses #1137 by adding an `include` kwarg to `concat_data` that allows the current `self.data` object to be inserted into the desired concatenated data list at any location.  This allows `load` to call `concat_data` once instead of twice.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Added a unit test parametrization that uses `include` to mimic the behaviour of `prepend`.

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
