### PR TITLE
ENH/BUG: Filename fix for #1173

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Added test for loading multiple days of data.
 * Bug Fix
   * Fixed `utils.files.parse_fixed_width_filenames` output for empty file list
+  * Updated the parsing functions in `utils.files` to consider type specifiers
+    when identifying appropriate files in a directory
 * Maintenance
   * Update link redirects in docs.
   * Improved Instrument ValueError messages.

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -507,7 +507,7 @@ class InstLibTests(object):
                 # Make sure the strict time flag doesn't interfere with
                 # the load tests, and re-run with desired clean level
                 load_and_set_strict_time_flag(self.test_inst, self.date,
-                                              raise_error=True, clean_off=False,
+                                              raise_error=True, clean_off=True,
                                               set_end_date=True)
 
                 # Make sure more than one day has been loaded

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -241,6 +241,40 @@ class TestParseFilenames(object):
         self.eval_parsed_filenames()
         return
 
+    @pytest.mark.parametrize("is_fixed", [True, False])
+    def test_parse_filenames_all_bad(self, is_fixed):
+        """Test files with a bad format are removed from consideration.
+
+        Parameters
+        ----------
+        is_fixed : bool
+            True for the fixed-width function, false for delimted.
+
+        """
+
+        # Format the test input
+        format_str = 'bad_test_{:s}.cdf'.format("_".join(
+            [self.kw_format[fkey] for fkey in self.fkwargs[0].keys()]))
+        bad_format = format_str.replace('revision:02d', 'revision:2s')
+        
+        # Create the input file list
+        file_list = []
+        for kwargs in self.fkwargs:
+            kwargs['revision'] = 'aa'
+            file_list.append(bad_format.format(**kwargs))
+
+        # Get the test results
+        if is_fixed:
+            self.file_dict = futils.parse_fixed_width_filenames(file_list,
+                                                                format_str)
+        else:
+            self.file_dict = futils.parse_delimited_filenames(file_list,
+                                                              format_str, "_")
+
+        # Test that all files were removed
+        assert len(self.file_dict['files']) == 0
+        return
+
     def test_parse_delimited_filename_empty(self):
         """Check ability to parse list of delimited files with no files."""
         # Format the test input

--- a/pysat/tests/test_utils_files.py
+++ b/pysat/tests/test_utils_files.py
@@ -256,7 +256,7 @@ class TestParseFilenames(object):
         format_str = 'bad_test_{:s}.cdf'.format("_".join(
             [self.kw_format[fkey] for fkey in self.fkwargs[0].keys()]))
         bad_format = format_str.replace('revision:02d', 'revision:2s')
-        
+
         # Create the input file list
         file_list = []
         for kwargs in self.fkwargs:

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -5,7 +5,6 @@
 #
 # DISTRIBUTION STATEMENT A: Approved for public release. Distribution is
 # unlimited.
-# This work was supported by the Office of Naval Research.
 # ----------------------------------------------------------------------------
 """Tests the pysat utility io routines."""
 import copy

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -90,7 +90,7 @@ def _init_parse_filenames(files, format_str):
     return stored, search_dict
 
 
-def _finish_parse_filenames(stored, files, format_str):
+def _finish_parse_filenames(stored, files, format_str, bad_files):
     """Reshape and finalize the output for the file parsing functions.
 
     Parameters
@@ -110,6 +110,9 @@ def _finish_parse_filenames(stored, files, format_str):
         and 'cycle' will be used for time and sorting information. For example,
         `instrument-{year:4d}_{month:02d}-{day:02d}_v{version:02d}.cdf`, or
         `*-{year:4d}_{month:02d}hithere{day:02d}_v{version:02d}.cdf`
+    bad_files : list
+        List of indices for files with names that do not fit the requested
+        format, or an empty list if all are good.
 
     Returns
     -------
@@ -125,20 +128,25 @@ def _finish_parse_filenames(stored, files, format_str):
     pysat.utils.files.parse_delimited_filenames
 
     """
-
+    # Change the bad file index list to a good file index list
+    good_files = [i for i in range(len(files)) if i not in bad_files]
+    
     # Convert to numpy arrays
     for key in stored.keys():
         if stored[key] is not None:
-            try:
-                # Assume key value is numeric integer
-                stored[key] = np.array(stored[key]).astype(np.int64)
-            except ValueError:
-                # Store key value as string
-                stored[key] = np.array(stored[key])
+            # Get the data type
+            dtype = type(stored[key][0])
+
+            # Cast the good data as an array of the desired type and select
+            # only the values with good files
+            stored[key] = np.array(stored[key])[good_files].astype(dtype)
 
     # Include files and file format in output
-    stored['files'] = files
     stored['format_str'] = format_str
+    if len(bad_files) == 0:
+        stored['files'] = files
+    else:
+        stored['files'] = list(np.array(files)[good_files])
 
     return stored
 
@@ -313,6 +321,7 @@ def parse_fixed_width_filenames(files, format_str):
                    np.array(end_key, dtype=np.int64) - max_len]
 
     # Need to parse out dates for datetime index
+    bad_files = []
     for i, temp in enumerate(files):
         for j, key in enumerate(search_dict['keys']):
             if key_str_idx[1][j] == 0:
@@ -323,7 +332,11 @@ def parse_fixed_width_filenames(files, format_str):
 
             # Cast the data value, if possible
             if search_dict['type'][j] is not None:
-                val = search_dict['type'][j](val)
+                try:
+                    val = search_dict['type'][j](val)
+                except ValueError:
+                    # The type is wrong, exclude this file
+                    bad_files.append(i)
 
             # Save the parsed variable for this key and file
             if stored[key] is None:
@@ -331,10 +344,8 @@ def parse_fixed_width_filenames(files, format_str):
             else:
                 stored[key].append(val)
 
-    raise RuntimeError('hi')
-
     # Convert to numpy arrays and add additional information to output
-    stored = _finish_parse_filenames(stored, files, format_str)
+    stored = _finish_parse_filenames(stored, files, format_str, bad_files)
 
     return stored
 
@@ -433,6 +444,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
         if stored[key] is None:
             stored[key] = []
 
+    bad_files = list()
     for temp in files:
         split_name = temp.split(delimiter)
         idx = 0
@@ -445,6 +457,15 @@ def parse_delimited_filenames(files, format_str, delimiter):
                     val = loop_sname[sidx:sidx + search_dict['lengths'][idx]]
                     loop_sname = loop_sname[sidx + search_dict['lengths'][idx]:]
 
+                    # Cast the value as the desired data type, if not possible
+                    # identify a bad file
+                    if search_dict['type'][j] is not None:
+                        try:
+                            val = search_dict['type'][j](val)
+                        except ValueError:
+                            # The type is wrong, exclude this file
+                            bad_files.append(i)
+
                     # Store parsed info and increment key index
                     stored[search_dict['keys'][idx]].append(val)
                     idx += 1
@@ -455,7 +476,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
                     break
 
     # Convert to numpy arrays and add additional information to output
-    stored = _finish_parse_filenames(stored, files, format_str)
+    stored = _finish_parse_filenames(stored, files, format_str, bad_files)
 
     return stored
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -459,7 +459,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
 
                     # Cast the value as the desired data type, if not possible
                     # identify a bad file
-                    if search_dict['type'][j] is not None:
+                    if search_dict['type'][idx] is not None:
                         try:
                             val = search_dict['type'][idx](val)
                         except ValueError:

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -445,7 +445,7 @@ def parse_delimited_filenames(files, format_str, delimiter):
             stored[key] = []
 
     bad_files = list()
-    for temp in files:
+    for ifile, temp in enumerate(files):
         split_name = temp.split(delimiter)
         idx = 0
         loop_split_idx = split_idx
@@ -461,10 +461,10 @@ def parse_delimited_filenames(files, format_str, delimiter):
                     # identify a bad file
                     if search_dict['type'][j] is not None:
                         try:
-                            val = search_dict['type'][j](val)
+                            val = search_dict['type'][idx](val)
                         except ValueError:
                             # The type is wrong, exclude this file
-                            bad_files.append(i)
+                            bad_files.append(ifile)
 
                     # Store parsed info and increment key index
                     stored[search_dict['keys'][idx]].append(val)

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -525,6 +525,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
 
     This is the first function employed by `pysat.Files.from_os`.
 
+    If no type is supplied for datetime parameters, int will be used.
+
     """
 
     out_dict = {'search_string': '', 'keys': [], 'type': [], 'lengths': [],
@@ -533,6 +535,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                  'o': np.int64, 'e': np.float64, 'E': np.float64,
                  'f': np.float64, 'F': np.float64, 'g': np.float64,
                  'G': np.float64}
+    int_keys = ['year', 'month', 'day', 'hour', 'minute', 'second',
+                'microsecond']
 
     if format_str is None:
         raise ValueError("Must supply a filename template (format_str).")
@@ -557,6 +561,8 @@ def construct_searchstring_from_format(format_str, wildcard=False):
                 snip_type = snip[2][-1]
                 if snip_type in type_dict.keys():
                     out_dict['type'].append(type_dict[snip_type])
+                elif snip[1] in int_keys:
+                    out_dict['type'].append(np.int64)
                 else:
                     out_dict['type'].append(None)
 

--- a/pysat/utils/files.py
+++ b/pysat/utils/files.py
@@ -130,7 +130,7 @@ def _finish_parse_filenames(stored, files, format_str, bad_files):
     """
     # Change the bad file index list to a good file index list
     good_files = [i for i in range(len(files)) if i not in bad_files]
-    
+
     # Convert to numpy arrays
     for key in stored.keys():
         if stored[key] is not None:


### PR DESCRIPTION
# Description

Addresses #1173 by introducing consideration of supplied type when parsing filename formats.

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)
- This change requires a documentation update

# How Has This Been Tested?

Ran using a modified example from the test case: 
```
import pysat
files = ["jro20230417drifts.001.hdf5”, “jro20230417drifts.txt.hdf5"]
format_str = "jro{year:04d}{month:02d}{day:02d}drifts.{version:03d}.hdf5"
pysat.utils.files.parse_fixed_width_filenames(files, format_str)
```
The output should not have the second file in `files` as a viable output file.

**Test Configuration**:
* Operating system: OS X. Big Sur
* Version number: Python 3.8
* Any details about your local setup that are relevant

# Checklist:

- [N/A] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
