### PR TITLE
TST: test empty load output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 * New Features
   * Added tests for warnings, logging messages, and errors in the Instrument
     clean method.
-  * Added loading test with padding for Instruments.
+  * Added Instrument loading test with padding and for times without data.
   * Allow Instruments to define custom `concat_data` methods.
   * Added `include` kwarg to `Instrument.concat_data` to expand allowed inputs.
   * Added data kwarg to the Instrument class `__getitem__` method and reduced

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -414,6 +414,9 @@ The load module method signature should appear as:
   commmonly specify the data set to be loaded
 - The :py:func:`load` routine should return a tuple with :py:attr:`data` as the
   first element and a :py:class:`pysat.Meta` object as the second element.
+  If there is no data to load, :py:attr:`data` should return an empty
+  :py:class:`pandas.DataFrame` or :py:class:`xarray.Dataset` and :py:attr:`meta`
+  should return an empty :py:class:`pysat.Meta` object.
 - For simple time-series data sets, :py:attr:`data` is a
   :py:class:`pandas.DataFrame`, column names are the data labels, rows are
   indexed by :py:class:`datetime.datetime` objects.

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -15,11 +15,9 @@ platform = 'pysat'
 name = 'ndtesting'
 
 pandas_format = False
-tags = {'': 'Regular testing data set',
-        'no_download': 'simulate an instrument without download support'}
+tags = {'': 'Regular testing data set'}
 inst_ids = {'': [tag for tag in tags.keys()]}
 _test_dates = {'': {tag: dt.datetime(2009, 1, 1) for tag in tags.keys()}}
-_test_download = {'': {'no_download': False}}
 _test_load_opt = {'': {'': [{'num_extra_time_coords': 0},
                             {'num_extra_time_coords': 1}]}}
 
@@ -95,10 +93,6 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
 
     # Support keyword testing
     pysat.logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
-
-    # If no download should be simulated, return empty `data` and `meta` objects
-    if tag == 'no_download':
-        return xr.Dataset(), pysat.Meta()
 
     # Create an artificial satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -15,9 +15,11 @@ platform = 'pysat'
 name = 'ndtesting'
 
 pandas_format = False
-tags = {'': 'Regular testing data set'}
+tags = {'': 'Regular testing data set',
+        'no_download': 'simulate an instrument without download support'}
 inst_ids = {'': [tag for tag in tags.keys()]}
 _test_dates = {'': {tag: dt.datetime(2009, 1, 1) for tag in tags.keys()}}
+_test_download = {'': {'no_download': False}}
 _test_load_opt = {'': {'': [{'num_extra_time_coords': 0},
                             {'num_extra_time_coords': 1}]}}
 
@@ -93,6 +95,10 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
 
     # Support keyword testing
     pysat.logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
+
+    # If no download should be simulated, return empty `data` and `meta` objects
+    if tag == 'no_download':
+        return xr.Dataset(), pysat.Meta()    
 
     # Create an artificial satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -98,7 +98,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
 
     # If no download should be simulated, return empty `data` and `meta` objects
     if tag == 'no_download':
-        return xr.Dataset(), pysat.Meta()    
+        return xr.Dataset(), pysat.Meta()
 
     # Create an artificial satellite data set
     iperiod = mm_test.define_period()

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -93,6 +93,10 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     # Support keyword testing
     pysat.logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
+    # If no download should be simulated, return empty `data` and `meta` objects
+    if tag == 'no_download':
+        return pds.DataFrame(), pysat.Meta()
+
     # Create an artificial satellite data set
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
@@ -172,16 +176,14 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     data.index = index
     data.index.name = 'Epoch'
 
+    # If we only want data and not metadata stop now
+    if tag == 'default_meta':
+        return data, pysat.Meta()
+
     # Set the meta data
     meta = mm_test.initialize_test_meta('Epoch', data.keys())
 
-    # TODO(#1120): Move logic up so that empty data is returned first.
-    if tag == 'default_meta':
-        return data, pysat.Meta()
-    elif tag == 'no_download':
-        return pds.DataFrame(), pysat.Meta()
-    else:
-        return data, meta
+    return data, meta
 
 
 list_files = functools.partial(mm_test.list_files, test_dates=_test_dates)

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -453,8 +453,6 @@ class InstLibTests(object):
         return
 
     @pytest.mark.second
-    # Need to maintain download mark for backwards compatibility.
-    # Can remove once pysat 3.1.0 is released and libraries are updated.
     @pytest.mark.load_options
     def test_load_multiple_days(self, inst_dict):
         """Test that instruments load at each cleaning level.

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -39,6 +39,7 @@ import warnings
 
 import pandas as pds
 import pytest
+import xarray as xr
 
 import pysat
 from pysat.utils import generate_instrument_list
@@ -408,6 +409,39 @@ class InstLibTests(object):
                 assert not test_inst.empty
         else:
             pytest.skip("Download data not available")
+
+        return
+
+    @pytest.mark.second
+    @pytest.mark.load_options
+    def test_load_empty(self, inst_dict):
+        """Test that instruments load empty objects if no data is available.
+
+        Parameters
+        ----------
+        inst_dict : dict
+            Dictionary containing info to instantiate a specific instrument.
+            Set automatically from instruments['download'] when
+            `initialize_test_package` is run.
+
+        """
+
+        # Get the instrument information and update the date to be in the future
+        test_inst, date = initialize_test_inst_and_date(inst_dict)
+        date = dt.datetime(dt.datetime.utcnow().year + 100, 1, 1)
+
+        # Make sure the strict time flag doesn't interfere with the load test
+        load_and_set_strict_time_flag(test_inst, date, raise_error=True)
+
+        # Check the empty status
+        assert test_inst.empty, "Data was loaded for a far-future time"
+        assert test_inst.meta == pysat.Meta(), "Meta data is not empty"
+        if test_inst.pandas_format:
+            assert all(test_inst.data == pds.DataFrame()), "Data not empty"
+        else:
+            assert test_inst.data.dims == xr.Dataset().dims, "Dims not empty"
+            assert test_inst.data.data_vars == xr.Dataset().data_vars, \
+                "Data variables not empty"
 
         return
 


### PR DESCRIPTION
# Description

Addresses #1120 by improving the pysat_testing.py load logic.  Also added a new unit test and expanded the 'no_download' tests to encompass xarray.

## Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)
- Potentially breaking change: tests enforce an expected output for empty data
- This change requires a documentation update

# How Has This Been Tested?

Added new unit tests

**Test Configuration**:
* Operating system: OS X Big Sur
* Version number: Python 3.9
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
