### PR TITLE
Impose minimum frequency of 1D

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -67,10 +67,15 @@
         "name": "Leite, Silvio",
         "orcid": "0000-0003-1707-7963"
       },
-	{
+	    {
         "affiliation": "NASA NPP",
         "name": "Esman, Teresa",
         "orcid": "0000-0003-0382-6281"
+      },
+      {
+        "affiliation": "Universities Space Research Association, Goddard Space Flight Center",
+        "name": "Govada, Aadarsh",
+        "orcid": "0009-0004-7873-5899"
       }
     ]
 }

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -67,7 +67,7 @@
         "name": "Leite, Silvio",
         "orcid": "0000-0003-1707-7963"
       },
-	    {
+	{
         "affiliation": "NASA NPP",
         "name": "Esman, Teresa",
         "orcid": "0000-0003-0382-6281"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Update usage of getitem for `pds.Series`
   * Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.timezone.utc)`
   * Drop testing for python 3.9 following NEP29.
+* Bug Fix
+  * Imposed minimum frequency of `1D` on `Instrument.bounds` to enable data loading for instruments with inter-file time intervals of less than one day
 
 [3.2.0] - 2024-03-27
 --------------------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -2027,6 +2027,13 @@ class Instrument(object):
         else:
             file_freq = '1D'  # This is the pysat default
 
+        # Force minimum file frequency to be 1D
+        common_dt = pds.to_datetime("2000-01-01")
+        min_freq_dt = common_dt + pds.tseries.frequencies.to_offset('1D')
+        file_freq_dt = common_dt + pds.tseries.frequencies.to_offset(file_freq)
+        if file_freq_dt < min_freq_dt:
+            file_freq = '1D'
+
         # Pull out start and stop times now that other optional items have
         # been checked out.
         start = value[0]


### PR DESCRIPTION
# Description

Addresses #1198 

Frequency-based iteration was failing for files with irregular frequencies, particularly with frequencies of less than one day. 

This pull imposes a minimum frequency of 1D. Once the file frequency is calculated, if it is less than 1D, it is set to 1D.


## Type of change

- Bug fix (non-breaking change which fixes an issue)


# How Has This Been Tested?

pysatCDAAC unit tests run locally with patch-develop branch rc on TestPyPI as pysat version

Test Configuration:

Operating system: MacOS 14.5
Version number: Python 3.10


# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

