### PR TITLE
ENH: overwrite kwarg for `registration_by_module`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,12 +15,14 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     memory usage in the `load` method.
   * Added a hidden method the Instrument class `_get_epoch_name_from_data` to
     reduce code duplication.
+  * Added the overwrite kwarg to `utils.registry.register_by_module`
 * Maintenance
   * Update link redirects in docs.
   * Improved Instrument ValueError messages.
   * Updated `Constellation.to_inst` method definition of coords, using dims
     to combine common dimensions instead.
   * Implement pyproject to manage metadata
+  * Updated docstring references to `pysat.utils.files` in other modules.
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/pysat/_files.py
+++ b/pysat/_files.py
@@ -46,8 +46,8 @@ class Files(object):
         `month`, `day`, etc. will be filled in as needed using python
         string formatting.  The default file format structure is supplied in the
         instrument `list_files` routine. See
-        `pysat.files.parse_delimited_filenames` and
-        `pysat.files.parse_fixed_width_filenames` for more information.
+        `pysat.utils.files.parse_delimited_filenames` and
+        `pysat.utils.files.parse_fixed_width_filenames` for more information.
         (default=None)
     write_to_disk : bool
         If true, the list of Instrument files will be written to disk.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -75,8 +75,8 @@ class Instrument(object):
         `month`, `day`, etc. will be filled in as needed using python
         string formatting.  The default file format structure is supplied
         in the instrument `list_files` routine. See
-        `pysat.files.parse_delimited_filenames` and
-        `pysat.files.parse_fixed_width_filenames` for more information.
+        `pysat.utils.files.parse_delimited_filenames` and
+        `pysat.utils.files.parse_fixed_width_filenames` for more information.
         The value will be None if not specified by the user at instantiation.
         (default=None)
     temporary_file_list : bool

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -208,7 +208,7 @@ def register(module_names, overwrite=False):
     return
 
 
-def register_by_module(module):
+def register_by_module(module, overwrite=False):
     """Register all sub-modules attached to input module.
 
     Enables instantiation of a third-party Instrument module using
@@ -221,6 +221,9 @@ def register_by_module(module):
     module : Python module
         Module with one or more pysat.Instrument support modules
         attached as sub-modules to the input `module`
+    overwrite : bool
+        If True, an existing registration will be updated
+        with the new module information.
 
     Raises
     ------
@@ -249,7 +252,7 @@ def register_by_module(module):
     module_names = [module.__name__ + '.' + mod for mod in module_names]
 
     # Register all of the sub-modules
-    register(module_names)
+    register(module_names, overwrite=overwrite)
 
     return
 

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -92,7 +92,7 @@ def register(module_names, overwrite=False):
         specify package name and instrument modules
     overwrite : bool
         If True, an existing registration will be updated
-        with the new module information.
+        with the new module information. (default=False)
 
     Raises
     ------

--- a/pysat/utils/registry.py
+++ b/pysat/utils/registry.py
@@ -223,7 +223,7 @@ def register_by_module(module, overwrite=False):
         attached as sub-modules to the input `module`
     overwrite : bool
         If True, an existing registration will be updated
-        with the new module information.
+        with the new module information. (default=False)
 
     Raises
     ------


### PR DESCRIPTION
# Description

Addresses #1133, #1135

Allows the `overwrite` kwarg to be passed through `registration_by_module`

Also updates some docstrings to point to the correct location of functions that moved to `pysat.utils.files`.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Via github actions

**Test Configuration**:
* Operating system: Monterrey
* Version number: Python 3.10.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
