### PR TITLE
MAINT: github actions, remove pandas cap, update NEP29

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,9 +17,9 @@ jobs:
 
     name: Documentation tests
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -30,9 +30,9 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }} with numpy ${{ matrix.numpy_ver }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,13 +12,13 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-latest", "windows-latest", "macos-latest"]
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:
           # NEP29 compliance settings
           - python-version: "3.9"
-            numpy_ver: "1.21"
+            numpy_ver: "1.23"
             os: ubuntu-latest
             test_config: "NEP29"
           # Operational compliance settings

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -18,9 +18,9 @@ jobs:
     name: Python ${{ matrix.python-version }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -18,9 +18,9 @@ jobs:
 
     name: Summary of instrument libraries
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
-[3.2.0] - 2023-xx-xx
+[3.2.0] - 2024-02-xx
 --------------------
 * New Features
   * Added tests for warnings, logging messages, and errors in the Instrument
@@ -39,7 +39,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Implement pyproject to manage metadata
   * Updated docstring references to `pysat.utils.files` in other modules.
   * Remove Sphinx cap
-  * Add pandas cap
   * Update usage of whitespace and if statements (E275)
   * Remove hacking cap
   * Removed deprecated `pysat_testing2d` instrument

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Space Physics community.  This module officially supports Python 3.X+.
 | -------------- | ----------------- |
 | dask           | netCDF4           |
 | numpy >= 1.12  |                   |
-| pandas < 2.1.1 |                   |
+| pandas         |                   |
 | portalocker    |                   |
 | pytest         |                   |
 | scipy          |                   |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
   "dask",
   "netCDF4",
   "numpy >= 1.12",
-  "pandas < 2.1.1",
+  "pandas",
   "portalocker",
   "pytest",
   "scipy",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 dask
 netCDF4
 numpy>=1.12
-pandas<2.1.1
+pandas
 portalocker
 pytest
 scipy


### PR DESCRIPTION
# Description

Closes #1142 

Pandas has released updates that runs again on github actions. 
- Removes the cap
- Updates versions for github actions to remain compliant
- Updates NEP29 minimum versions to test.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via github actions


# Checklist:

- [rc] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
