### PR TITLE
MAINT: SPEC-0000 tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,11 +16,14 @@ jobs:
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:
-          # NEP29 compliance settings
+          # SPEC0000 compliance settings
           - python-version: "3.10"
             numpy_ver: "1.24"
+            pandas_ver: "1.5.0"
+            scipy_ver: "1.10.0"
+            xarray_ver: "2022.9.0"
             os: ubuntu-latest
-            test_config: "NEP29"
+            test_config: "SPEC0000"
           # Operational compliance settings
           - python-version: "3.6.8"
             numpy_ver: "1.19.5"
@@ -44,10 +47,13 @@ jobs:
         pip install -r test_requirements.txt
         python setup.py install
 
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.test_config == 'NEP29'}}
+    - name: Install SPEC0000 dependencies
+      if: ${{ matrix.test_config == 'SPEC0000'}}
       run: |
         pip install numpy==${{ matrix.numpy_ver }}
+        pip install pandas==${{ matrix.pandas_ver }}
+        pip install scipy==${{ matrix.scipy_ver }}
+        pip install xarray==${{ matrix.xarray_ver }}
         pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install standard dependencies

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -17,11 +17,14 @@ jobs:
         numpy_ver: ["latest"]
         test_config: ["latest"]
         include:
-          # NEP29 compliance settings
+          # SPEC0000 compliance settings
           - python-version: "3.10"
-            numpy_ver: "1.23"
+            numpy_ver: "1.24"
+            pandas_ver: "1.5.0"
+            scipy_ver: "1.10.0"
+            xarray_ver: "2022.9.0"
             os: ubuntu-latest
-            test_config: "NEP29"
+            test_config: "SPEC0000"
           # Operational compliance settings
           - python-version: "3.6.8"
             numpy_ver: "1.19.5"
@@ -51,10 +54,13 @@ jobs:
         pip install -r requirements.txt
         pip install "pip<19.0"
 
-    - name: Install NEP29 dependencies
-      if: ${{ matrix.test_config == 'NEP29'}}
+    - name: Install SPEC0000 dependencies
+      if: ${{ matrix.test_config == 'SPEC0000'}}
       run: |
         pip install numpy==${{ matrix.numpy_ver }}
+        pip install pandas==${{ matrix.pandas_ver }}
+        pip install scipy==${{ matrix.scipy_ver }}
+        pip install xarray==${{ matrix.xarray_ver }}
         pip install --upgrade-strategy only-if-needed -r requirements.txt
 
     - name: Install pysat RC

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,12 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Update frequency strings for `pandas`
   * Update usage of getitem for `pds.Series`
   * Updates usage of `dt.datetime.utcnow()` to `dt.datetime.now(dt.timezone.utc)`
-  * Drop testing for python 3.9 following NEP29.
+  * Implement SPEC0000 testing limits for pandas, scipy, xarray.
   * Update pip rc install workflow to test against multiple python versions
   * Implement coveralls app in GitHub Actions
   * Updated deprecated useage of `step.delta` to `pds.Timedelta(step)`
   * Updated rationale and usage for `export_pysat_info` in docstrings.
+  * Update lower limits of core dependencies based on operational tests
 
 [3.2.0] - 2024-03-27
 --------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,13 +44,13 @@ keywords = [
 dependencies = [
   "dask",
   "netCDF4",
-  "numpy >= 1.12",
-  "pandas",
+  "numpy >= 1.19",
+  "pandas >= 1.1.5",
   "portalocker",
   "pytest",
-  "scipy",
+  "scipy >= 1.5.4",
   "toolz",
-  "xarray"
+  "xarray >= 0.16.2"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Description

Implements SPEC-0000 test requirements instead of limiting to only numpy (NEP29). Uses two-year support window to test for earlier versions of 
- pandas
- scipy
- xarray

See https://scientific-python.org/specs/spec-0000/

Also adds minimum versions for these in pyproject.toml to match the current tests in the operational environment.

## Type of change

- New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

via github actions, including verifying that correct versions were installed for this job.

# Checklist:

- [na] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
