### PR TITLE
BUG/DOC: export pysat info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Update pip rc install workflow to test against multiple python versions
   * Implement coveralls app in GitHub Actions
   * Updated deprecated useage of `step.delta` to `pds.Timedelta(step)`
+  * Updated rationale and usage for `export_pysat_info` in docstrings.
 
 [3.2.0] - 2024-03-27
 --------------------

--- a/pysat/_instrument.py
+++ b/pysat/_instrument.py
@@ -3743,8 +3743,11 @@ class Instrument(object):
              and a value is NaN then that attribute simply won't be included in
              the netCDF4 file. (default=None)
         export_pysat_info : bool
-            If True, platform, name, tag, and inst_id will be appended to the
-            metadata.  (default=True)
+            If True, platform, name, tag, inst_id, acknowledgements, and
+            references will be appended to the metadata.  For some operational
+            uses (e.g., conversion of Level 1 to Level 2 data), it may be
+            desirable to set this to false to avoid conflicting versions of
+            these parameters. (default=True)
         unlimited_time : bool
              Flag specifying whether or not the epoch/time dimension should be
              unlimited; it is when the flag is True. (default=True)


### PR DESCRIPTION
# Description

Addresses #1201 

Updates docstring for `export_pysat_info` instructions, including potential use cases for the non-default case.

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

inspection of docs

GitHub Actions workflows (ignoring known issues with python 3.6.8)

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
