### PR TITLE
ENH: add `_new_tests` to allow instruments to temporarily ignore tests requiring concat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Removed deprecated usage of None for tag and inst_id
   * Removed deprecated kwarg behaviour for 'fname' in `to_netCDF4`
   * Added verion cap for sphinx_rtd_theme
-  * Used line specific noqa statements for imports 
+  * Used line specific noqa statements for imports
+  * Add `_test_new_tests` flag for packages to ignore select new tests
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Removed deprecated kwarg behaviour for 'fname' in `to_netCDF4`
   * Added verion cap for sphinx_rtd_theme
   * Used line specific noqa statements for imports
-  * Add `_test_new_tests` flag for packages to ignore select new tests
+  * Add `_new_tests` flag for packages to ignore select new tests
 
 [3.1.0] - 2023-05-31
 --------------------

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -930,13 +930,13 @@ present. This flag is defaults to :py:val:`False` if not specified.
 Updates to Instrument Suite Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes new standard tests are added to pysat that ensure all data handling features
-work as expected throughout the ecosystem. For example, pysat 3.2.0 adds new tests
-for loading multiple days at a time or using a data pad. When these tests
-require significant updates, an additional flag may be used to suppress these
-tests temporarily for specific instruments while updates are made to that
-instrument. These new tests are run by default unless specified using the
-:py:attr:`_new_tests` flag.
+Sometimes new standard tests are added to pysat that ensure all data handling
+features work as expected throughout the ecosystem. For example, pysat 3.2.0
+adds new tests for loading multiple days at a time or using a data pad. When
+these tests require significant updates, an additional flag may be used to
+suppress these tests temporarily for specific instruments while updates are
+made to that instrument. These new tests are run by default unless specified
+using the :py:attr:`_new_tests` flag.
 
 .. code:: python
 

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -926,3 +926,28 @@ present. This flag is defaults to :py:val:`False` if not specified.
    _test_dates = {'': {'Level_1': dt.datetime(2020, 1, 1),
                        'Level_2': dt.datetime(2020, 1, 1)}}
    _password_req = {'': {'Level_1': True}}
+
+Updates to Instrument Suite Tests
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Sometimes new standard tests are added to pysat that update compliance
+requirements throughout the ecosystem. For example, pysat 3.2.0 adds new tests
+for loading multiple days at a time or using a data pad. When these tests
+require significant updates, an additional flag may be used to suppress these
+tests temporarily for specific instruments while updates are made throughout
+the ecosystem. These new tests are run by default unless specified using the
+:py:attr:`_new_tests` flag.
+
+.. code:: python
+
+   platform = 'newsat'
+   name = 'data'
+   tags = {'Level_1': 'Level 1 data, fully compliant',
+           'Level_2': 'Level 2 data, needs updates for padding'}
+   inst_ids = {'': ['Level_1', 'Level_2']}
+   _test_dates = {'': {'Level_1': dt.datetime(2020, 1, 1),
+                       'Level_2': dt.datetime(2020, 1, 1)}}
+   _new_tests = {'': {'Level_2': False}}
+
+The new tests are marked with a `@pytest.mark.new_tests` statement, and will be
+re-evaluated at each minor version release.

--- a/docs/new_instrument.rst
+++ b/docs/new_instrument.rst
@@ -930,12 +930,12 @@ present. This flag is defaults to :py:val:`False` if not specified.
 Updates to Instrument Suite Tests
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Sometimes new standard tests are added to pysat that update compliance
-requirements throughout the ecosystem. For example, pysat 3.2.0 adds new tests
+Sometimes new standard tests are added to pysat that ensure all data handling features
+work as expected throughout the ecosystem. For example, pysat 3.2.0 adds new tests
 for loading multiple days at a time or using a data pad. When these tests
 require significant updates, an additional flag may be used to suppress these
-tests temporarily for specific instruments while updates are made throughout
-the ecosystem. These new tests are run by default unless specified using the
+tests temporarily for specific instruments while updates are made to that
+instrument. These new tests are run by default unless specified using the
 :py:attr:`_new_tests` flag.
 
 .. code:: python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,6 +86,7 @@ markers = [
   "download",
   "no_download",
   "load_options",
+  "new_tests",
   "first",
   "second"
 ]

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1366,7 +1366,7 @@ class Instrument(object):
             directory_format, file_format, multi_file_day, orbit_info, and
             pandas_format
         test attributes
-            _test_download, _test_download_ci, and _password_req
+            _test_download, _test_download_ci, _test_new_tests, and _password_req
 
         """
         # Declare the standard Instrument methods and attributes
@@ -1378,7 +1378,7 @@ class Instrument(object):
                       'multi_file_day': False, 'orbit_info': None,
                       'pandas_format': True}
         test_attrs = {'_test_download': True, '_test_download_ci': True,
-                      '_password_req': False}
+                      '_test_new_tests': True, '_password_req': False}
 
         # Set method defaults
         for mname in [mm for val in inst_methods.values() for mm in val]:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1372,8 +1372,7 @@ class Instrument(object):
             directory_format, file_format, multi_file_day, orbit_info, and
             pandas_format
         test attributes
-            _test_download, _test_download_ci, _test_new_tests, and
-            _password_req
+            _test_download, _test_download_ci, _new_tests, and _password_req
 
         """
         # Declare the standard Instrument methods and attributes
@@ -1385,7 +1384,7 @@ class Instrument(object):
                       'multi_file_day': False, 'orbit_info': None,
                       'pandas_format': True}
         test_attrs = {'_test_download': True, '_test_download_ci': True,
-                      '_test_new_tests': True, '_password_req': False}
+                      '_new_tests': True, '_password_req': False}
 
         # Set method defaults
         for mname in [mm for val in inst_methods.values() for mm in val]:

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1372,7 +1372,8 @@ class Instrument(object):
             directory_format, file_format, multi_file_day, orbit_info, and
             pandas_format
         test attributes
-            _test_download, _test_download_ci, _test_new_tests, and _password_req
+            _test_download, _test_download_ci, _test_new_tests, and
+            _password_req
 
         """
         # Declare the standard Instrument methods and attributes

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -485,8 +485,7 @@ class InstLibTests(object):
 
         return
 
-    # TODO(v3.3.0): remove mark.new_tests when ecosystem is fully compliant
-    # for this test
+    # TODO(#1172): remove mark.new_tests
     @pytest.mark.second
     @pytest.mark.load_options
     @pytest.mark.new_tests
@@ -624,8 +623,7 @@ class InstLibTests(object):
 
         return
 
-    # TODO(v3.3.0): remove mark.new_tests when ecosystem is fully compliant
-    # for this test
+    # TODO(#1172): remove mark.new_tests at v3.3.0
     @pytest.mark.second
     @pytest.mark.load_options
     @pytest.mark.new_tests

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -260,6 +260,11 @@ class InstLibTests(object):
                     mark = pytest.mark.parametrize("inst_name",
                                                    instruments['names'])
                     getattr(self, method).pytestmark.append(mark)
+                elif 'new_tests' in mark_names:
+                    # Prioritize new test marks if present
+                    mark = pytest.mark.parametrize("inst_dict",
+                                                   instruments['new_tests'])
+                    getattr(self, method).pytestmark.append(mark)
                 elif 'load_options' in mark_names:
                     # Prioritize load_options mark if present
                     mark = pytest.mark.parametrize("inst_dict",
@@ -468,8 +473,11 @@ class InstLibTests(object):
 
         return
 
+    # TODO (v3.3.0): remove mark.new_tests when ecosystem is fully compliant
+    # for this test
     @pytest.mark.second
     @pytest.mark.load_options
+    @pytest.mark.new_tests
     def test_load_multiple_days(self, inst_dict):
         """Test that instruments load at each cleaning level.
 
@@ -604,8 +612,11 @@ class InstLibTests(object):
 
         return
 
+    # TODO (v3.3.0): remove mark.new_tests when ecosystem is fully compliant
+    # for this test
     @pytest.mark.second
     @pytest.mark.load_options
+    @pytest.mark.new_tests
     @pytest.mark.parametrize('pad', [{'days': 1}, dt.timedelta(days=1)])
     def test_load_w_pad(self, pad, inst_dict):
         """Test that instruments load at each cleaning level.

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -473,7 +473,7 @@ class InstLibTests(object):
 
         return
 
-    # TODO (v3.3.0): remove mark.new_tests when ecosystem is fully compliant
+    # TODO(v3.3.0): remove mark.new_tests when ecosystem is fully compliant
     # for this test
     @pytest.mark.second
     @pytest.mark.load_options
@@ -612,7 +612,7 @@ class InstLibTests(object):
 
         return
 
-    # TODO (v3.3.0): remove mark.new_tests when ecosystem is fully compliant
+    # TODO(v3.3.0): remove mark.new_tests when ecosystem is fully compliant
     # for this test
     @pytest.mark.second
     @pytest.mark.load_options

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -485,7 +485,7 @@ class InstLibTests(object):
 
         return
 
-    # TODO(#1172): remove mark.new_tests
+    # TODO(#1172): remove mark.new_tests at v3.3.0
     @pytest.mark.second
     @pytest.mark.load_options
     @pytest.mark.new_tests

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -326,6 +326,7 @@ def generate_instrument_list(inst_loc, user_info=None):
     instrument_download = []
     instrument_optional_load = []
     instrument_no_download = []
+    instrument_new_tests = []
 
     # Look through list of available instrument modules in the given location
     for inst_module in instrument_names:
@@ -374,6 +375,8 @@ def generate_instrument_list(inst_loc, user_info=None):
                         # Check if instrument is configured for download tests.
                         if inst._test_download:
                             instrument_download.append(in_dict.copy())
+                            if inst._test_new_tests:
+                                instrument_new_tests.append(in_dict.copy())
                             if hasattr(module, '_test_load_opt'):
                                 # Add optional load tests
                                 try:
@@ -385,6 +388,10 @@ def generate_instrument_list(inst_loc, user_info=None):
                                         # Append as copy so kwargs are unique.
                                         instrument_optional_load.append(
                                             in_dict.copy())
+                                        if inst._test_new_tests:
+                                            instrument_new_tests.append(
+                                                in_dict.copy())
+
                                 except KeyError:
                                     # Option does not exist for tag/inst_id
                                     # combo
@@ -400,7 +407,8 @@ def generate_instrument_list(inst_loc, user_info=None):
     output = {'names': instrument_names,
               'download': instrument_download,
               'load_options': instrument_download + instrument_optional_load,
-              'no_download': instrument_no_download}
+              'no_download': instrument_no_download,
+              'new_tests': instrument_new_tests}
 
     return output
 

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -379,7 +379,7 @@ def generate_instrument_list(inst_loc, user_info=None):
                         # Check if instrument is configured for download tests.
                         if inst._test_download:
                             instrument_download.append(in_dict.copy())
-                            if inst._test_new_tests:
+                            if inst._new_tests:
                                 instrument_new_tests.append(in_dict.copy())
                             if hasattr(module, '_test_load_opt'):
                                 # Add optional load tests
@@ -392,7 +392,7 @@ def generate_instrument_list(inst_loc, user_info=None):
                                         # Append as copy so kwargs are unique.
                                         instrument_optional_load.append(
                                             in_dict.copy())
-                                        if inst._test_new_tests:
+                                        if inst._new_tests:
                                             instrument_new_tests.append(
                                                 in_dict.copy())
 


### PR DESCRIPTION
# Description

Many of the files across the ecosystem require significant updates to run the new tests. This adds a new testing flag, specifically for `test_load_multiple_days` and `test_load_w_pad`. By default, this is set to `True`, but instruments may set it to `False` for known failures that are documented in the issues. This allows the testing suite to run while instrument modules are updated. TODO statements are tied to the next version release. 

Down the line, this could be used for other new standard instrument tests that require significant upgrades throughout the ecosystem.

## Type of change

- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

pytest on the `pysatNASA` branch [here](https://github.com/pysat/pysatNASA/pull/223)
pytest on the `pysatModels` branch [here](https://github.com/pysat/pysatModels/pull/138)

Also, manual inspection such as:
```
# Import the test classes from pysat
import pysat
from pysat.tests.classes import cls_instrument_library as clslib

import pysatModels
import pysatNASA

# Retrieve the lists of instruments and testing methods
instruments = clslib.InstLibTests.initialize_test_package(
    clslib.InstLibTests, inst_loc=pysatNASA.instruments)

models = clslib.InstLibTests.initialize_test_package(
    clslib.InstLibTests, inst_loc=pysatModels.models)
```
In this case, `models['new_tests']` should be an empty list since all the instruments have the new flag set to `False`. `instruments['new_tests']` should have 110 items (12 less than `instruments['load_options']`). Ignored should be the cnofs plp, maven insitu kp, icon euv, and timed guvi sdr instruments.

**Test Configuration**:
* Operating system: Ventura
* Version number: Python 3.10.9
* Usage of a branch with a package that uses the flags appropriately.

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
