### PR TITLE
BUG: sphinx and pandas caps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     to combine common dimensions instead.
   * Implement pyproject to manage metadata
   * Remove Sphinx cap
+  * Add pandas cap
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated `Constellation.to_inst` method definition of coords, using dims
     to combine common dimensions instead.
   * Implement pyproject to manage metadata
+  * Remove Sphinx cap
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ doc = [
   "ipython",
   "m2r2",
   "numpydoc",
-  "sphinx < 7.0",
+  "sphinx",
   "sphinx_rtd_theme >= 1.2.2"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "dask",
   "netCDF4",
   "numpy >= 1.12",
-  "pandas",
+  "pandas < 2.1.1",
   "portalocker",
   "pytest",
   "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "dask",
   "netCDF4",
   "numpy >= 1.12",
-  "pandas < 2.1.1",
+  "pandas < 2.1",
   "portalocker",
   "pytest",
   "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ doc = [
   "m2r2",
   "numpydoc",
   "sphinx",
-  "sphinx_rtd_theme"
+  "sphinx_rtd_theme >= 1.2.2"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "dask",
   "netCDF4",
   "numpy >= 1.12",
-  "pandas < 2.1",
+  "pandas < 2.1.1",
   "portalocker",
   "pytest",
   "scipy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ doc = [
   "m2r2",
   "numpydoc",
   "sphinx",
-  "sphinx_rtd_theme >= 1.2.2"
+  "sphinx_rtd_theme"
 ]
 
 [project.urls]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask
 netCDF4
 numpy>=1.12
-pandas
+pandas<2.1.1
 portalocker
 pytest
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask
 netCDF4
 numpy>=1.12
-pandas<2.1.1
+pandas<2.1
 portalocker
 pytest
 scipy

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask
 netCDF4
 numpy>=1.12
-pandas<2.1
+pandas<2.1.1
 portalocker
 pytest
 scipy

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -9,4 +9,4 @@ pysatSpaceWeather
 pytest-cov
 pytest-ordering
 sphinx
-sphinx_rtd_theme
+sphinx_rtd_theme>=1.2.2

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,5 +8,5 @@ numpydoc
 pysatSpaceWeather
 pytest-cov
 pytest-ordering
-sphinx<7.0
+sphinx
 sphinx_rtd_theme


### PR DESCRIPTION
# Description

Addresses #1119 and #1142

`sphinx` 7.0+ dropped a style tag that `sphinx_rtd_theme` relied on. The latest version fixed this, so there's no need for us to maintain a cap.

pandas 2.1.1 is less memory efficient, and crashes the tests on GitHUb Actions (though not locally on my machine). This adds a cap (temporarily?) so that CI can continue.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

running sphinx-build

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
