### PR TITLE
MAINT: FutureWarnings for datetime, pandas, xarray

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 --------------------
 * Maintenance
   * Update usage of `dims` to be consistent with future versions of `xarray`
-  * Update frequency strings for pandas
+  * Update frequency strings for `pandas`
+  * Update usage of getitem for `pds.Series`
   * Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.UTC)`
 
 [3.2.0] - 2024-03-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[3.2.1] - 2024-XX-XX
+--------------------
+* Maintenance
+  * Update usage of `dims` to be consistent with future versions of `xarray`
+  * Update frequency strings for pandas
+  * Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.UTC)`
+
 [3.2.0] - 2024-03-27
 --------------------
 * New Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Update usage of `dims` to be consistent with future versions of `xarray`
   * Update frequency strings for `pandas`
   * Update usage of getitem for `pds.Series`
-  * Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.UTC)`
+  * Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.timezone.utc)`
 
 [3.2.0] - 2024-03-27
 --------------------

--- a/docs/examples/example_orbit.rst
+++ b/docs/examples/example_orbit.rst
@@ -55,7 +55,7 @@ the pysat repository at ``demo/cnofs_vefi_dc_b_orbit_plots.py``.
        # pandas documentation for more information about the `resample` mtehod.
        # The 1-s cadence was chosen because it is the nominal cadence for this
        # instrument.
-       vefi.data = vefi.data.resample('1S', label='left').ffill(limit=1)
+       vefi.data = vefi.data.resample('1s', label='left').ffill(limit=1)
 
        # Create a figure with seven subplots
        fig, ax = plt.subplots(7, sharex=True, figsize=(8.5, 11))

--- a/pysat/_constellation.py
+++ b/pysat/_constellation.py
@@ -745,7 +745,7 @@ class Constellation(object):
             # Get the common coordinates needed for all data
             for cinst in self.instruments:
                 if not cinst.pandas_format:
-                    for new_coord in cinst.data.dims.keys():
+                    for new_coord in cinst.data.sizes.keys():
                         if new_coord in cinst.data.coords.keys():
                             if new_coord not in coords.keys():
                                 coords[new_coord] = cinst.data.coords[new_coord]

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -1696,9 +1696,9 @@ class Instrument(object):
                                        date.strftime('%d %B %Y')))
             else:
                 output_str = ' '.join(('Returning', output_str, 'data from',
-                                       fname[0]))
+                                       fname.iloc[0]))
                 if len(fname) > 1:
-                    output_str = ' '.join((output_str, '::', fname[-1]))
+                    output_str = ' '.join((output_str, '::', fname.iloc[-1]))
         else:
             # There was no data signal
             if date is not None:
@@ -3675,8 +3675,8 @@ class Instrument(object):
                     dsel2 = slice(last_date, last_date
                                   + dt.timedelta(hours=23, minutes=59,
                                                  seconds=59))
-                    if all([curr_bound[0][0] == self.files[dsel1][0],
-                            curr_bound[1][0] == self.files[dsel2][-1]]):
+                    if all([curr_bound[0][0] == self.files[dsel1].iloc[0],
+                            curr_bound[1][0] == self.files[dsel2].iloc[-1]]):
                         pysat.logger.info(' '.join(('Updating instrument',
                                                     'object bounds by file')))
                         dsel1 = slice(self.files.start_date,
@@ -3686,8 +3686,8 @@ class Instrument(object):
                         dsel2 = slice(self.files.stop_date, self.files.stop_date
                                       + dt.timedelta(hours=23, minutes=59,
                                                      seconds=59))
-                        self.bounds = (self.files[dsel1][0],
-                                       self.files[dsel2][-1],
+                        self.bounds = (self.files[dsel1].iloc[0],
+                                       self.files[dsel2].iloc[-1],
                                        curr_bound[2], curr_bound[3])
         else:
             pysat.logger.warning('Requested download over an empty date range.')

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2385,7 +2385,7 @@ class Instrument(object):
                 equal_dims = True
                 idat = 0
                 while idat < len(new_data) - 1 and equal_dims:
-                    if new_data[idat].dims != new_data[idat + 1].dims:
+                    if new_data[idat].sizes != new_data[idat + 1].sizes:
                         equal_dims = False
                     idat += 1
 

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -533,9 +533,9 @@ class Orbits(object):
         # the time difference between orbits (not individual orbits)
         orbit_ut_diff = ut_vals[ind].diff()
         if not self.inst.pandas_format:
-            orbit_lt_diff = self.inst[self.orbit_index].to_pandas()[ind].diff()
+            orbit_lt_diff = self.inst[self.orbit_index].to_pandas().iloc[ind].diff()
         else:
-            orbit_lt_diff = self.inst[self.orbit_index][ind].diff()
+            orbit_lt_diff = self.inst[self.orbit_index].iloc[ind].diff()
 
         # Look for time gaps between partial orbits. The full orbital time
         # period is not required between end of one orbit and beginning of next

--- a/pysat/_orbits.py
+++ b/pysat/_orbits.py
@@ -533,7 +533,8 @@ class Orbits(object):
         # the time difference between orbits (not individual orbits)
         orbit_ut_diff = ut_vals[ind].diff()
         if not self.inst.pandas_format:
-            orbit_lt_diff = self.inst[self.orbit_index].to_pandas().iloc[ind].diff()
+            orbit_lt_diff = self.inst[
+                self.orbit_index].to_pandas().iloc[ind].diff()
         else:
             orbit_lt_diff = self.inst[self.orbit_index].iloc[ind].diff()
 

--- a/pysat/instruments/methods/testing.py
+++ b/pysat/instruments/methods/testing.py
@@ -525,7 +525,7 @@ def generate_fake_data(t0, num_array, period=5820, data_range=[0.0, 24.0],
     return data
 
 
-def generate_times(fnames, num, freq='1S', start_time=None):
+def generate_times(fnames, num, freq='1s', start_time=None):
     """Construct list of times for simulated instruments.
 
     Parameters
@@ -537,7 +537,7 @@ def generate_times(fnames, num, freq='1S', start_time=None):
         current day.
     freq : str
         Frequency of temporal output, compatible with pandas.date_range
-        [default : '1S']
+        (default='1s')
     start_time : dt.timedelta or NoneType
         Offset time of start time in fractional hours since midnight UT.
         If None, set to 0.

--- a/pysat/instruments/pysat_ndtesting.py
+++ b/pysat/instruments/pysat_ndtesting.py
@@ -45,7 +45,7 @@ preprocess = mm_test.preprocess
 def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
          sim_multi_file_left=False, root_date=None, non_monotonic_index=False,
          non_unique_index=False, start_time=None, num_samples=864,
-         sample_rate='100S', test_load_kwarg=None, max_latitude=90.0,
+         sample_rate='100s', test_load_kwarg=None, max_latitude=90.0,
          num_extra_time_coords=0):
     """Load the test files.
 

--- a/pysat/instruments/pysat_testing.py
+++ b/pysat/instruments/pysat_testing.py
@@ -109,7 +109,7 @@ def load(fnames, tag='', inst_id='', sim_multi_file_right=False,
     iperiod = mm_test.define_period()
     drange = mm_test.define_range()
 
-    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='1S',
+    uts, index, dates = mm_test.generate_times(fnames, num_samples, freq='1s',
                                                start_time=start_time)
 
     # Specify the date tag locally and determine the desired date range

--- a/pysat/instruments/pysat_testmodel.py
+++ b/pysat/instruments/pysat_testmodel.py
@@ -75,7 +75,7 @@ def load(fnames, tag='', inst_id='', start_time=None, num_samples=96,
     pysat.logger.info(''.join(('test_load_kwarg = ', str(test_load_kwarg))))
 
     # Create an artificial model data set
-    freq_str = '900S' if tag == '' else '1H'
+    freq_str = '900s' if tag == '' else '1h'
     uts, index, dates = mm_test.generate_times(fnames, num_samples,
                                                freq=freq_str,
                                                start_time=start_time)

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -777,7 +777,7 @@ class InstAccessTests(object):
 
         self.testInst.load(self.ref_time.year, self.ref_doy)
         assert np.all(self.testInst[index, 'mlt']
-                      == self.testInst.data['mlt'][index])
+                      == self.testInst.data['mlt'].iloc[index])
         return
 
     def test_data_access_by_row_slicing(self):

--- a/pysat/tests/classes/cls_instrument_access.py
+++ b/pysat/tests/classes/cls_instrument_access.py
@@ -776,8 +776,12 @@ class InstAccessTests(object):
         """
 
         self.testInst.load(self.ref_time.year, self.ref_doy)
-        assert np.all(self.testInst[index, 'mlt']
-                      == self.testInst.data['mlt'].iloc[index])
+        if self.testInst.pandas_format:
+            assert np.all(self.testInst[index, 'mlt']
+                          == self.testInst.data['mlt'].iloc[index])
+        else:
+            assert np.all(self.testInst[index, 'mlt']
+                          == self.testInst.data['mlt'][index])
         return
 
     def test_data_access_by_row_slicing(self):

--- a/pysat/tests/classes/cls_instrument_iteration.py
+++ b/pysat/tests/classes/cls_instrument_iteration.py
@@ -79,7 +79,7 @@ class InstIterationTests(object):
 
         if inds is not None:
             for i in inds:
-                fnames.append(self.testInst.files.files[i])
+                fnames.append(self.testInst.files.files.iloc[i])
                 ftimes.append(filter_datetime_input(pds.to_datetime(
                     self.testInst.files.files.index[i]).to_pydatetime()))
 

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -467,7 +467,7 @@ class InstLibTests(object):
 
         # Get the instrument information and update the date to be in the future
         self.test_inst, self.date = initialize_test_inst_and_date(inst_dict)
-        self.date = dt.datetime(dt.datetime.utcnow().year + 100, 1, 1)
+        self.date = dt.datetime(dt.datetime.now(dt.UTC).year + 100, 1, 1)
 
         # Make sure the strict time flag doesn't interfere with the load test
         load_and_set_strict_time_flag(self.test_inst, self.date,

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -467,7 +467,8 @@ class InstLibTests(object):
 
         # Get the instrument information and update the date to be in the future
         self.test_inst, self.date = initialize_test_inst_and_date(inst_dict)
-        self.date = dt.datetime(dt.datetime.now(dt.UTC).year + 100, 1, 1)
+        self.date = dt.datetime(dt.datetime.now(dt.timezone.utc).year + 100,
+                                1, 1)
 
         # Make sure the strict time flag doesn't interfere with the load test
         load_and_set_strict_time_flag(self.test_inst, self.date,

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -315,7 +315,7 @@ class InstPropertyTests(object):
     def test_today_yesterday_and_tomorrow(self):
         """Test the correct instantiation of yesterday/today/tomorrow dates."""
 
-        self.ref_time = dt.datetime.now(dt.UTC)
+        self.ref_time = dt.datetime.now(dt.timezone.utc)
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         assert self.out == self.testInst.today()
@@ -326,7 +326,7 @@ class InstPropertyTests(object):
     def test_filtered_date_attribute(self):
         """Test use of filter during date assignment."""
 
-        self.ref_time = dt.datetime.now(dt.UTC)
+        self.ref_time = dt.datetime.now(dt.timezone.utc)
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         self.testInst.date = self.ref_time

--- a/pysat/tests/classes/cls_instrument_property.py
+++ b/pysat/tests/classes/cls_instrument_property.py
@@ -315,7 +315,7 @@ class InstPropertyTests(object):
     def test_today_yesterday_and_tomorrow(self):
         """Test the correct instantiation of yesterday/today/tomorrow dates."""
 
-        self.ref_time = dt.datetime.utcnow()
+        self.ref_time = dt.datetime.now(dt.UTC)
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         assert self.out == self.testInst.today()
@@ -326,7 +326,7 @@ class InstPropertyTests(object):
     def test_filtered_date_attribute(self):
         """Test use of filter during date assignment."""
 
-        self.ref_time = dt.datetime.utcnow()
+        self.ref_time = dt.datetime.now(dt.UTC)
         self.out = dt.datetime(self.ref_time.year, self.ref_time.month,
                                self.ref_time.day)
         self.testInst.date = self.ref_time

--- a/pysat/tests/test_constellation.py
+++ b/pysat/tests/test_constellation.py
@@ -477,7 +477,7 @@ class TestConstellationFunc(object):
                        for iname in self.const.names])
 
         # Test the output instrument data
-        testing.assert_lists_equal(self.dims, list(out_inst.data.dims.keys()))
+        testing.assert_lists_equal(self.dims, list(out_inst.data.sizes.keys()))
         testing.assert_list_contains(self.dims,
                                      list(out_inst.data.coords.keys()))
 

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -241,7 +241,7 @@ class TestBasicsNDXarray(TestBasics):
                                            self.ref_time + dt.timedelta(days=2)]
         assert not self.testInst.empty
         assert len(self.testInst.index) == 0
-        for dim in self.testInst.data.dims.keys():
+        for dim in self.testInst.data.dims:
             if dim != 'time':
                 assert len(self.testInst[dim]) > 0
         return

--- a/pysat/tests/test_instrument.py
+++ b/pysat/tests/test_instrument.py
@@ -148,7 +148,7 @@ class TestInstYearlyCadence(TestInstCadence):
 
         reload(pysat.instruments.pysat_testing)
         self.ref_time = pysat.instruments.pysat_testing._test_dates['']['']
-        self.freq = 'AS'
+        self.freq = 'YS'
 
         # Since these are yearly files, use a longer date range
         date_range = pds.date_range(self.ref_time - pds.DateOffset(years=1),

--- a/pysat/tests/test_instrument_padding.py
+++ b/pysat/tests/test_instrument_padding.py
@@ -126,7 +126,7 @@ class TestDataPaddingbyFile(object):
 
         self.testInst.load(fname=self.testInst.files[1], verifyPad=True)
         self.delta = pds.date_range(self.testInst.index[0],
-                                    self.testInst.index[-1], freq='S')
+                                    self.testInst.index[-1], freq='s')
         assert np.all(self.testInst.index == self.delta)
         return
 
@@ -441,7 +441,7 @@ class TestDataPadding(object):
         self.ref_doy = 1
         self.testInst.load(self.ref_time.year, self.ref_doy, verifyPad=True)
         test_index = pds.date_range(self.testInst.index[0],
-                                    self.testInst.index[-1], freq='S')
+                                    self.testInst.index[-1], freq='s')
         assert (np.all(self.testInst.index == test_index))
         return
 

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -77,7 +77,10 @@ class TestInstruments(InstLibTests):
 
         self.test_inst.load(date=date)
 
-        assert self.test_inst['uts'].iloc[0] == output
+        if self.test_inst.pandas_format:
+            assert self.test_inst['uts'].iloc[0] == output
+        else:
+            assert self.test_inst['uts'][0] == output
         return
 
     @pytest.mark.parametrize("inst_dict", instruments['download'])

--- a/pysat/tests/test_instruments.py
+++ b/pysat/tests/test_instruments.py
@@ -77,7 +77,7 @@ class TestInstruments(InstLibTests):
 
         self.test_inst.load(date=date)
 
-        assert self.test_inst['uts'][0] == output
+        assert self.test_inst['uts'].iloc[0] == output
         return
 
     @pytest.mark.parametrize("inst_dict", instruments['download'])

--- a/pysat/tests/test_methods_testing.py
+++ b/pysat/tests/test_methods_testing.py
@@ -59,7 +59,7 @@ class TestMethodsTesting(object):
                                     'freq': '10s'},
                                [3600.0, 3690.0]),
                               (87000, {}, [0.0, 86399.0]),
-                              (10, {'freq': '10mS'}, [0.0, 0.09])])
+                              (10, {'freq': '10ms'}, [0.0, 0.09])])
     def test_generate_times_kwargs(self, num, kwargs, output):
         """Test use of kwargs in generate_times, including default behavior.
 

--- a/pysat/tests/test_utils.py
+++ b/pysat/tests/test_utils.py
@@ -353,7 +353,7 @@ class TestIfyFunctions(object):
 
         new_iterable = utils.listify(iterable)
         tst_iterable = [np.nan
-                        for i in range(int(np.product(np.shape(iterable))))]
+                        for i in range(int(np.prod(np.shape(iterable))))]
         utils.testing.assert_lists_equal(new_iterable, tst_iterable,
                                          test_nan=True)
         return
@@ -365,7 +365,7 @@ class TestIfyFunctions(object):
         """Test listify with various np.arrays of integers."""
 
         new_iterable = utils.listify(iterable)
-        tst_iterable = [1 for i in range(int(np.product(np.shape(iterable))))]
+        tst_iterable = [1 for i in range(int(np.prod(np.shape(iterable))))]
         utils.testing.assert_lists_equal(new_iterable, tst_iterable)
         return
 
@@ -394,7 +394,7 @@ class TestIfyFunctions(object):
 
         new_iterable = utils.listify(iterable)
         tst_iterable = [np.timedelta64(1)
-                        for i in range(int(np.product(np.shape(iterable))))]
+                        for i in range(int(np.prod(np.shape(iterable))))]
         utils.testing.assert_lists_equal(new_iterable, tst_iterable)
         return
 

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -425,11 +425,11 @@ class TestExpandXarrayDims(object):
             exclude_dims = []
 
         # Define the reference Dataset
-        ref_dims = list(self.out[0].dims.keys())
+        ref_dims = list(self.out[0].sizes.keys())
 
         # Cycle through the remaining Datasets
         for i, xdata in enumerate(self.out[1:]):
-            test_dims = list(xdata.dims.keys())
+            test_dims = list(xdata.sizes.keys())
 
             # Test that the expected dimension names overlap between datasets
             if dims_equal:

--- a/pysat/tests/test_utils_io.py
+++ b/pysat/tests/test_utils_io.py
@@ -1378,15 +1378,15 @@ class TestXarrayIO(object):
         vars = io.xarray_all_vars(self.testInst.data)
 
         # Get data variables
-        xvars = self.testInst.data.data_vars.keys()
+        xvars = list(self.testInst.data.data_vars.keys())
         testing.assert_list_contains(xvars, vars)
 
         # Get/test coordinate variables
-        xcoords = self.testInst.data.coords.keys()
+        xcoords = list(self.testInst.data.coords.keys())
         testing.assert_list_contains(xcoords, vars)
 
         # Get/test dimension variables
-        xdims = self.testInst.data.dims.keys()
+        xdims = list(self.testInst.data.sizes.keys())
         testing.assert_list_contains(xdims, vars)
 
         # Test uniqueness

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -298,7 +298,7 @@ class TestFilterDatetimeInput(object):
         return
 
     @pytest.mark.parametrize("in_time, islist",
-                             [(dt.datetime.now(dt.UTC), False),
+                             [(dt.datetime.now(dt.timezone.utc), False),
                               (dt.datetime(2010, 1, 1, 12, tzinfo=dt.timezone(
                                   dt.timedelta(seconds=14400))), False),
                               ([dt.datetime(2010, 1, 1, 12, i,

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -125,8 +125,8 @@ class TestCalcFreqRes(object):
         return
 
     @pytest.mark.parametrize('trange,freq_out',
-                             [(np.arange(0.0, 4.0, 1.0), '1S'),
-                              (np.arange(0.0, 0.04, .01), '10000000N')])
+                             [(np.arange(0.0, 4.0, 1.0), '1s'),
+                              (np.arange(0.0, 0.04, .01), '10000000ns')])
     def test_calc_freq(self, trange, freq_out):
         """Test index frequency calculation."""
 
@@ -138,8 +138,8 @@ class TestCalcFreqRes(object):
         return
 
     @pytest.mark.parametrize('freq_in,res_out',
-                             [('S', 1.0), ('2D', 172800.0),
-                              ('10000000N', 0.01)])
+                             [('s', 1.0), ('2D', 172800.0),
+                              ('10000000ns', 0.01)])
     def test_freq_to_res(self, freq_in, res_out):
         """Test index frequency to resolution calculation."""
         res = pytime.freq_to_res(freq_in)

--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -298,7 +298,7 @@ class TestFilterDatetimeInput(object):
         return
 
     @pytest.mark.parametrize("in_time, islist",
-                             [(dt.datetime.utcnow(), False),
+                             [(dt.datetime.now(dt.UTC), False),
                               (dt.datetime(2010, 1, 1, 12, tzinfo=dt.timezone(
                                   dt.timedelta(seconds=14400))), False),
                               ([dt.datetime(2010, 1, 1, 12, i,

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -300,7 +300,7 @@ def expand_xarray_dims(data_list, meta, dims_equal=False, exclude_dims=None):
     # Get a list of all the dimensions
     if dims_equal:
         if len(data_list) > 0:
-            dims = [dim_key for dim_key in list(data_list[0].dims.keys())
+            dims = [dim_key for dim_key in data_list[0].dims
                     if dim_key not in exclude_dims]
         else:
             dims = []
@@ -308,10 +308,10 @@ def expand_xarray_dims(data_list, meta, dims_equal=False, exclude_dims=None):
         dims = list()
         for sdata in data_list:
             if len(dims) == 0:
-                dims = [dim_key for dim_key in list(sdata.dims.keys())
+                dims = [dim_key for dim_key in sdata.dims
                         if dim_key not in exclude_dims]
             else:
-                for dim in list(sdata.dims.keys()):
+                for dim in sdata.dims:
                     if dim not in dims and dim not in exclude_dims:
                         dims.append(dim)
 
@@ -324,8 +324,8 @@ def expand_xarray_dims(data_list, meta, dims_equal=False, exclude_dims=None):
     out_list = list()
     for i, sdata in enumerate(data_list):
         # Determine which dimensions need to be updated
-        fix_dims = [dim for dim in sdata.dims.keys() if dim in combo_dims.keys()
-                    and sdata.dims[dim] < combo_dims[dim]]
+        fix_dims = [dim for dim in sdata.dims if dim in combo_dims.keys()
+                    and sdata.sizes[dim] < combo_dims[dim]]
 
         new_data = {}
         update_new = False

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -317,14 +317,15 @@ def expand_xarray_dims(data_list, meta, dims_equal=False, exclude_dims=None):
 
     # After loading all the data, determine which dimensions may need to be
     # expanded, as they could differ in dimensions from file to file
-    combo_dims = {dim: max([sdata.dims[dim] for sdata in data_list
-                            if dim in sdata.dims]) for dim in dims}
+    combo_dims = {dim: max([sdata.sizes[dim] for sdata in data_list
+                            if dim in sdata.sizes.keys()]) for dim in dims}
 
     # Expand the data so that all dimensions are the same shape
     out_list = list()
     for i, sdata in enumerate(data_list):
         # Determine which dimensions need to be updated
-        fix_dims = [dim for dim in sdata.dims if dim in combo_dims.keys()
+        fix_dims = [dim for dim in sdata.sizes.keys()
+                    if dim in combo_dims.keys()
                     and sdata.sizes[dim] < combo_dims[dim]]
 
         new_data = {}

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -1429,7 +1429,8 @@ def inst_to_netcdf(inst, fname, base_instrument=None, epoch_name=None,
     attrb_dict['File_Date'] = inst.index[-1].strftime(
         '%a, %d %b %Y,  %Y-%m-%dT%H:%M:%S.%f')
     attrb_dict['File_Date'] = attrb_dict['File_Date'][:-3] + ' UTC'
-    attrb_dict['Generation_Date'] = dt.datetime.now(dt.UTC).strftime('%Y%m%d')
+    utcnow = dt.datetime.now(dt.timezone.utc)
+    attrb_dict['Generation_Date'] = utcnow.strftime('%Y%m%d')
     attrb_dict['Logical_File_ID'] = os.path.split(fname)[-1].split('.')[:-1]
 
     # Check for binary types, convert to string or int when found

--- a/pysat/utils/io.py
+++ b/pysat/utils/io.py
@@ -1429,7 +1429,7 @@ def inst_to_netcdf(inst, fname, base_instrument=None, epoch_name=None,
     attrb_dict['File_Date'] = inst.index[-1].strftime(
         '%a, %d %b %Y,  %Y-%m-%dT%H:%M:%S.%f')
     attrb_dict['File_Date'] = attrb_dict['File_Date'][:-3] + ' UTC'
-    attrb_dict['Generation_Date'] = dt.datetime.utcnow().strftime('%Y%m%d')
+    attrb_dict['Generation_Date'] = dt.datetime.now(dt.UTC).strftime('%Y%m%d')
     attrb_dict['Logical_File_ID'] = os.path.split(fname)[-1].split('.')[:-1]
 
     # Check for binary types, convert to string or int when found

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -196,10 +196,10 @@ def calc_freq(index):
     # Format output frequency
     if np.floor(freq_sec) == freq_sec:
         # The frequency is on the order of seconds or greater
-        freq = "{:.0f}S".format(freq_sec)
+        freq = "{:.0f}s".format(freq_sec)
     else:
         # There are sub-seconds.  Go straigt to nanosec for best resoution
-        freq = "{:.0f}N".format(freq_sec * 1.0e9)
+        freq = "{:.0f}ns".format(freq_sec * 1.0e9)
 
     return freq
 

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -387,6 +387,6 @@ def today():
         Today's date in UTC
 
     """
-    today_utc = filter_datetime_input(dt.datetime.utcnow())
+    today_utc = filter_datetime_input(dt.datetime.now(dt.UTC))
 
     return today_utc

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -387,6 +387,6 @@ def today():
         Today's date in UTC
 
     """
-    today_utc = filter_datetime_input(dt.datetime.now(dt.UTC))
+    today_utc = filter_datetime_input(dt.datetime.now(dt.timezone.utc))
 
     return today_utc

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -253,7 +253,7 @@ def create_date_range(start, stop, freq='D'):
         stop dates.
     freq : str
         The frequency of the desired output.  Codes correspond to pandas
-        date_range codes: 'D' daily, 'M' monthly, 'S' secondly
+        date_range codes: 'D' daily, 'M' monthly, 's' secondly
 
     Returns
     -------


### PR DESCRIPTION
# Description

Addresses #1186, #1185, #1189

- Update usage of `dims` to be consistent with future versions of `xarray`
- Update frequency strings for `pandas`
- Update usage of getitem for `pds.Series` (ie, `.iloc` for integer indices)
- Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.timezone.utc)`

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

via pytest and inspection of warnings.

**Test Configuration**:
* Operating system: Ventura 13.6.4
* Version number: Python 3.11.5
* pandas 2.2.0 and pandas 1.5.3

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
