### PR TITLE
BUG: Assumptions in clean tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This project adheres to [Semantic Versioning](https://semver.org/).
 
 [3.2.1] - 2024-XX-XX
 --------------------
+* Bug Fix
+  * Fixed a bug for identifying clean warnings to test
 * Maintenance
   * Update usage of `dims` to be consistent with future versions of `xarray`
   * Update frequency strings for `pandas`

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -545,8 +545,14 @@ class InstLibTests(object):
         # Not all Instruments have warning messages to test, only run tests
         # when the desired test attribute is defined
         if hasattr(inst_dict['inst_module'], '_clean_warn'):
-            clean_warn = inst_dict['inst_module']._clean_warn[
-                inst_dict['inst_id']][inst_dict['tag']]
+            try:
+                clean_warn = inst_dict['inst_module']._clean_warn[
+                    inst_dict['inst_id']][inst_dict['tag']]
+            except KeyError:
+                # Combo does not exist for this instrument, skip test.
+                pytest.skip("".join(["No clean warnings for Instrument ",
+                                     repr(inst_dict['inst_module']), " level ",
+                                     clean_level]))
 
             # Cleaning warnings may vary by clean level, test the warning
             # messages at the current clean level, specified by `clean_level`


### PR DESCRIPTION
# Description

Addresses #1196

Only tests for clean warning if a particular inst_id / tag combo exists in the instrument module. Defaults to skip test if this is not present.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Run pytest for pysatNASA.

**Test Configuration**:
* Operating system: Mac 14.5
* Version number: Python 3.10.9

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
