### PR TITLE
TST: added more file utility unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
     shift in time.
   * Added orbit number to `pysat_ndtesting`.
   * Added the overwrite kwarg to `utils.registry.register_by_module`.
-  * Added unit tests for all file parsing functions in `utils.files`.
+  * Added unit tests for all functions in `utils.files`.
   * Reduced code duplication in the `utils.files.parse_fixed_width_filenames`
     and `utils.files.parse_delimited_filenames` functions
 * Bug Fix

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -5,10 +5,10 @@
 # ----------------------------------------------------------------------------
 """Tests the `pysat.utils.files` functions."""
 
+from collections import OrderedDict
 import datetime as dt
 from importlib import reload
 import numpy as np
-from collections import OrderedDict
 import os
 import pandas as pds
 import platform

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -709,19 +709,19 @@ class TestFileUtils(CICleanSetup):
         del self.testInst, self.out, self.tempdir, self.start, self.stop
         return
 
+    @pytest.mark.skipif(os.environ.get('CI') != 'true', reason="CI test only")
     def test_updating_directories_no_registration(self, capsys):
         """Test directory structure update method without registered insts."""
-        # New Template
-        templ = '{platform}'
-
         # Convert directories to simpler platform structure, to get output
+        templ = '{platform}'
         futils.update_data_directory_structure(new_template=templ,
                                                full_breakdown=True)
 
         # Capture printouts and test the results
         captured = capsys.readouterr()
-        assert captured.find("No registered instruments detected.") >= 0, \
-            "Expected output not captured in: {:}".format(captured)
+        captxt = captured.out
+        assert captxt.find("No registered instruments detected.") >= 0, \
+            "Expected output not captured in STDOUT: {:}".format(captxt)
         return
 
     def test_search_local_system_formatted_filename(self):

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -709,6 +709,40 @@ class TestFileUtils(CICleanSetup):
         del self.testInst, self.out, self.tempdir, self.start, self.stop
         return
 
+    def test_updating_directories_no_registration(self, capsys):
+        """Test directory structure update method without registered insts."""
+        # New Template
+        templ = '{platform}'
+
+        # Convert directories to simpler platform structure, to get output
+        futils.update_data_directory_structure(new_template=templ,
+                                               full_breakdown=True)
+
+        # Capture printouts and test the results
+        captured = capsys.readouterr()
+        assert captured.find("No registered instruments detected.") >= 0, \
+            "Expected output not captured in: {:}".format(captured)
+        return
+
+    def test_search_local_system_formatted_filename(self):
+        """Test `search_local_system_formatted_filename` success."""
+        # Create a temporary file with a unique, searchable name
+        prefix = "test_me"
+        suffix = "tstfile"
+        searchstr = "*".join([prefix, suffix])
+        with tempfile.NamedTemporaryFile(
+                dir=self.testInst.files.data_path, prefix=prefix,
+                suffix=suffix) as temp:
+            files = futils.search_local_system_formatted_filename(
+                self.testInst.files.data_path, searchstr)
+
+        assert len(files) == 1, "unexpected number of files in search results"
+        assert files[0].find(
+            prefix) >= 0, "unexpected file prefix in search results"
+        assert files[0].find(
+            suffix) > 0, "unexpected file extension in search results"
+        return
+
     def test_get_file_information(self):
         """Test `utils.files.get_file_information` success with existing files.
 

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -6,9 +6,9 @@
 """Tests the `pysat.utils.files` functions."""
 
 import datetime as dt
-from collections import OrderedDict
 from importlib import reload
 import numpy as np
+from collections import OrderedDict
 import os
 import pandas as pds
 import platform

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -730,9 +730,8 @@ class TestFileUtils(CICleanSetup):
         prefix = "test_me"
         suffix = "tstfile"
         searchstr = "*".join([prefix, suffix])
-        with tempfile.NamedTemporaryFile(
-                dir=self.testInst.files.data_path, prefix=prefix,
-                suffix=suffix) as temp:
+        with tempfile.NamedTemporaryFile(dir=self.testInst.files.data_path,
+                                         prefix=prefix, suffix=suffix):
             files = futils.search_local_system_formatted_filename(
                 self.testInst.files.data_path, searchstr)
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -19,8 +19,8 @@ from pysat.utils._core import available_instruments
 from pysat.utils._core import listify
 from pysat.utils.time import create_datetime_index
 
-# Define hidden support functions
 
+# Define hidden support functions
 
 def _init_parse_filenames(files, format_str):
     """Set the initial output for the file parsing functions.
@@ -464,7 +464,7 @@ def construct_searchstring_from_format(format_str, wildcard=False):
         `instrument_{year:04d}{month:02d}{day:02d}_v{version:02d}.cdf`
     wildcard : bool
         If True, replaces each '?' sequence that would normally
-        be returned with a single '*'.
+        be returned with a single '*'. (default=False)
 
     Returns
     -------
@@ -531,10 +531,10 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                             out_dict['search_string'] += '*'
                         break
             else:
-                estr = ''.join(["Couldn't determine formatting width. ",
-                                "This may be due to the use of unsupported ",
-                                "wildcard characters."])
-                raise ValueError(estr)
+                raise ValueError(
+                    ''.join(["Couldn't determine formatting width, check ",
+                             "formatting length specification (e.g., ",
+                             "{day:03d} for day of year)."]))
 
     return out_dict
 


### PR DESCRIPTION
# Description

Addresses #854 by adding unit tests for all the file utility functions instead of relying solely on integration tests.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Ran unit tests

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
