### PR TITLE
MAINT: Update `use_header` handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated `Constellation.to_inst` method definition of coords, using dims
     to combine common dimensions instead.
   * Implement pyproject to manage metadata
-* Updated docstring references to `pysat.utils.files` in other modules.
+  * Updated docstring references to `pysat.utils.files` in other modules.
   * Remove Sphinx cap
   * Add pandas cap
   * Update usage of whitespace and if statements (E275)
@@ -42,6 +42,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Removed deprecated `convert_timestamp_to_datetime` function
   * Removed deprecated `_test_download_travis` flag
   * Removed deprecated `freq` kwarg from `download`
+  * Removed deprecated `use_header` kwarg from `load` and changed default
+    behaviour to `use_header=True`
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/docs/tutorial/tutorial_basics.rst
+++ b/docs/tutorial/tutorial_basics.rst
@@ -518,15 +518,16 @@ the instrument PI, etc.  Previous versions of pysat stored this data as custom
 attributes attached to the :py:class:`pysat.Instrument`, instead of keeping all
 metadata in the :py:class:`pysat.Meta` object.
 
-To avoid breaking existing workflows, global metadata is only loaded into
-:py:class:`pysat.MetaHeader` through completely internal pysat processes or
-after setting the :py:data:`use_header` keyword argument.
+Global metadata is loaded into the :py:class:`pysat.MetaHeader` by default, but
+to avoid breaking existing workflows, loading this metadata directly into the
+:py:class:`~pysat._instrument.Instrument` by setting the :py:data:`use_header`
+keyword argument.
 
 .. code:: python
 
-   # This will show: Metadata for 0 global attributes
-   dmsp.load(date=start, use_header=True)
-   print(dmsp.meta.header)
+   # This will raise a warning that future releases will require use of
+   # the MetaHeader class
+   dmsp.load(date=start, use_header=False)
 
 
 You can manually add global metadata the same way you would assign an attribute.

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -333,8 +333,7 @@ class Instrument(object):
             # Expand the dict to include method keywords for load.
             # TODO(#1020): Remove this if statement when `use_header` is removed
             if fkey == 'load':
-                meth = getattr(self, fkey)
-                default_kwargs.update(_get_supported_keywords(meth))
+                default_kwargs['use_header'] = True
 
             # Confirm there are no reserved keywords present
             for kwarg in kwargs.keys():

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -331,7 +331,7 @@ class Instrument(object):
             default_kwargs = _get_supported_keywords(func)
 
             # Expand the dict to include method keywords for load.
-            # TODO(#1020): Remove this if statement for the 3.2.0+ release
+            # TODO(#1020): Remove this if statement when `use_header` is removed
             if fkey == 'load':
                 meth = getattr(self, fkey)
                 default_kwargs.update(_get_supported_keywords(meth))
@@ -2920,7 +2920,7 @@ class Instrument(object):
 
     def load(self, yr=None, doy=None, end_yr=None, end_doy=None, date=None,
              end_date=None, fname=None, stop_fname=None, verifyPad=False,
-             use_header=False, **kwargs):
+             **kwargs):
         """Load the instrument data and metadata.
 
         Parameters
@@ -2957,9 +2957,6 @@ class Instrument(object):
         verifyPad : bool
             If True, padding data not removed for debugging. Padding
             parameters are provided at Instrument instantiation. (default=False)
-        use_header : bool
-            If True, moves custom Meta attributes to MetaHeader instead of
-            Instrument (default=False)
         **kwargs : dict
             Dictionary of keywords that may be options for specific instruments.
 
@@ -3017,6 +3014,22 @@ class Instrument(object):
             inst.load(fname=inst.files[0], stop_fname=inst.files[1])
 
         """
+        # If the `use_header` kwarg is included, set it here. Otherwise set
+        # it to True.
+        # TODO(#1020): removed this logic after kwarg not supported.
+        if 'use_header' in kwargs.keys():
+            use_header = kwargs['use_header']
+            warnings.warn(''.join(['Meta now contains a class for global ',
+                                   'metadata (MetaHeader). Allowing attachment',
+                                   ' of global attributes to Instrument ',
+                                   'through `use_header=False` will be ',
+                                   'Deprecated in pysat 3.3.0+. Remove ',
+                                   '`use_header` kwarg (now same as ',
+                                   '`use_header=True`) to stop this warning.']),
+                          DeprecationWarning, stacklevel=2)
+        else:
+            use_header = True
+
         # Add the load kwargs from initialization those provided on input
         for lkey in self.kwargs['load'].keys():
             # Only use the initialized kwargs if a request hasn't been
@@ -3368,19 +3381,11 @@ class Instrument(object):
 
         # Transfer any extra attributes in meta to the Instrument object.
         # Metadata types need to be initialized before preprocess is run.
-        # TODO(#1020): Change the way this kwarg is handled
+        # TODO(#1020): Remove warning and logic when kwarg is removed
         if use_header or ('use_header' in self.kwargs['load']
                           and self.kwargs['load']['use_header']):
             self.meta.transfer_attributes_to_header()
         else:
-            warnings.warn(''.join(['Meta now contains a class for global ',
-                                   'metadata (MetaHeader). Default attachment ',
-                                   'of global attributes to Instrument will ',
-                                   'be Deprecated in pysat 3.2.0+. Set ',
-                                   '`use_header=True` in this load call or ',
-                                   'on Instrument instantiation to remove this',
-                                   ' warning.']), DeprecationWarning,
-                          stacklevel=2)
             self.meta.transfer_attributes_to_instrument(self)
 
         # Transfer loaded data types to meta.

--- a/pysat/constellations/testing.py
+++ b/pysat/constellations/testing.py
@@ -13,8 +13,8 @@ Each instrument has a different sample size to test the common_index
 import pysat
 
 instruments = [pysat.Instrument('pysat', 'testing', clean_level='clean',
-                                num_samples=10, use_header=True),
+                                num_samples=10),
                pysat.Instrument('pysat', 'ndtesting', clean_level='clean',
-                                num_samples=16, use_header=True),
+                                num_samples=16),
                pysat.Instrument('pysat', 'testmodel', clean_level='clean',
-                                num_samples=18, use_header=True)]
+                                num_samples=18)]

--- a/pysat/constellations/testing_partial.py
+++ b/pysat/constellations/testing_partial.py
@@ -9,6 +9,6 @@ instruments : list
 import pysat
 
 instruments = [pysat.Instrument('pysat', 'testing', clean_level='clean',
-                                num_samples=10, use_header=True),
+                                num_samples=10),
                pysat.Instrument('pysat', 'testing', tag='no_download',
-                                clean_level='clean', use_header=True)]
+                                clean_level='clean')]

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -47,8 +47,7 @@ class InstAccessTests(object):
         """Test Instrument object fully complete by self._init_rtn()."""
 
         # Create a base instrument to compare against
-        inst_copy = pysat.Instrument(inst_module=self.testInst.inst_module,
-                                     use_header=True)
+        inst_copy = pysat.Instrument(inst_module=self.testInst.inst_module)
 
         # Get instrument module and init funtcion
         inst_mod = self.testInst.inst_module
@@ -71,7 +70,7 @@ class InstAccessTests(object):
 
         # Instantiate instrument with test module which invokes needed test
         # code in the background
-        pysat.Instrument(inst_module=inst_mod, use_header=True)
+        pysat.Instrument(inst_module=inst_mod)
 
         # Restore nominal init function
         inst_mod.init = inst_mod_init
@@ -125,8 +124,7 @@ class InstAccessTests(object):
         """
 
         # Load data by year and day of year
-        self.testInst.load(self.ref_time.year, self.ref_doy, **kwargs,
-                           use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy, **kwargs)
 
         # Test that the loaded date range is correct
         self.eval_successful_load()
@@ -152,7 +150,7 @@ class InstAccessTests(object):
             # Test doesn't check against loading by filename since that produces
             # an error if there is no file. Loading by yr, doy no different
             # than date in this case.
-            self.testInst.load(date=no_data_d, pad=pad, use_header=True)
+            self.testInst.load(date=no_data_d, pad=pad)
 
         # Confirm by checking against caplog that metadata was
         # not assigned.
@@ -182,7 +180,7 @@ class InstAccessTests(object):
         end_date = self.ref_time + dt.timedelta(days=2)
         end_doy = int(end_date.strftime("%j"))
         self.testInst.load(self.ref_time.year, self.ref_doy, end_date.year,
-                           end_doy, use_header=True)
+                           end_doy)
 
         # Test that the loaded date range is correct
         self.eval_successful_load(end_date=end_date)
@@ -195,8 +193,7 @@ class InstAccessTests(object):
         testing.eval_bad_input(self.testInst.load, TypeError,
                                "load() got an unexpected keyword",
                                input_kwargs={'date': self.ref_time,
-                                             'unsupported_keyword': True,
-                                             'use_header': True})
+                                             'unsupported_keyword': True})
         return
 
     def test_basic_instrument_load_yr_no_doy(self):
@@ -205,7 +202,7 @@ class InstAccessTests(object):
         # Check that the correct error is raised
         estr = 'Unknown or incomplete input combination.'
         testing.eval_bad_input(self.testInst.load, TypeError, estr,
-                               [self.ref_time.year], {'use_header': True})
+                               [self.ref_time.year])
         return
 
     @pytest.mark.parametrize('doy', [0, 367, 1000, -1, -10000])
@@ -221,7 +218,7 @@ class InstAccessTests(object):
 
         estr = 'Day of year (doy) is only valid between and '
         testing.eval_bad_input(self.testInst.load, ValueError, estr,
-                               [self.ref_time.year, doy], {'use_header': True})
+                               [self.ref_time.year, doy])
         return
 
     @pytest.mark.parametrize('end_doy', [0, 367, 1000, -1, -10000])
@@ -239,7 +236,7 @@ class InstAccessTests(object):
         testing.eval_bad_input(self.testInst.load, ValueError, estr,
                                [self.ref_time.year, 1],
                                {'end_yr': self.ref_time.year,
-                                'end_doy': end_doy, 'use_header': True})
+                                'end_doy': end_doy})
         return
 
     def test_basic_instrument_load_yr_no_end_doy(self):
@@ -248,7 +245,7 @@ class InstAccessTests(object):
         estr = 'Both end_yr and end_doy must be set'
         testing.eval_bad_input(self.testInst.load, ValueError, estr,
                                [self.ref_time.year, self.ref_doy,
-                                self.ref_time.year], {'use_header': True})
+                                self.ref_time.year])
         return
 
     @pytest.mark.parametrize("kwargs", [{'yr': 2009, 'doy': 1,
@@ -277,7 +274,6 @@ class InstAccessTests(object):
 
         """
 
-        kwargs['use_header'] = True
         estr = 'An inconsistent set of inputs have been'
         testing.eval_bad_input(self.testInst.load, ValueError, estr,
                                input_kwargs=kwargs)
@@ -286,7 +282,7 @@ class InstAccessTests(object):
     def test_basic_instrument_load_no_input(self):
         """Test that `.load()` loads all data."""
 
-        self.testInst.load(use_header=True)
+        self.testInst.load()
         assert (self.testInst.index[0] == self.testInst.files.start_date)
         assert (self.testInst.index[-1] >= self.testInst.files.stop_date)
         assert (self.testInst.index[-1] <= self.testInst.files.stop_date
@@ -316,7 +312,6 @@ class InstAccessTests(object):
         else:
             load_kwargs = dict()
 
-        load_kwargs['use_header'] = True
         testing.eval_bad_input(self.testInst.load, ValueError, verr,
                                input_kwargs=load_kwargs)
         return
@@ -324,7 +319,7 @@ class InstAccessTests(object):
     def test_basic_instrument_load_by_date(self):
         """Test loading by date."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         self.eval_successful_load()
         return
 
@@ -332,8 +327,7 @@ class InstAccessTests(object):
         """Test date range loading, `date` and `end_date`."""
 
         end_date = self.ref_time + dt.timedelta(days=2)
-        self.testInst.load(date=self.ref_time, end_date=end_date,
-                           use_header=True)
+        self.testInst.load(date=self.ref_time, end_date=end_date)
         self.eval_successful_load(end_date=end_date)
         return
 
@@ -341,15 +335,14 @@ class InstAccessTests(object):
         """Ensure `.load(date=date)` only uses date portion of datetime."""
 
         # Put in a date that has more than year, month, day
-        self.testInst.load(date=(self.ref_time + dt.timedelta(minutes=71)),
-                           use_header=True)
+        self.testInst.load(date=(self.ref_time + dt.timedelta(minutes=71)))
         self.eval_successful_load()
         return
 
     def test_basic_instrument_load_data(self):
         """Test that correct day loads (checking down to the sec)."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.eval_successful_load()
         return
 
@@ -361,7 +354,7 @@ class InstAccessTests(object):
 
         self.ref_time = dt.datetime(2008, 12, 31)
         self.ref_doy = 366
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.eval_successful_load()
         return
 
@@ -398,7 +391,7 @@ class InstAccessTests(object):
 
         """
 
-        self.testInst.load(fname=self.testInst.files[1], use_header=True)
+        self.testInst.load(fname=self.testInst.files[1])
 
         # Set new bounds that do not include this date.
         self.testInst.bounds = (self.testInst.files[0], self.testInst.files[2],
@@ -418,7 +411,7 @@ class InstAccessTests(object):
 
         """
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
 
         # Set new bounds that do not include this date.
         self.testInst.bounds = (self.ref_time + dt.timedelta(days=1),
@@ -435,7 +428,7 @@ class InstAccessTests(object):
         # If mangle_file_date is true, index will not match exactly.
         # Find the closest point instead.
         ind = np.argmin(abs(self.testInst.files.files.index - self.ref_time))
-        self.testInst.load(fname=self.testInst.files[ind], use_header=True)
+        self.testInst.load(fname=self.testInst.files[ind])
         self.eval_successful_load()
         return
 
@@ -455,7 +448,7 @@ class InstAccessTests(object):
         # If mangle_file_date is true, index will not match exactly.
         # Find the closest point.
         ind = np.argmin(abs(self.testInst.files.files.index - self.ref_time))
-        self.testInst.load(fname=self.testInst.files[ind], use_header=True)
+        self.testInst.load(fname=self.testInst.files[ind])
         getattr(self.testInst, operator)()
 
         # Modify ref time since iterator changes load date.
@@ -468,8 +461,7 @@ class InstAccessTests(object):
     def test_filename_load(self):
         """Test if file is loadable by filename with no path."""
 
-        self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'),
-                           use_header=True)
+        self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'))
         self.eval_successful_load()
         return
 
@@ -481,7 +473,7 @@ class InstAccessTests(object):
         stop_fname = self.ref_time + foff
         stop_fname = stop_fname.strftime('%Y-%m-%d.nofile')
         self.testInst.load(fname=self.ref_time.strftime('%Y-%m-%d.nofile'),
-                           stop_fname=stop_fname, use_header=True)
+                           stop_fname=stop_fname)
         assert self.testInst.index[0] == self.ref_time
         assert self.testInst.index[-1] >= self.ref_time + foff
         assert self.testInst.index[-1] <= self.ref_time + (2 * foff)
@@ -499,8 +491,7 @@ class InstAccessTests(object):
 
         testing.eval_bad_input(self.testInst.load, ValueError, estr,
                                input_kwargs={'fname': stop_fname,
-                                             'stop_fname': check_fname,
-                                             'use_header': True})
+                                             'stop_fname': check_fname})
         return
 
     def test_eq_no_data(self):
@@ -513,7 +504,7 @@ class InstAccessTests(object):
     def test_eq_both_with_data(self):
         """Test equality when the same object with loaded data."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         inst_copy = self.testInst.copy()
         assert inst_copy == self.testInst
         return
@@ -521,7 +512,7 @@ class InstAccessTests(object):
     def test_eq_one_with_data(self):
         """Test equality when the same objects but only one with loaded data."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         inst_copy = self.testInst.copy()
         inst_copy.data = self.testInst._null_data
         assert inst_copy != self.testInst
@@ -530,7 +521,7 @@ class InstAccessTests(object):
     def test_eq_different_data_type(self):
         """Test equality different data type."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         inst_copy = self.testInst.copy()
 
         # Can only change data types if Instrument empty
@@ -596,12 +587,12 @@ class InstAccessTests(object):
         ref_time2 = self.ref_time + pds.tseries.frequencies.to_offset(
             self.testInst.files.files.index.freqstr)
         doy2 = int(ref_time2.strftime('%j'))
-        self.testInst.load(ref_time2.year, doy2, use_header=True)
+        self.testInst.load(ref_time2.year, doy2)
         data2 = self.testInst.data
         len2 = len(self.testInst.index)
 
         # Load a different data set into the instrument
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         len1 = len(self.testInst.index)
 
         # Set the keyword arguments
@@ -655,7 +646,7 @@ class InstAccessTests(object):
     def test_empty_flag_data_not_empty(self):
         """Test the status of the empty flag for loaded data."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         assert not self.testInst.empty
         return
 
@@ -666,7 +657,7 @@ class InstAccessTests(object):
         assert isinstance(self.testInst.index, pds.Index)
 
         # Test an index is present with data loaded in an Instrument
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         assert isinstance(self.testInst.index, pds.Index)
         return
 
@@ -674,7 +665,7 @@ class InstAccessTests(object):
         """Test that the index is returned in the proper format."""
 
         # Load data
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
 
         # Ensure we get the index back
         if self.testInst.pandas_format:
@@ -697,7 +688,7 @@ class InstAccessTests(object):
 
         """
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all((self.testInst[labels]
                        == self.testInst.data[labels]).values)
         return
@@ -716,7 +707,7 @@ class InstAccessTests(object):
 
         """
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[index, 'mlt']
                       == self.testInst.data['mlt'][index])
         return
@@ -724,7 +715,7 @@ class InstAccessTests(object):
     def test_data_access_by_row_slicing(self):
         """Check that each variable is downsampled."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         result = self.testInst[0:10]
         for variable, array in result.items():
             assert len(array) == len(self.testInst.data[variable].values[0:10])
@@ -737,7 +728,7 @@ class InstAccessTests(object):
         if not self.testInst.pandas_format:
             pytest.skip("name slicing not implemented for xarray")
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         result = self.testInst[0:10, 'uts':'mlt']
         for variable, array in result.items():
             assert len(array) == len(self.testInst.data[variable].values[0:10])
@@ -747,7 +738,7 @@ class InstAccessTests(object):
     def test_data_access_by_datetime_and_name(self):
         """Check that datetime can be used to access data."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.out = dt.datetime(2009, 1, 1, 0, 0, 0)
         assert np.all(self.testInst[self.out, 'uts']
                       == self.testInst.data['uts'].values[0])
@@ -756,7 +747,7 @@ class InstAccessTests(object):
     def test_data_access_by_datetime_slicing_and_name(self):
         """Check that a slice of datetimes can be used to access data."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         time_step = (self.testInst.index[1]
                      - self.testInst.index[0]).value / 1.E9
         offset = dt.timedelta(seconds=(10 * time_step))
@@ -769,7 +760,7 @@ class InstAccessTests(object):
     def test_setting_data_by_name(self):
         """Test setting data by name."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         assert np.all(self.testInst['doubleMLT'] == 2. * self.testInst['mlt'])
         return
@@ -777,7 +768,7 @@ class InstAccessTests(object):
     def test_setting_series_data_by_name(self):
         """Test setting series data by name."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * pds.Series(
             self.testInst['mlt'].values, index=self.testInst.index)
         assert np.all(self.testInst['doubleMLT'] == 2. * self.testInst['mlt'])
@@ -789,7 +780,7 @@ class InstAccessTests(object):
     def test_setting_pandas_dataframe_by_names(self):
         """Test setting pandas dataframe by name."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst[['doubleMLT', 'tripleMLT']] = pds.DataFrame(
             {'doubleMLT': 2. * self.testInst['mlt'].values,
              'tripleMLT': 3. * self.testInst['mlt'].values},
@@ -801,7 +792,7 @@ class InstAccessTests(object):
     def test_setting_data_by_name_single_element(self):
         """Test setting data by name for a single element."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2.
         assert np.all(self.testInst['doubleMLT'] == 2.)
         assert len(self.testInst['doubleMLT']) == len(self.testInst.index)
@@ -813,7 +804,7 @@ class InstAccessTests(object):
     def test_setting_data_by_name_with_meta(self):
         """Test setting data by name with meta."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = {'data': 2. * self.testInst['mlt'],
                                       'units': 'hours',
                                       'long_name': 'double trouble'}
@@ -825,7 +816,7 @@ class InstAccessTests(object):
     def test_setting_partial_data(self):
         """Test setting partial data by index."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.out = self.testInst
         if self.testInst.pandas_format:
             self.testInst[0:3] = 0
@@ -860,7 +851,7 @@ class InstAccessTests(object):
 
         """
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst[changed, 'doubleMLT'] = 0
         assert (self.testInst[fixed, 'doubleMLT']
@@ -871,7 +862,7 @@ class InstAccessTests(object):
     def test_modifying_data_inplace(self):
         """Test modification of data inplace."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = 2. * self.testInst['mlt']
         self.testInst['doubleMLT'] += 100
         assert (self.testInst['doubleMLT']
@@ -890,7 +881,7 @@ class InstAccessTests(object):
 
         """
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         inst_subset = self.testInst[index]
         if self.testInst.pandas_format:
             assert len(inst_subset) == len(index)
@@ -913,7 +904,7 @@ class InstAccessTests(object):
         """
 
         # Check for error for unknown variable name
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
 
         # Capture the ValueError and message
         testing.eval_bad_input(self.testInst.rename, ValueError,
@@ -944,7 +935,7 @@ class InstAccessTests(object):
             values = {var: mapper(var) for var in self.testInst.variables}
 
         # Test single variable
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst.rename(mapper, lowercase_data_labels=lowercase)
 
         for key in values:

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -68,7 +68,7 @@ def initialize_test_inst_and_date(inst_dict):
                                  tag=inst_dict['tag'],
                                  inst_id=inst_dict['inst_id'],
                                  temporary_file_list=True, update_files=True,
-                                 use_header=True, **kwargs)
+                                 **kwargs)
     test_dates = inst_dict['inst_module']._test_dates
     date = test_dates[inst_dict['inst_id']][inst_dict['tag']]
     return test_inst, date
@@ -94,7 +94,7 @@ def load_and_set_strict_time_flag(test_inst, date, raise_error=False,
     """
 
     try:
-        test_inst.load(date=date, use_header=True)
+        test_inst.load(date=date)
     except Exception as err:
         # Catch all potential input errors, and only ensure that the one caused
         # by the strict time flag is prevented from occurring on future load
@@ -111,7 +111,7 @@ def load_and_set_strict_time_flag(test_inst, date, raise_error=False,
 
             # Evaluate the warning
             with warnings.catch_warnings(record=True) as war:
-                test_inst.load(date=date, use_header=True)
+                test_inst.load(date=date)
 
             assert len(war) >= 1
             categories = [war[j].category for j in range(len(war))]
@@ -279,7 +279,7 @@ class InstLibTests(object):
         for inst_id in module.inst_ids.keys():
             for tag in module.inst_ids[inst_id]:
                 inst = pysat.Instrument(inst_module=module, tag=tag,
-                                        inst_id=inst_id, use_header=True)
+                                        inst_id=inst_id)
 
                 # Test to see that the class parameters were passed in
                 testing.assert_isinstance(inst, pysat.Instrument)
@@ -462,7 +462,7 @@ class InstLibTests(object):
                             with caplog.at_level(
                                     getattr(logging, clean_method_level),
                                     logger='pysat'):
-                                test_inst.load(date=date, use_header=True)
+                                test_inst.load(date=date)
 
                             # Test the returned message
                             out_msg = caplog.text
@@ -472,7 +472,7 @@ class InstLibTests(object):
                         elif clean_method == 'warning':
                             # A warning message is expected
                             with warnings.catch_warnings(record=True) as war:
-                                test_inst.load(date=date, use_header=True)
+                                test_inst.load(date=date)
 
                             # Test the warning output
                             testing.eval_warnings(war, [clean_method_msg],
@@ -482,8 +482,7 @@ class InstLibTests(object):
                             # and the error message
                             testing.eval_bad_input(
                                 test_inst.load, clean_method_level,
-                                clean_method_msg,
-                                input_kwargs={'date': date, 'use_header': True})
+                                clean_method_msg, input_kwargs={'date': date})
                         else:
                             raise AttributeError(
                                 'unknown type of warning: {:}'.format(

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -378,7 +378,7 @@ class InstPropertyTests(object):
 
         greeting = '... listen!'
         self.testInst.hei = greeting
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         assert self.testInst.hei == greeting
         return
 
@@ -416,15 +416,11 @@ class InstPropertyTests(object):
         """Test string output with Orbit data."""
 
         reload(pysat.instruments.pysat_testing)
-        orbit_info = {'index': 'mlt',
-                      'kind': 'local time',
+        orbit_info = {'index': 'mlt', 'kind': 'local time',
                       'period': np.timedelta64(97, 'm')}
         testInst = pysat.Instrument(platform='pysat', name='testing',
-                                    num_samples=10,
-                                    clean_level='clean',
-                                    update_files=True,
-                                    orbit_info=orbit_info,
-                                    use_header=True)
+                                    num_samples=10, clean_level='clean',
+                                    update_files=True, orbit_info=orbit_info)
 
         self.out = testInst.__str__()
 
@@ -434,7 +430,7 @@ class InstPropertyTests(object):
         assert self.out.find('Loaded Orbit Number: 0') > 0
 
         # Activate orbits, check that message has changed
-        testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        testInst.load(self.ref_time.year, self.ref_doy)
         testInst.orbits.next()
         self.out = testInst.__str__()
         assert self.out.find('Loaded Orbit Number: 1') > 0
@@ -462,7 +458,7 @@ class InstPropertyTests(object):
     def test_str_w_load_lots_data(self):
         """Test string output with loaded data with many variables."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.out = self.testInst.__str__()
         assert self.out.find('Number of variables:') > 0
         assert self.out.find('...') > 0
@@ -472,7 +468,7 @@ class InstPropertyTests(object):
         """Test string output with loaded data with few (4) variables."""
 
         # Load the test data
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
 
         # Ensure the desired data variable is present and delete all others
         # 4-6 variables are needed to test all lines; choose the lesser limit
@@ -548,7 +544,7 @@ class InstPropertyTests(object):
 
         with caplog.at_level(logging.INFO, logger='pysat'):
             # Trigger load functions
-            self.testInst.load(date=self.ref_time, use_header=True)
+            self.testInst.load(date=self.ref_time)
 
             # Refresh files to trigger other functions
             self.testInst.files.refresh()
@@ -607,7 +603,7 @@ class InstPropertyTests(object):
 
         with caplog.at_level(logging.INFO, logger='pysat'):
             # Trigger load functions
-            self.testInst.load(date=self.ref_time, use_header=True)
+            self.testInst.load(date=self.ref_time)
 
             # Refresh files to trigger other functions
             self.testInst.files.refresh()

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -43,8 +43,7 @@ class TestConstellationInitReg(TestWithRegistration):
 
         # Initialize the Constellation using the desired kwargs
         const = pysat.Constellation(
-            **{ikey: ivals[i] for i, ikey in enumerate(ikeys)},
-            use_header=True)
+            **{ikey: ivals[i] for i, ikey in enumerate(ikeys)})
 
         # Test that the appropriate number of Instruments were loaded. Each
         # fake Instrument has 5 tags and 1 inst_id.
@@ -72,7 +71,7 @@ class TestConstellationInitReg(TestWithRegistration):
         # Load the Constellation and capture log output
         with caplog.at_level(logging.WARNING, logger='pysat'):
             const = pysat.Constellation(platforms=['Executor', 'platname1'],
-                                        tags=[''], use_header=True)
+                                        tags=[''])
 
         # Test the partial Constellation initialization
         assert len(const.instruments) == 2
@@ -164,7 +163,7 @@ class TestConstellationInit(object):
         """Test Constellation iteration through instruments attribute."""
 
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
+        self.const = pysat.Constellation(**self.in_kwargs)
         tst_get_inst = self.const[:]
         pysat.utils.testing.assert_lists_equal(self.instruments, tst_get_inst)
         return
@@ -173,7 +172,7 @@ class TestConstellationInit(object):
         """Test Constellation string output with instruments loaded."""
 
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
+        self.const = pysat.Constellation(**self.in_kwargs)
         out_str = self.const.__repr__()
 
         assert out_str.find("Constellation(instruments") >= 0
@@ -183,7 +182,7 @@ class TestConstellationInit(object):
         """Test Constellation string output with instruments loaded."""
 
         self.in_kwargs['const_module'] = None
-        self.const = pysat.Constellation(**self.in_kwargs, use_header=True)
+        self.const = pysat.Constellation(**self.in_kwargs)
         out_str = self.const.__str__()
 
         assert out_str.find("pysat Constellation ") >= 0
@@ -216,7 +215,7 @@ class TestConstellationInit(object):
 
         self.in_kwargs["common_index"] = common_index
         self.const = pysat.Constellation(**self.in_kwargs)
-        self.const.load(date=self.ref_time, use_header=True)
+        self.const.load(date=self.ref_time)
         out_str = self.const.__str__()
 
         assert out_str.find("pysat Constellation ") >= 0
@@ -239,7 +238,7 @@ class TestConstellationInit(object):
 
         # Add the custom function
         self.const.custom_attach(double_mlt, at_pos='end')
-        self.const.load(date=self.ref_time, use_header=True)
+        self.const.load(date=self.ref_time)
 
         # Test the added value
         for inst in self.const:
@@ -255,7 +254,7 @@ class TestConstellationFunc(object):
         """Set up the unit test environment for each method."""
 
         self.inst = list(constellations.testing.instruments)
-        self.const = pysat.Constellation(instruments=self.inst, use_header=True)
+        self.const = pysat.Constellation(instruments=self.inst)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.attrs = ["platforms", "names", "tags", "inst_ids", "instruments",
                       "bounds", "empty", "empty_partial", "index_res",
@@ -342,7 +341,7 @@ class TestConstellationFunc(object):
         """Test the status of the empty flag for partially loaded data."""
 
         self.const = pysat.Constellation(
-            const_module=constellations.testing_partial, use_header=True)
+            const_module=constellations.testing_partial)
         self.const.load(date=self.ref_time)
         assert self.const.empty_partial
         assert not self.const.empty
@@ -352,7 +351,7 @@ class TestConstellationFunc(object):
         """Test the alt status of the empty flag for partially loaded data."""
 
         self.const = pysat.Constellation(
-            const_module=constellations.testing_partial, use_header=True)
+            const_module=constellations.testing_partial)
         self.const.load(date=self.ref_time)
         assert not self.const._empty(all_inst=False)
         return
@@ -361,7 +360,7 @@ class TestConstellationFunc(object):
         """Test the status of the empty flag for loaded data."""
 
         # Load data and test the status flag
-        self.const.load(date=self.ref_time, use_header=True)
+        self.const.load(date=self.ref_time)
         assert not self.const.empty
         return
 
@@ -372,7 +371,7 @@ class TestConstellationFunc(object):
 
         # Test the attribute with loaded data
         self.const = pysat.Constellation(instruments=self.inst, **ikwarg)
-        self.const.load(date=self.ref_time, use_header=True)
+        self.const.load(date=self.ref_time)
         assert isinstance(self.const.index, pds.Index)
         assert self.const.index[0] == self.ref_time
 
@@ -394,7 +393,7 @@ class TestConstellationFunc(object):
         """Test the date property when no data is loaded."""
 
         # Test the attribute with loaded data
-        self.const.load(date=self.ref_time, use_header=True)
+        self.const.load(date=self.ref_time)
 
         assert self.const.date == self.ref_time
         return
@@ -403,7 +402,7 @@ class TestConstellationFunc(object):
         """Test the variables property when no data is loaded."""
 
         # Test the attribute with loaded data
-        self.const.load(date=self.ref_time, use_header=True)
+        self.const.load(date=self.ref_time)
 
         assert len(self.const.variables) > 0
         assert 'uts_pysat_testing' in self.const.variables
@@ -501,10 +500,9 @@ class TestConstellationFunc(object):
         """
         # Redefine the Instrument and constellation
         self.inst = pysat.Instrument(
-            inst_module=pysat.instruments.pysat_testing, use_header=True,
-            pad=pds.DateOffset(hours=1), num_samples=10)
-        self.const = pysat.Constellation(instruments=[self.inst],
-                                         use_header=True)
+            inst_module=pysat.instruments.pysat_testing, num_samples=10,
+            pad=pds.DateOffset(hours=1))
+        self.const = pysat.Constellation(instruments=[self.inst])
 
         # Load the data
         self.inst.load(date=self.ref_time)
@@ -539,11 +537,11 @@ class TestConstellationFunc(object):
         pad = pds.DateOffset(hours=1)
         self.inst = [
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             use_header=True, pad=pad, num_samples=10),
+                             pad=pad, num_samples=10),
             pysat.Instrument(inst_module=pysat.instruments.pysat_testing,
-                             use_header=True, pad=2 * pad,
-                             clean_level=clean_level, num_samples=10)]
-        self.const = pysat.Constellation(instruments=self.inst, use_header=True)
+                             pad=2 * pad, clean_level=clean_level,
+                             num_samples=10)]
+        self.const = pysat.Constellation(instruments=self.inst)
 
         # Load the Instrument and Constellation data
         self.inst[-1].load(date=self.ref_time)

--- a/pysat/tests/test_files.py
+++ b/pysat/tests/test_files.py
@@ -148,8 +148,7 @@ class TestBasics(object):
 
         self.testInst = pysat.Instrument(
             inst_module=pysat.instruments.pysat_testing, clean_level='clean',
-            temporary_file_list=self.temporary_file_list, update_files=True,
-            use_header=True)
+            temporary_file_list=self.temporary_file_list, update_files=True)
 
         # Create instrument directories in tempdir
         create_dir(self.testInst)
@@ -215,7 +214,7 @@ class TestBasics(object):
     def test_equality_with_copy_with_data(self):
         """Test that copy is the same as original, loaded `inst.data`."""
         # Load data
-        self.testInst.load(date=self.start, use_header=True)
+        self.testInst.load(date=self.start)
 
         # Make copy
         self.out = self.testInst.files.copy()

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -49,10 +49,8 @@ class TestBasics(InstAccessTests, InstIntegrationTests, InstIterationTests,
 
         reload(pysat.instruments.pysat_testing)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=10,
-                                         clean_level='clean',
+                                         num_samples=10, clean_level='clean',
                                          update_files=True,
-                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -90,10 +88,8 @@ class TestInstCadence(TestBasics):
                                     self.ref_time + pds.DateOffset(years=2)
                                     - pds.DateOffset(days=1), freq=self.freq)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=10,
-                                         clean_level='clean',
+                                         num_samples=10, clean_level='clean',
                                          update_files=True,
-                                         use_header=True,
                                          file_date_range=date_range,
                                          **self.testing_kwargs)
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -122,10 +118,8 @@ class TestInstMonthlyCadence(TestInstCadence):
                                     + pds.DateOffset(years=2, days=-1),
                                     freq=self.freq)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=10,
-                                         clean_level='clean',
+                                         num_samples=10, clean_level='clean',
                                          update_files=True,
-                                         use_header=True,
                                          file_date_range=date_range,
                                          **self.testing_kwargs)
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -155,10 +149,8 @@ class TestInstYearlyCadence(TestInstCadence):
                                     + pds.DateOffset(years=5, days=-1),
                                     freq=self.freq)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=10,
-                                         clean_level='clean',
+                                         num_samples=10, clean_level='clean',
                                          update_files=True,
-                                         use_header=True,
                                          file_date_range=date_range,
                                          **self.testing_kwargs)
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -180,11 +172,8 @@ class TestBasicsInstModule(TestBasics):
 
         reload(pysat.instruments.pysat_testing)
         imod = pysat.instruments.pysat_testing
-        self.testInst = pysat.Instrument(inst_module=imod,
-                                         num_samples=10,
-                                         clean_level='clean',
-                                         update_files=True,
-                                         use_header=True,
+        self.testInst = pysat.Instrument(inst_module=imod, num_samples=10,
+                                         clean_level='clean', update_files=True,
                                          **self.testing_kwargs)
         self.ref_time = imod._test_dates['']['']
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -211,12 +200,9 @@ class TestBasicsNDXarray(TestBasics):
         """Set up the unit test environment for each method."""
 
         reload(pysat.instruments.pysat_ndtesting)
-        self.testInst = pysat.Instrument(platform='pysat',
-                                         name='ndtesting',
-                                         num_samples=10,
-                                         clean_level='clean',
+        self.testInst = pysat.Instrument(platform='pysat', name='ndtesting',
+                                         num_samples=10, clean_level='clean',
                                          update_files=True,
-                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = pysat.instruments.pysat_ndtesting._test_dates['']['']
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -232,7 +218,7 @@ class TestBasicsNDXarray(TestBasics):
     def test_setting_data_as_tuple(self):
         """Test setting data as a tuple."""
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleMLT'] = ('time', 2. * self.testInst['mlt'].values)
         assert np.all(self.testInst['doubleMLT'] == 2. * self.testInst['mlt'])
         return
@@ -267,7 +253,7 @@ class TestBasicsNDXarray(TestBasics):
 
         """
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[index, index, 'profiles']
                       == self.testInst.data['profiles'][index, index])
         return
@@ -275,7 +261,7 @@ class TestBasicsNDXarray(TestBasics):
     def test_data_access_by_2d_tuple_indices_and_name(self):
         """Check that variables and be accessed by multi-dim tuple index."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         index = ([0, 1, 2, 3], [0, 1, 2, 3])
         assert np.all(self.testInst[index, 'profiles']
                       == self.testInst.data['profiles'][index[0], index[1]])
@@ -284,7 +270,7 @@ class TestBasicsNDXarray(TestBasics):
     def test_data_access_bad_dimension_tuple(self):
         """Test raises ValueError for mismatched tuple index and data dims."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         index = ([0, 1, 2, 3], [0, 1, 2, 3], [0, 1, 2, 3])
 
         with pytest.raises(ValueError) as verr:
@@ -297,7 +283,7 @@ class TestBasicsNDXarray(TestBasics):
     def test_data_access_bad_dimension_for_multidim(self):
         """Test raises ValueError for mismatched index and data dimensions."""
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         index = [0, 1, 2, 3]
 
         with pytest.raises(ValueError) as verr:
@@ -324,7 +310,7 @@ class TestBasicsNDXarray(TestBasics):
 
         """
 
-        self.testInst.load(self.ref_time.year, self.ref_doy, use_header=True)
+        self.testInst.load(self.ref_time.year, self.ref_doy)
         self.testInst['doubleProfile'] = 2. * self.testInst['profiles']
         self.testInst[changed, changed, 'doubleProfile'] = 0
         assert np.all(np.all(self.testInst[fixed, fixed, 'doubleProfile']
@@ -373,7 +359,7 @@ class TestBasicsNDXarray(TestBasics):
 
         warnings.simplefilter("always")
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
 
         with warnings.catch_warnings(record=True) as self.war:
             self.testInst["new_val"] = val
@@ -391,7 +377,7 @@ class TestBasicsNDXarray(TestBasics):
 
         """
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         self.testInst.data = self.testInst.data.assign_coords(
             {'preset_val': np.array([1.0, 2.0])})
 
@@ -413,7 +399,7 @@ class TestBasicsNDXarray(TestBasics):
 
         """
 
-        self.testInst.load(date=self.ref_time, use_header=True)
+        self.testInst.load(date=self.ref_time)
         self.testInst.data = self.testInst.data.assign_coords(
             {'preset_val': 1.0})
 
@@ -433,12 +419,10 @@ class TestBasicsShiftedFileDates(TestBasics):
 
         reload(pysat.instruments.pysat_testing)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=10,
-                                         clean_level='clean',
+                                         num_samples=10, clean_level='clean',
                                          update_files=True,
                                          mangle_file_dates=True,
                                          strict_time_flag=True,
-                                         use_header=True,
                                          **self.testing_kwargs)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
         self.ref_doy = int(self.ref_time.strftime('%j'))
@@ -517,11 +501,11 @@ class TestInstGeneral(object):
 
         obj1 = pysat.Instrument(platform='pysat', name='testing',
                                 num_samples=10, clean_level='clean',
-                                update_files=True, use_header=True)
+                                update_files=True)
 
         obj2 = pysat.Instrument(platform='pysat', name='ndtesting',
                                 num_samples=10, clean_level='clean',
-                                update_files=True, use_header=True)
+                                update_files=True)
         assert not (obj1 == obj2)
         return
 
@@ -567,7 +551,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
+            tinst = pysat.Instrument(**self.in_kwargs)
 
         self.warn_msgs = np.array(["`labels` is deprecated, use `meta_kwargs`"])
 
@@ -597,7 +581,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
+            tinst = pysat.Instrument(**self.in_kwargs)
             labels = tinst.meta_labels
 
         self.warn_msgs = np.array(["Deprecated attribute, returns `meta_kwarg"])
@@ -622,7 +606,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
+            tinst = pysat.Instrument(**self.in_kwargs)
             tinst.generic_meta_translator(tinst.meta)
 
         self.warn_msgs = np.array(["".join(["This function has been deprecated",
@@ -637,8 +621,8 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
-            tinst.load(date=self.ref_time, use_header=True)
+            tinst = pysat.Instrument(**self.in_kwargs)
+            tinst.load(date=self.ref_time)
             mdata_dict = tinst.meta._data.to_dict()
             tinst._filter_netcdf4_metadata(mdata_dict,
                                            coltype='str')
@@ -659,7 +643,7 @@ class TestDeprecation(object):
 
         # Catch the warnings
         with warnings.catch_warnings(record=True) as self.war:
-            tinst = pysat.Instrument(use_header=True, **self.in_kwargs)
+            tinst = pysat.Instrument(**self.in_kwargs)
             try:
                 tinst.to_netcdf4()
             except ValueError:
@@ -686,7 +670,7 @@ class TestDeprecation(object):
         """
 
         with warnings.catch_warnings(record=True) as self.war:
-            pysat.Instrument('pysat', 'testing', use_header=True, **kwargs)
+            pysat.Instrument('pysat', 'testing', **kwargs)
 
         self.warn_msgs = np.array(["".join(["The usage of None in `tag` and ",
                                             "`inst_id` has been deprecated ",
@@ -697,19 +681,20 @@ class TestDeprecation(object):
         self.eval_warnings()
         return
 
+    # TODO(#1020): Remove test when keyword `use_header` is removed.
     def test_load_use_header(self):
         """Test that user is informed of MetaHeader on load."""
 
         # Determine the expected warnings
         self.warn_msgs = np.array(["".join(['Meta now contains a class for ',
                                             'global metadata (MetaHeader). ',
-                                            'Default attachment of global ',
-                                            'attributes to Instrument will be',
-                                            ' Deprecated in pysat 3.2.0+. Set ',
-                                            '`use_header=True` in this load ',
-                                            'call or on Instrument ',
-                                            'instantiation to remove this',
-                                            ' warning.'])])
+                                            'Allowing attachment of global ',
+                                            'attributes to Instrument through',
+                                            ' `use_header=False` will be ',
+                                            'Deprecated in pysat 3.3.0+. ',
+                                            'Remove `use_header` kwarg (now ',
+                                            'same as `use_header=True`) to ',
+                                            'stop this warning.'])])
 
         # Capture the warnings
         with warnings.catch_warnings(record=True) as self.war:

--- a/pysat/tests/test_instrument_custom.py
+++ b/pysat/tests/test_instrument_custom.py
@@ -43,7 +43,7 @@ class TestLogging(object):
 
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
                                          clean_level='clean',
-                                         update_files=False, use_header=True)
+                                         update_files=False)
         self.out = ''
         return
 
@@ -73,9 +73,7 @@ class TestBasics(object):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=10,
-                                         clean_level='clean',
-                                         update_files=True,
-                                         use_header=True)
+                                         clean_level='clean', update_files=True)
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.load(date=self.load_date)
         self.custom_args = [2]
@@ -236,8 +234,7 @@ class TestBasicsXarray(TestBasics):
         """Set up the unit test environment for each method."""
 
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
-                                         num_samples=10, clean_level='clean',
-                                         use_header=True)
+                                         num_samples=10, clean_level='clean')
         self.load_date = pysat.instruments.pysat_ndtesting._test_dates
         self.load_date = self.load_date['']['']
         self.testInst.load(date=self.load_date)
@@ -259,8 +256,7 @@ class TestConstellationBasics(object):
 
         self.testConst = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
-                             clean_level='clean', update_files=True,
-                             use_header=True)
+                             clean_level='clean', update_files=True)
             for i in range(5)])
         self.load_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.testConst.load(date=self.load_date)
@@ -371,8 +367,7 @@ class TestConstellationBasics(object):
                   {'function': mult_data, 'args': self.custom_args}]
         testConst2 = pysat.Constellation(instruments=[
             pysat.Instrument('pysat', 'testing', num_samples=10,
-                             clean_level='clean', custom=custom,
-                             use_header=True)
+                             clean_level='clean', custom=custom)
             for i in range(5)])
 
         # Ensure all instruments within both constellations have the same
@@ -400,7 +395,7 @@ class TestConstellationBasics(object):
                    'apply_inst': False}]
         testConst2 = pysat.Constellation(
             instruments=[pysat.Instrument('pysat', 'testing', num_samples=10,
-                                          clean_level='clean', use_header=True)
+                                          clean_level='clean')
                          for i in range(5)], custom=custom)
 
         # Ensure both constellations have the same custom_* attributes

--- a/pysat/tests/test_instrument_index.py
+++ b/pysat/tests/test_instrument_index.py
@@ -47,13 +47,9 @@ class TestIndex(object):
 
         """
 
-        test_inst = pysat.Instrument(platform='pysat',
-                                     name=self.name,
-                                     num_samples=10,
-                                     clean_level='clean',
-                                     update_files=True,
-                                     strict_time_flag=True,
-                                     use_header=True,
+        test_inst = pysat.Instrument(platform='pysat', name=self.name,
+                                     num_samples=10, clean_level='clean',
+                                     update_files=True, strict_time_flag=True,
                                      **kwargs)
         year, doy = pysat.utils.time.getyrdoy(self.ref_time)
         testing.eval_bad_input(test_inst.load, ValueError, msg,

--- a/pysat/tests/test_instrument_padding.py
+++ b/pysat/tests/test_instrument_padding.py
@@ -23,15 +23,11 @@ class TestDataPaddingbyFile(object):
         reload(pysat.instruments.pysat_testing)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
-                                         pad={'minutes': 5},
-                                         update_files=True,
-                                         use_header=True)
+                                         pad={'minutes': 5}, update_files=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
 
         self.rawInst = pysat.Instrument(platform='pysat', name='testing',
-                                        clean_level='clean',
-                                        update_files=True,
-                                        use_header=True)
+                                        clean_level='clean', update_files=True)
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
         return
@@ -143,23 +139,15 @@ class TestDataPaddingbyFileXarray(TestDataPaddingbyFile):
         """Set up the unit test environment for each method."""
 
         reload(pysat.instruments.pysat_ndtesting)
-        self.testInst = pysat.Instrument(platform='pysat',
-                                         name='ndtesting',
-                                         num_samples=86400,
-                                         sample_rate='1s',
+        self.testInst = pysat.Instrument(platform='pysat', name='ndtesting',
+                                         num_samples=86400, sample_rate='1s',
                                          clean_level='clean',
-                                         pad={'minutes': 5},
-                                         update_files=True,
-                                         use_header=True)
+                                         pad={'minutes': 5}, update_files=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
 
-        self.rawInst = pysat.Instrument(platform='pysat',
-                                        name='ndtesting',
-                                        num_samples=86400,
-                                        sample_rate='1s',
-                                        clean_level='clean',
-                                        update_files=True,
-                                        use_header=True)
+        self.rawInst = pysat.Instrument(platform='pysat', name='ndtesting',
+                                        num_samples=86400, sample_rate='1s',
+                                        clean_level='clean', update_files=True)
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
         return
@@ -182,14 +170,11 @@ class TestOffsetRightFileDataPaddingBasics(TestDataPaddingbyFile):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.rawInst = pysat.Instrument(platform='pysat', name='testing',
-                                        tag='',
-                                        clean_level='clean',
+                                        tag='', clean_level='clean',
                                         update_files=True,
-                                        sim_multi_file_right=True,
-                                        use_header=True)
+                                        sim_multi_file_right=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
@@ -216,16 +201,11 @@ class TestOffsetRightFileDataPaddingBasicsXarray(TestDataPaddingbyFile):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
-        self.rawInst = pysat.Instrument(platform='pysat',
-                                        name='ndtesting',
-                                        num_samples=86400,
-                                        sample_rate='1s',
-                                        clean_level='clean',
-                                        update_files=True,
-                                        sim_multi_file_right=True,
-                                        use_header=True)
+                                         pad={'minutes': 5})
+        self.rawInst = pysat.Instrument(platform='pysat', name='ndtesting',
+                                        num_samples=86400, sample_rate='1s',
+                                        clean_level='clean', update_files=True,
+                                        sim_multi_file_right=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
@@ -246,16 +226,12 @@ class TestOffsetLeftFileDataPaddingBasics(TestDataPaddingbyFile):
 
         reload(pysat.instruments.pysat_testing)
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         clean_level='clean',
-                                         update_files=True,
+                                         clean_level='clean', update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.rawInst = pysat.Instrument(platform='pysat', name='testing',
-                                        clean_level='clean',
-                                        update_files=True,
-                                        sim_multi_file_left=True,
-                                        use_header=True)
+                                        clean_level='clean', update_files=True,
+                                        sim_multi_file_left=True)
         self.testInst.bounds = ('2008-01-01.nofile', '2010-12-31.nofile')
         self.rawInst.bounds = self.testInst.bounds
         self.delta = dt.timedelta(seconds=0)
@@ -278,8 +254,7 @@ class TestDataPadding(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad={'minutes': 5},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
         self.delta = dt.timedelta(minutes=5)
@@ -319,8 +294,7 @@ class TestDataPadding(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad=pad,
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         self.eval_index_start_end()
         return
@@ -354,8 +328,7 @@ class TestDataPadding(object):
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
                                          clean_level='clean',
                                          pad={'days': 2},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
 
         testing.eval_bad_input(self.testInst.load, ValueError,
                                'Data padding window must be shorter than ',
@@ -486,8 +459,7 @@ class TestDataPaddingNonMonotonic(TestDataPadding):
                                          clean_level='clean',
                                          pad={'minutes': 5},
                                          non_monotonic_index=True,
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
         self.delta = dt.timedelta(minutes=5)
@@ -513,8 +485,7 @@ class TestDataPaddingXArray(TestDataPadding):
                                          sample_rate='1s',
                                          clean_level='clean',
                                          pad={'minutes': 5},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
         self.delta = dt.timedelta(minutes=5)
@@ -541,8 +512,7 @@ class TestDataPaddingXArrayNonMonotonic(TestDataPadding):
                                          clean_level='clean',
                                          pad={'minutes': 5},
                                          non_monotonic_index=True,
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
         self.delta = dt.timedelta(minutes=5)
@@ -566,8 +536,7 @@ class TestMultiFileRightDataPaddingBasics(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -593,8 +562,7 @@ class TestMultiFileRightDataPaddingBasicsNonMonotonic(TestDataPadding):
                                          update_files=True,
                                          sim_multi_file_right=True,
                                          non_monotonic_index=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -622,8 +590,7 @@ class TestMultiFileRightDataPaddingBasicsXarray(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_right=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -652,8 +619,7 @@ class TestMultiFileRightDataPaddingBasicsXarrayNonMonotonic(TestDataPadding):
                                          update_files=True,
                                          sim_multi_file_right=True,
                                          non_monotonic_index=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -679,8 +645,7 @@ class TestMultiFileLeftDataPaddingBasics(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -707,8 +672,7 @@ class TestMultiFileLeftDataPaddingBasicsNonMonotonic(TestDataPadding):
                                          update_files=True,
                                          sim_multi_file_left=True,
                                          non_monotonic_index=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -736,8 +700,7 @@ class TestMultiFileLeftDataPaddingBasicsXarray(TestDataPadding):
                                          clean_level='clean',
                                          update_files=True,
                                          sim_multi_file_left=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2
@@ -758,16 +721,12 @@ class TestMultiFileLeftDataPaddingBasicsXarrayNonMonotonic(TestDataPadding):
         """Set up the unit test environment for each method."""
 
         reload(pysat.instruments.pysat_ndtesting)
-        self.testInst = pysat.Instrument(platform='pysat',
-                                         name='ndtesting',
-                                         clean_level='clean',
-                                         update_files=True,
-                                         num_samples=86400,
-                                         sample_rate='1s',
+        self.testInst = pysat.Instrument(platform='pysat', name='ndtesting',
+                                         clean_level='clean', update_files=True,
+                                         num_samples=86400, sample_rate='1s',
                                          sim_multi_file_left=True,
                                          non_monotonic_index=True,
-                                         pad={'minutes': 5},
-                                         use_header=True)
+                                         pad={'minutes': 5})
         self.testInst.multi_file_day = True
         self.ref_time = dt.datetime(2009, 1, 2)
         self.ref_doy = 2

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -64,11 +64,10 @@ class TestInstruments(InstLibTests):
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         if kwarg:
             self.test_inst = pysat.Instrument(
-                inst_module=inst_dict['inst_module'], start_time=kwarg,
-                use_header=True)
+                inst_module=inst_dict['inst_module'], start_time=kwarg)
         else:
             self.test_inst = pysat.Instrument(
-                inst_module=inst_dict['inst_module'], use_header=True)
+                inst_module=inst_dict['inst_module'])
 
         self.test_inst.load(date=date)
 
@@ -92,7 +91,7 @@ class TestInstruments(InstLibTests):
         num = 10
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
-                                          num_samples=num, use_header=True)
+                                          num_samples=num)
         self.test_inst.load(date=date)
 
         assert len(self.test_inst['uts']) == num
@@ -115,7 +114,7 @@ class TestInstruments(InstLibTests):
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
         self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
                                           file_date_range=file_date_range,
-                                          update_files=True, use_header=True)
+                                          update_files=True)
         file_list = self.test_inst.files.files
 
         assert all(file_date_range == file_list.index)
@@ -134,8 +133,7 @@ class TestInstruments(InstLibTests):
         """
 
         _, date = cls_inst_lib.initialize_test_inst_and_date(inst_dict)
-        self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'],
-                                          use_header=True)
+        self.test_inst = pysat.Instrument(inst_module=inst_dict['inst_module'])
         if self.test_inst.name != 'testmodel':
             self.test_inst.load(date=date, max_latitude=10.)
             assert np.all(np.abs(self.test_inst['latitude']) <= 10.)

--- a/pysat/tests/test_meta.py
+++ b/pysat/tests/test_meta.py
@@ -67,7 +67,7 @@ class TestMeta(object):
         """
         if inst_kwargs is not None:
             # Load the test Instrument
-            self.testInst = pysat.Instrument(**inst_kwargs, use_header=True)
+            self.testInst = pysat.Instrument(**inst_kwargs)
             stime = self.testInst.inst_module._test_dates['']['']
             self.testInst.load(date=stime)
 
@@ -1476,8 +1476,7 @@ class TestMetaMutable(object):
     def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         use_header=True)
+        self.testInst = pysat.Instrument(platform='pysat', name='testing')
         self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         self.meta = self.testInst.meta
         self.meta.mutable = True
@@ -1612,8 +1611,7 @@ class TestToDict(object):
     def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5,
-                                         use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.load(date=self.stime)
 
@@ -1676,8 +1674,7 @@ class TestToDictXarrayND(TestToDict):
     def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument('pysat', 'ndtesting',
-                                         num_samples=5, use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'ndtesting', num_samples=5)
         self.stime = pysat.instruments.pysat_ndtesting._test_dates['']['']
         self.testInst.load(date=self.stime)
 
@@ -1693,8 +1690,7 @@ class TestToDictXarrayModel(TestToDict):
     def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.testInst = pysat.Instrument('pysat', 'testmodel',
-                                         num_samples=5, use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'testmodel', num_samples=5)
         self.stime = pysat.instruments.pysat_testmodel._test_dates['']['']
         self.testInst.load(date=self.stime)
 

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -114,7 +114,7 @@ class TestRemoveLeadText(object):
 
         # Load a test instrument
         self.testInst = pysat.Instrument('pysat', 'testing', num_samples=12,
-                                         clean_level='clean', use_header=True)
+                                         clean_level='clean')
         self.testInst.load(2009, 1)
         self.npts = len(self.testInst['uts'])
         return
@@ -199,10 +199,8 @@ class TestRemoveLeadTextXarray(TestRemoveLeadText):
         """Set up the unit test environment for each method."""
 
         # Load a test instrument
-        self.testInst = pysat.Instrument('pysat', 'ndtesting',
-                                         num_samples=12,
-                                         clean_level='clean',
-                                         use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'ndtesting', num_samples=12,
+                                         clean_level='clean')
         self.testInst.load(2009, 1)
         self.npts = len(self.testInst['uts'])
         return

--- a/pysat/tests/test_methods_testing.py
+++ b/pysat/tests/test_methods_testing.py
@@ -16,7 +16,7 @@ class TestMethodsTesting(object):
     def setup_method(self):
         """Set up the unit test environment for each method."""
 
-        self.test_inst = pysat.Instrument('pysat', 'testing', use_header=True)
+        self.test_inst = pysat.Instrument('pysat', 'testing')
 
         # Get list of filenames.
         self.fnames = [self.test_inst.files.files.values[0]]

--- a/pysat/tests/test_orbits.py
+++ b/pysat/tests/test_orbits.py
@@ -140,7 +140,6 @@ class TestOrbitsUserInterface(object):
         """
 
         self.in_kwargs['orbit_info'] = info
-        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
         self.testInst.load(date=self.stime)
 
@@ -168,7 +167,6 @@ class TestOrbitsUserInterface(object):
         """
 
         self.in_kwargs['orbit_info'] = info
-        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
 
         # Force index to None beforee loading and iterating
@@ -182,7 +180,6 @@ class TestOrbitsUserInterface(object):
         """Test the Orbit representation."""
 
         self.in_kwargs['orbit_info'] = {'index': 'mlt'}
-        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
         out_str = self.testInst.orbits.__repr__()
 
@@ -193,7 +190,6 @@ class TestOrbitsUserInterface(object):
         """Test the Orbit string representation with data."""
 
         self.in_kwargs['orbit_info'] = {'index': 'mlt'}
-        self.in_kwargs['use_header'] = True
         self.testInst = pysat.Instrument(*self.in_args, **self.in_kwargs)
         self.testInst.load(date=self.stime)
         out_str = self.testInst.orbits.__str__()
@@ -212,8 +208,7 @@ class TestSpecificUTOrbits(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.inc_min = 97
         self.etime = None
@@ -391,8 +386,7 @@ class TestGeneralOrbitsMLT(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -592,8 +586,7 @@ class TestGeneralOrbitsMLTxarray(TestGeneralOrbitsMLT):
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_ndtesting._test_dates['']['']
         return
 
@@ -620,8 +613,7 @@ class TestGeneralOrbitsNonStandardIteration(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.testInst.bounds = (self.testInst.files.files.index[0],
                                 self.testInst.files.files.index[11],
                                 '2D', dt.timedelta(days=3))
@@ -683,8 +675,7 @@ class TestGeneralOrbitsLong(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
                                                      'kind': 'longitude'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -705,8 +696,7 @@ class TestGeneralOrbitsLongXarray(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
                                                      'kind': 'longitude'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -727,8 +717,7 @@ class TestGeneralOrbitsOrbitNumber(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
                                                      'kind': 'orbit'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -749,8 +738,7 @@ class TestGeneralOrbitsOrbitNumberXarray(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
                                                      'kind': 'orbit'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_ndtesting._test_dates['']['']
         return
 
@@ -771,8 +759,7 @@ class TestGeneralOrbitsLatitude(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
                                                      'kind': 'polar'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         return
 
@@ -793,8 +780,7 @@ class TestGeneralOrbitsLatitudeXarray(TestGeneralOrbitsMLT):
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
                                                      'kind': 'polar'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_ndtesting._test_dates['']['']
         return
 
@@ -835,8 +821,7 @@ class TestOrbitsGappyData(object):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -877,8 +862,7 @@ class TestOrbitsGappyDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
                                          clean_level='clean',
                                          orbit_info={'index': 'mlt'},
-                                         update_files=True,
-                                         use_header=True)
+                                         update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -919,8 +903,7 @@ class TestOrbitsGappyData2(object):
 
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
-                                         orbit_info={'index': 'mlt'},
-                                         use_header=True)
+                                         orbit_info={'index': 'mlt'})
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.custom_attach(filter_data, kwargs={'times': self.times})
         return
@@ -948,8 +931,7 @@ class TestOrbitsGappyData2Xarray(TestOrbitsGappyData2):
 
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
                                          clean_level='clean',
-                                         orbit_info={'index': 'mlt'},
-                                         use_header=True)
+                                         orbit_info={'index': 'mlt'})
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.testInst.custom_attach(filter_data, kwargs={'times': self.times})
         return
@@ -970,8 +952,7 @@ class TestOrbitsGappyLongData(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
-                                                     'kind': 'longitude'},
-                                         use_header=True)
+                                                     'kind': 'longitude'})
 
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
@@ -994,8 +975,7 @@ class TestOrbitsGappyLongDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
                                          clean_level='clean',
                                          orbit_info={'index': 'longitude',
-                                                     'kind': 'longitude'},
-                                         use_header=True)
+                                                     'kind': 'longitude'})
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -1017,8 +997,7 @@ class TestOrbitsGappyOrbitNumData(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
-                                                     'kind': 'orbit'},
-                                         use_header=True)
+                                                     'kind': 'orbit'})
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -1040,8 +1019,7 @@ class TestOrbitsGappyOrbitNumDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
                                          clean_level='clean',
                                          orbit_info={'index': 'orbit_num',
-                                                     'kind': 'orbit'},
-                                         use_header=True)
+                                                     'kind': 'orbit'})
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
         self.testInst.custom_attach(filter_data, kwargs={'times': self.gaps})
@@ -1063,8 +1041,7 @@ class TestOrbitsGappyOrbitLatData(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'testing',
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
-                                                     'kind': 'polar'},
-                                         use_header=True)
+                                                     'kind': 'polar'})
 
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime
@@ -1087,8 +1064,7 @@ class TestOrbitsGappyOrbitLatDataXarray(TestOrbitsGappyData):
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
                                          clean_level='clean',
                                          orbit_info={'index': 'latitude',
-                                                     'kind': 'polar'},
-                                         use_header=True)
+                                                     'kind': 'polar'})
 
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.gaps = self.stime + self.deltime

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -50,7 +50,7 @@ class TestUpdateFill(object):
         """
 
         # Initalize the instrument
-        inst = pysat.Instrument('pysat', name, use_header=True)
+        inst = pysat.Instrument('pysat', name)
         inst.load(date=self.ref_time)
 
         # Ensure there are fill values to check
@@ -82,7 +82,7 @@ class TestUpdateFill(object):
         """
 
         # Initalize the instrument
-        inst = pysat.Instrument('pysat', name, use_header=True)
+        inst = pysat.Instrument('pysat', name)
         inst.load(date=self.ref_time)
 
         # Ensure there are fill values to check

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -67,8 +67,7 @@ class TestUpdateLon(object):
     def test_update_longitude(self, name):
         """Test `update_longitude` successful run."""
 
-        self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name)
         self.py_inst.load(date=self.inst_time)
 
         # Test instruments initially define longitude between 0-360 deg
@@ -85,8 +84,7 @@ class TestUpdateLon(object):
     def test_bad_lon_name_update_longitude(self):
         """Test update_longitude with a bad longitude name."""
 
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing",
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing")
         self.py_inst.load(date=self.inst_time)
 
         testing.eval_bad_input(coords.update_longitude, ValueError,
@@ -124,7 +122,7 @@ class TestCalcSLT(object):
 
         # Instantiate instrument and load data
         self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        num_samples=1, use_header=True)
+                                        num_samples=1)
         self.py_inst.load(date=self.inst_time)
 
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -148,7 +146,7 @@ class TestCalcSLT(object):
 
         # Instantiate instrument and load data
         self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        num_samples=1, use_header=True)
+                                        num_samples=1)
         self.py_inst.load(date=self.inst_time)
 
         # Apply solar local time method and capture logging output
@@ -167,8 +165,7 @@ class TestCalcSLT(object):
         """Test calc_solar_local_time with longitudes from -180 to 180 deg."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing",
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing")
         self.py_inst.load(date=self.inst_time)
 
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -186,8 +183,7 @@ class TestCalcSLT(object):
         """Test raises ValueError with a bad longitude name."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name="testing",
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name="testing")
         self.py_inst.load(date=self.inst_time)
 
         # Test that the correct Exception and error message are raised
@@ -203,8 +199,7 @@ class TestCalcSLT(object):
         """Test calc_solar_local_time with longitude coordinates."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name)
         self.py_inst.load(date=self.inst_time)
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
                                      slt_name='slt')
@@ -219,8 +214,7 @@ class TestCalcSLT(object):
         """Test non modulated solar local time output for a 2 day range."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name)
         self.py_inst.load(date=self.inst_time,
                           end_date=self.inst_time + dt.timedelta(days=2))
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -237,8 +231,7 @@ class TestCalcSLT(object):
         """Test non modulated SLT output for a 2 day range with a ref date."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name)
         self.py_inst.load(date=self.inst_time, end_date=self.inst_time
                           + dt.timedelta(days=2))
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
@@ -257,8 +250,7 @@ class TestCalcSLT(object):
         """Test SLT calc with longitude coordinates and no modulus."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name=name,
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name=name)
         self.py_inst.load(date=self.inst_time)
         coords.calc_solar_local_time(self.py_inst, lon_name="longitude",
                                      slt_name='slt', apply_modulus=False)
@@ -273,8 +265,7 @@ class TestCalcSLT(object):
         """Test calc_solar_local_time with a single longitude value."""
 
         # Instantiate instrument and load data
-        self.py_inst = pysat.Instrument(platform='pysat', name="ndtesting",
-                                        use_header=True)
+        self.py_inst = pysat.Instrument(platform='pysat', name="ndtesting")
         self.py_inst.load(date=self.inst_time)
         lon_name = 'lon2'
 
@@ -362,7 +353,7 @@ class TestExpandXarrayDims(object):
     def setup_method(self):
         """Set up the unit test environment."""
         self.test_inst = pysat.Instrument(
-            inst_module=pysat.instruments.pysat_ndtesting, use_header=True)
+            inst_module=pysat.instruments.pysat_ndtesting)
         self.start_time = pysat.instruments.pysat_ndtesting._test_dates['']['']
         self.data_list = []
         self.out = None
@@ -397,12 +388,12 @@ class TestExpandXarrayDims(object):
             # Load a second data set with half the time samples
             self.test_inst = pysat.Instrument(
                 inst_module=self.test_inst.inst_module,
-                num_samples=num_samples, use_header=True)
+                num_samples=num_samples)
         else:
             # Load a second data set with different dimensions apart from time
             self.test_inst = pysat.Instrument(
                 inst_module=pysat.instruments.pysat_testmodel,
-                num_samples=num_samples, use_header=True)
+                num_samples=num_samples)
 
         self.test_inst.load(date=self.start_time + dt.timedelta(days=1))
         self.data_list.append(self.test_inst.data)

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -152,15 +152,13 @@ class TestFileDirectoryTranslations(CICleanSetup):
         self.insts_kwargs = []
 
         # Data by day, ACE SIS data
-        self.insts.append(pysat.Instrument('ace', 'sis', tag='historic',
-                                           use_header=True))
+        self.insts.append(pysat.Instrument('ace', 'sis', tag='historic'))
         test_dates = pysatSpaceWeather.instruments.ace_sis._test_dates
         self.insts_dates.append([test_dates['']['historic']] * 2)
         self.insts_kwargs.append({})
 
         # Data with date mangling, regular F10.7 data, stored monthly
-        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic',
-                                           use_header=True))
+        self.insts.append(pysat.Instrument('sw', 'f107', tag='historic'))
         test_dates = pysatSpaceWeather.instruments.sw_f107._test_dates
         self.insts_dates.append([test_dates['']['historic'],
                                  test_dates['']['historic']
@@ -265,7 +263,7 @@ class TestFileDirectoryTranslations(CICleanSetup):
             # Refresh inst with the old directory template set to get now 'old'
             # path information.
             inst2 = pysat.Instrument(inst.platform, inst.name, tag=inst.tag,
-                                     inst_id=inst.inst_id, use_header=True)
+                                     inst_id=inst.inst_id)
 
             # Check that directories with simpler platform org were NOT removed.
             assert os.path.isdir(inst2.files.data_path)
@@ -326,7 +324,7 @@ class TestFileUtils(CICleanSetup):
 
         self.testInst = pysat.Instrument(
             inst_module=pysat.instruments.pysat_testing, clean_level='clean',
-            update_files=True, use_header=True)
+            update_files=True)
 
         # Create instrument directories in tempdir
         pysat.utils.files.check_and_make_path(self.testInst.files.data_path)

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -61,8 +61,7 @@ class TestLoadNetCDF(object):
         pysat.params['data_dirs'] = self.tempdir.name
 
         self.testInst = pysat.Instrument(platform='pysat', name='testing',
-                                         num_samples=100, update_files=True,
-                                         use_header=True)
+                                         num_samples=100, update_files=True)
         self.stime = pysat.instruments.pysat_testing._test_dates['']['']
         self.epoch_name = 'time'
 
@@ -114,7 +113,7 @@ class TestLoadNetCDF(object):
         """Test basic netCDF4 read/write with mixed case data variables."""
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.tempdir.name, 'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         # Modify data names in data
         if self.testInst.pandas_format:
@@ -157,7 +156,7 @@ class TestLoadNetCDF(object):
         """Test basic netCDF4 read/write with mixed case metadata variables."""
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.tempdir.name, 'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         # Modify data and metadata names in data
         self.testInst.meta.rename(str.upper)
@@ -200,7 +199,7 @@ class TestLoadNetCDF(object):
         """
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.tempdir.name, 'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         io.inst_to_netcdf(self.testInst, fname=outfile, preserve_meta_case=True,
                           epoch_name=default_epoch_name, **kwargs)
@@ -235,7 +234,7 @@ class TestLoadNetCDF(object):
                                                    'pysat_test_ncdf_%Y%j.nc'))
 
         # Load and write the test instrument data
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
         self.testInst.to_netcdf4(fname=outfile, epoch_name=default_epoch_name)
 
         # Load the written file directly into an Instrument
@@ -244,7 +243,7 @@ class TestLoadNetCDF(object):
         netcdf_inst = pysat.Instrument(
             'pysat', 'netcdf', data_dir=file_path, update_files=True,
             file_format=file_root, pandas_format=self.testInst.pandas_format,
-            use_header=True, epoch_name=default_epoch_name, **tkwargs)
+            epoch_name=default_epoch_name, **tkwargs)
 
         # Confirm data path is correct
         assert os.path.normpath(netcdf_inst.files.data_path) \
@@ -253,7 +252,7 @@ class TestLoadNetCDF(object):
         # Deleting the test file here via os.remove(...) does work
 
         # Load data
-        netcdf_inst.load(date=self.stime, use_header=True)
+        netcdf_inst.load(date=self.stime)
 
         # Test the loaded Instrument data
         self.loaded_inst = netcdf_inst.data
@@ -316,7 +315,7 @@ class TestLoadNetCDF(object):
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
         self.testInst['MLT'] = 1
 
         # Evaluate the expected error and message
@@ -348,7 +347,7 @@ class TestLoadNetCDF(object):
         # Load data
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         # Write file
         io.inst_to_netcdf(self.testInst, fname=outfile, epoch_name=write_epoch)
@@ -392,7 +391,7 @@ class TestLoadNetCDF(object):
             # Load data
             outfile = os.path.join(self.tempdir.name,
                                    'pysat_test_ncdf.nc')
-            self.testInst.load(date=self.stime, use_header=True)
+            self.testInst.load(date=self.stime)
 
             # Write file
             io.inst_to_netcdf(self.testInst, outfile, epoch_name=write_epoch)
@@ -430,7 +429,7 @@ class TestLoadNetCDF(object):
         # Create a new file based on loaded test data
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
         if 'epoch_name' not in wkwargs.keys():
             wkwargs['epoch_name'] = default_epoch_name
         io.inst_to_netcdf(self.testInst, fname=outfile, **wkwargs)
@@ -471,7 +470,7 @@ class TestLoadNetCDF(object):
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.tempdir.name,
                                'pysat_{:}_ncdf.nc'.format(self.testInst.name))
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         io.inst_to_netcdf(self.testInst, fname=outfile,
                           epoch_name=default_epoch_name)
@@ -523,7 +522,7 @@ class TestLoadNetCDF(object):
 
     def test_netcdf_prevent_attribute_override(self):
         """Test that attributes will not be overridden by default."""
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         # Test that `bespoke` attribute is initially missing
         assert not hasattr(self.testInst, 'bespoke')
@@ -543,7 +542,7 @@ class TestLoadNetCDF(object):
 
     def test_netcdf_attribute_override(self):
         """Test that attributes in the netCDF file may be overridden."""
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
         self.testInst.meta.mutable = True
         self.testInst.meta.bespoke = True
 
@@ -583,7 +582,7 @@ class TestLoadNetCDF(object):
         # Create a file
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
         io.inst_to_netcdf(self.testInst, fname=outfile,
                           epoch_name=default_epoch_name)
 
@@ -633,7 +632,7 @@ class TestLoadNetCDF(object):
         # Create a file with additional metadata
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         # Add additional metadata
         self.testInst.meta['mlt'] = {drop_label: 1.}
@@ -687,8 +686,7 @@ class TestLoadNetCDFXArray(TestLoadNetCDF):
 
         self.testInst = pysat.Instrument(platform='pysat',
                                          name='ndtesting',
-                                         update_files=True, num_samples=100,
-                                         use_header=True)
+                                         update_files=True, num_samples=100)
         self.stime = pysat.instruments.pysat_ndtesting._test_dates[
             '']['']
         self.epoch_name = 'time'
@@ -737,7 +735,7 @@ class TestLoadNetCDFXArray(TestLoadNetCDF):
         # Prepare output test data
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
 
         # Modify the variable attributes directly before writing to file
         self.testInst.meta['uts'] = {'units': 'seconds'}
@@ -767,7 +765,7 @@ class TestLoadNetCDFXArray(TestLoadNetCDF):
         # Create a bunch of files by year and doy
         outfile = os.path.join(self.tempdir.name,
                                'pysat_test_ncdf.nc')
-        self.testInst.load(date=self.stime, use_header=True)
+        self.testInst.load(date=self.stime)
         io.inst_to_netcdf(self.testInst, fname=outfile)
 
         # Evaluate the error raised and the expected message
@@ -801,10 +799,8 @@ class TestNetCDF4Integration(object):
 
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
-        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5,
-                                         use_header=True)
-        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
-                           use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'testing', num_samples=5)
+        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         self.pformat = self.testInst.pandas_format
 
         return
@@ -1256,9 +1252,8 @@ class TestNetCDF4IntegrationXarray(TestNetCDF4Integration):
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
         self.testInst = pysat.Instrument('pysat', 'ndtesting',
-                                         num_samples=5, use_header=True)
-        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
-                           use_header=True)
+                                         num_samples=5)
+        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         self.pformat = self.testInst.pandas_format
 
         return
@@ -1272,10 +1267,8 @@ class TestNetCDF4IntegrationXarrayModels(TestNetCDF4Integration):
 
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
-        self.testInst = pysat.Instrument('pysat', 'testmodel', num_samples=5,
-                                         use_header=True)
-        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
-                           use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'testmodel', num_samples=5)
+        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         self.pformat = self.testInst.pandas_format
 
         return
@@ -1289,10 +1282,8 @@ class TestXarrayIO(object):
 
         # Create an instrument object that has a meta with some
         # variables allowed to be nan within metadata when exporting.
-        self.testInst = pysat.Instrument('pysat', 'ndtesting',
-                                         num_samples=5, use_header=True)
-        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''],
-                           use_header=True)
+        self.testInst = pysat.Instrument('pysat', 'ndtesting', num_samples=5)
+        self.testInst.load(date=self.testInst.inst_module._test_dates[''][''])
         self.epoch_name = 'time'
 
         return
@@ -1411,8 +1402,7 @@ class TestMetaTranslation(object):
     def setup_method(self):
         """Create test environment."""
 
-        self.test_inst = pysat.Instrument('pysat', 'testing', num_samples=5,
-                                          use_header=True)
+        self.test_inst = pysat.Instrument('pysat', 'testing', num_samples=5)
         self.test_date = pysat.instruments.pysat_testing._test_dates['']['']
         self.test_inst.load(date=self.test_date)
         self.meta_dict = self.test_inst.meta.to_dict()
@@ -1694,7 +1684,7 @@ class TestMetaTranslationXarray(TestMetaTranslation):
         """Create test environment."""
 
         self.test_inst = pysat.Instrument('pysat', 'ndtesting',
-                                          num_samples=5, use_header=True)
+                                          num_samples=5)
         self.test_date = pysat.instruments.pysat_ndtesting._test_dates['']['']
         self.test_inst.load(date=self.test_date)
         self.meta_dict = self.test_inst.meta.to_dict()
@@ -1716,8 +1706,7 @@ class TestMetaTranslationModel(TestMetaTranslation):
     def setup_method(self):
         """Create test environment."""
 
-        self.test_inst = pysat.Instrument('pysat', 'testmodel',
-                                          num_samples=5, use_header=True)
+        self.test_inst = pysat.Instrument('pysat', 'testmodel', num_samples=5)
         self.test_date = pysat.instruments.pysat_testmodel._test_dates['']['']
         self.test_inst.load(date=self.test_date)
         self.meta_dict = self.test_inst.meta.to_dict()
@@ -1782,8 +1771,7 @@ class TestIODeprecation(object):
 
         # Create a test file
         testInst = pysat.Instrument(platform='pysat', name=inst_name,
-                                    num_samples=100, update_files=True,
-                                    use_header=True)
+                                    num_samples=100, update_files=True)
         testInst.load(date=testInst.inst_module._test_dates[''][''])
         io.inst_to_netcdf(testInst, fname=self.outfile)
 


### PR DESCRIPTION
# Description

Partially addresses #1020 by removing `use_header` as a standard kwarg from `Instrument.load`.  Updated the DeprecationWarning and removed unnecessary use of `use_header` from the test suite.

## Type of change

Please delete options that are not relevant.

- Breaking change (fix or feature that would cause existing functionality
      to not work as expected)
- This change requires a documentation update

# How Has This Been Tested?

```
import pysat

inst = pysat.Instrument('pysat', 'testing')
# This will not raise a deprecation warning
inst.load(2009, 1)

# This will raise a deprecation warning, but behave the same way
inst.load(2009, 2, use_header=True)

# This will raise a deprecation warning, and go back to the old behaviour
inst.load(2009, 1, use_header=False)
```

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
