### PR TITLE
Padding bugfix

### DIFF
--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1307,7 +1307,7 @@ class Instrument(object):
 
         Returns
         -------
-        pds.Series
+        index : pds.Series
             Series containing the time indices for the Instrument data
 
         """
@@ -1316,15 +1316,17 @@ class Instrument(object):
             data = self.data
 
         if self.pandas_format:
-            return data.index
+            index = data.index
         else:
             epoch_names = self._get_epoch_name_from_data(data=data)
 
             if len(epoch_names) == 0:
-                return pds.Index([])
+                index = pds.Index([])
             else:
                 # Xarray preferred epoch name order is opposite
-                return data.indexes[epoch_names[-1]]
+                index = data.indexes[epoch_names[-1]]
+
+        return index
 
     def _pass_method(*args, **kwargs):
         """Empty default method for updatable Instrument methods."""
@@ -3301,11 +3303,10 @@ class Instrument(object):
                 if not self._empty(ndata):
                     # Test the data index, slicing if necessary
                     nindex = self._index(data=ndata)
-                    if len(nindex) > 0:
+                    if len(nindex) > 1:
                         if nindex[0] == self.index[-1]:
                             ndata = self.__getitem__(
-                                slice(1, len(ndata[self.index.name])),
-                                data=ndata)
+                                slice(1, len(nindex)), data=ndata)
                         cdata.append(ndata)
                         if include is None:
                             include = 0

--- a/pysat/instruments/methods/general.py
+++ b/pysat/instruments/methods/general.py
@@ -256,5 +256,12 @@ def load_csv_data(fnames, read_csv_kwargs=None):
     for fname in fnames:
         fdata.append(pds.read_csv(fname, **read_csv_kwargs))
 
-    data = pds.DataFrame() if len(fdata) == 0 else pds.concat(fdata, axis=0)
+    if len(fdata) == 0:
+        data = pds.DataFrame()
+    else:
+        data = pds.concat(fdata, axis=0)
+
+        if data.index.name is None:
+            data.index.name = "Epoch"
+
     return data

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -11,6 +11,15 @@ from pysat.instruments.methods import general as gen
 from pysat.utils import testing
 
 
+def test_filename_creator():
+    """Test the `filename_creator` placeholder."""
+
+    testing.eval_bad_input(gen.filename_creator, NotImplementedError,
+                               'This feature has not been implemented yet',
+                               input_args=[0.0])
+    return
+
+
 class TestListFiles(object):
     """Unit tests for `pysat.instrument.methods.general.list_files`."""
 
@@ -268,7 +277,7 @@ class TestLoadCSVData(object):
         return
 
     def test_load_single_file(self):
-        """Test the CVS data load with a single file."""
+        """Test the CSV data load with a single file."""
 
         self.data = gen.load_csv_data(self.csv_file)
         assert isinstance(self.data.index, pds.RangeIndex)
@@ -277,7 +286,7 @@ class TestLoadCSVData(object):
         return
 
     def test_load_file_list(self):
-        """Test the CVS data load with multiple files."""
+        """Test the CSV data load with multiple files."""
 
         self.data = gen.load_csv_data([self.csv_file, self.csv_file])
         assert self.data.index.dtype == 'int64'
@@ -286,7 +295,7 @@ class TestLoadCSVData(object):
         return
 
     def test_load_file_with_kwargs(self):
-        """Test the CVS data load with kwargs."""
+        """Test the CSV data load with kwargs."""
 
         self.data = gen.load_csv_data([self.csv_file],
                                       read_csv_kwargs={"parse_dates": True,
@@ -294,4 +303,13 @@ class TestLoadCSVData(object):
         assert isinstance(self.data.index, pds.DatetimeIndex)
         self.eval_data_cols()
         assert len(self.data.columns) == len(self.data_cols)
+        return
+
+    def test_load_empty_filelist(self):
+        """Test the CSV data loading with an empty file list."""
+
+        self.data = gen.load_csv_data([])
+
+        # Evaluate the empty output
+        assert self.data.empty
         return

--- a/pysat/tests/test_methods_general.py
+++ b/pysat/tests/test_methods_general.py
@@ -15,8 +15,8 @@ def test_filename_creator():
     """Test the `filename_creator` placeholder."""
 
     testing.eval_bad_input(gen.filename_creator, NotImplementedError,
-                               'This feature has not been implemented yet',
-                               input_args=[0.0])
+                           'This feature has not been implemented yet',
+                           input_args=[0.0])
     return
 
 


### PR DESCRIPTION
# Description

Addresses https://github.com/pysat/pysatSpaceWeather/issues/127.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```
import pysat
import pysatSpaceWeather

f107 = pysat.Instrument('sw', 'f107', tag='daily', pad=dt.timedelta(days=1))
f107.download(start=f107.today())

# This will be empty
f107.load(date=f107.today())

f107.pad = None

# This will not be empty
f107.load(date=f107.today())
```

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
