### PR TITLE
MAINT: tidy tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,7 +60,7 @@ test = [
   "flake8",
   "flake8-docstrings",
   "hacking >= 1.0",
-  "pysatSpaceWeather",
+  "pysatSpaceWeather<0.1.0",
   "pytest-cov",
   "pytest-ordering"
 ]

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -210,13 +210,14 @@ class InstLibTests(object):
         """Initialize parameters before each method."""
         self.test_inst = None
         self.date = None
+        self.module = None
 
         return
 
     def teardown_method(self):
         """Clean up any instruments that were initialized."""
 
-        del self.test_inst, self.date
+        del self.test_inst, self.date, self.module
 
         return
 
@@ -302,35 +303,36 @@ class InstLibTests(object):
         """
 
         # Ensure that each module is at minimum importable
-        module = import_module(''.join(('.', inst_name)),
-                               package=self.inst_loc.__name__)
+        self.module = import_module(''.join(('.', inst_name)),
+                                    package=self.inst_loc.__name__)
 
         # Check for presence of basic instrument module attributes
         for mattr in self.module_attrs:
-            testing.assert_hasattr(module, mattr)
+            testing.assert_hasattr(self.module, mattr)
             if mattr in self.attr_types.keys():
-                testing.assert_isinstance(getattr(module, mattr),
+                testing.assert_isinstance(getattr(self.module, mattr),
                                           self.attr_types[mattr])
 
         # Check for presence of required instrument attributes
-        for inst_id in module.inst_ids.keys():
-            for tag in module.inst_ids[inst_id]:
-                inst = pysat.Instrument(inst_module=module, tag=tag,
-                                        inst_id=inst_id)
+        for inst_id in self.module.inst_ids.keys():
+            for tag in self.module.inst_ids[inst_id]:
+                self.test_inst = pysat.Instrument(inst_module=self.module,
+                                                  tag=tag, inst_id=inst_id)
 
                 # Test to see that the class parameters were passed in
-                testing.assert_isinstance(inst, pysat.Instrument)
-                assert inst.platform == module.platform
-                assert inst.name == module.name
-                assert inst.inst_id == inst_id
-                assert inst.tag == tag
-                assert inst.inst_module is not None
+                testing.assert_isinstance(self.test_inst, pysat.Instrument)
+                assert self.test_inst.platform == self.module.platform
+                assert self.test_inst.name == self.module.name
+                assert self.test_inst.inst_id == inst_id
+                assert self.test_inst.tag == tag
+                assert self.test_inst.inst_module is not None
 
                 # Test the required class attributes
                 for iattr in self.inst_attrs:
-                    testing.assert_hasattr(inst, iattr)
+                    testing.assert_hasattr(self.test_inst, iattr)
                     if iattr in self.attr_types:
-                        testing.assert_isinstance(getattr(inst, iattr),
+                        testing.assert_isinstance(getattr(self.test_inst,
+                                                          iattr),
                                                   self.attr_types[iattr])
         return
 
@@ -346,14 +348,14 @@ class InstLibTests(object):
 
         """
 
-        module = import_module(''.join(('.', inst_name)),
-                               package=self.inst_loc.__name__)
+        self.module = import_module(''.join(('.', inst_name)),
+                                    package=self.inst_loc.__name__)
 
         # Test for presence of all standard module functions
         for mcall in self.inst_callable:
-            if hasattr(module, mcall):
+            if hasattr(self.module, mcall):
                 # If present, must be a callable function
-                assert callable(getattr(module, mcall))
+                assert callable(getattr(self.module, mcall))
             else:
                 # If absent, must not be a required function
                 assert mcall not in self.module_attrs
@@ -371,9 +373,9 @@ class InstLibTests(object):
 
         """
 
-        module = import_module(''.join(('.', inst_name)),
-                               package=self.inst_loc.__name__)
-        info = module._test_dates
+        self.module = import_module(''.join(('.', inst_name)),
+                                    package=self.inst_loc.__name__)
+        info = self.module._test_dates
         for inst_id in info.keys():
             for tag in info[inst_id].keys():
                 testing.assert_isinstance(info[inst_id][tag], dt.datetime)
@@ -744,10 +746,10 @@ class InstLibTests(object):
 
         """
 
-        test_inst, self.date = initialize_test_inst_and_date(inst_dict)
+        self.test_inst, self.date = initialize_test_inst_and_date(inst_dict)
 
         with warnings.catch_warnings(record=True) as war:
-            test_inst.download(self.date, self.date)
+            self.test_inst.download(self.date, self.date)
 
         assert len(war) >= 1
         categories = [war[j].category for j in range(0, len(war))]

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -221,13 +221,9 @@ def freq_to_res(freq):
     --------
     pds.offsets.DateOffset
 
-    References
-    ----------
-    Separating alpha and numeric portions of strings, as described in:
-    https://stackoverflow.com/a/12409995
-
     """
-    # Separate the alpha and numeric portions of the string
+    # Separate the alpha and numeric portions of the string as described in:
+    # https://stackoverflow.com/a/12409995
     regex = re.compile(r'(\d+|\s+)')
     out_str = [sval for sval in regex.split(freq) if len(sval) > 0]
 

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -5,7 +5,7 @@ hacking>=1.0
 ipython
 m2r2
 numpydoc
-pysatSpaceWeather
+pysatSpaceWeather<0.1.0
 pytest-cov
 pytest-ordering
 readthedocs-sphinx-search==0.3.2


### PR DESCRIPTION
# Description

Not all the testing suite methods clean up after themselves. Found during troubleshooting for pysatCDAAC.

Other minor tweaks to get check marks up and running:
- Version cap for pysatSpaceWeather. The 0.1.0 release is breaking tests for mac. This is only used to support certain tests. Since this is on the scope to remove as a dependency when new functions are added (#779), version cap is the path forward.
- Moved a link to comments to satisfy the Sphinx. 🦁 

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

running against pysatMissions.

**Test Configuration**:
* Operating system: Ventura 13.6.2
* Version number: Python 3.10.9
* Any details about your local setup that are relevant

# Checklist:

- [rc] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes

If this is a release PR, replace the first item of the above checklist with the release
checklist on the wiki: https://github.com/pysat/pysat/wiki/Checklist-for-Release
