### PR TITLE
MAINT: ops for python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,8 +25,8 @@ jobs:
             os: ubuntu-latest
             test_config: "SPEC0000"
           # Operational compliance settings
-          - python-version: "3.6.8"
-            numpy_ver: "1.19.5"
+          - python-version: "3.9"
+            numpy_ver: "1.23.5"
             os: "ubuntu-20.04"
             test_config: "Ops"
 
@@ -43,9 +43,7 @@ jobs:
       if: ${{ matrix.test_config == 'Ops'}}
       run: |
         pip install numpy==${{ matrix.numpy_ver }}
-        pip install -r requirements.txt
-        pip install -r test_requirements.txt
-        python setup.py install
+        pip install --upgrade-strategy only-if-needed .[test]
 
     - name: Install SPEC0000 dependencies
       if: ${{ matrix.test_config == 'SPEC0000'}}

--- a/.github/workflows/pip_rc_install.yml
+++ b/.github/workflows/pip_rc_install.yml
@@ -26,8 +26,8 @@ jobs:
             os: ubuntu-latest
             test_config: "SPEC0000"
           # Operational compliance settings
-          - python-version: "3.6.8"
-            numpy_ver: "1.19.5"
+          - python-version: "3.9"
+            numpy_ver: "1.23.5"
             os: "ubuntu-20.04"
             test_config: "Ops"
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+.python-version
 env/
 build/
 develop-eggs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Update .gitignore
   * Update zenodo affiliations and references
   * Clarified controlled information distribution statement
+  * Updated Ops tests to new lower limit of Python 3.9 and removed 3.6 support
 
 [3.2.1] - 2024-10-03
 --------------------
@@ -28,7 +29,6 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated deprecated useage of `step.delta` to `pds.Timedelta(step)`
   * Updated rationale and usage for `export_pysat_info` in docstrings.
   * Update lower limits of core dependencies based on operational tests
-  * Updated Ops tests to new lower limit of Python 3.9 and removed 3.6 support
 
 [3.2.0] - 2024-03-27
 --------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](https://semver.org/).
   * Updated deprecated useage of `step.delta` to `pds.Timedelta(step)`
   * Updated rationale and usage for `export_pysat_info` in docstrings.
   * Update lower limits of core dependencies based on operational tests
+  * Updated Ops tests to new lower limit of Python 3.9 and removed 3.6 support
 
 [3.2.0] - 2024-03-27
 --------------------

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ examples on how to use the routines.
 ## Prerequisites
 
 pysat uses common Python modules, as well as modules developed by and for the
-Space Physics community.  This module officially supports Python 3.X+.
+Space Physics community.  This module officially supports Python 3.9+.
 
 | Common modules | Community modules |
 | -------------- | ----------------- |
@@ -80,9 +80,7 @@ Space Physics community.  This module officially supports Python 3.X+.
 ```
 pip install pysat
 ```
-Note that while support for python 3.6 is maintained for opertional purposes, there 
-have been issues with installing through PyPi on older systems. Installation through 
-GitHub is recommended for older systems.
+
 
 ## GitHub Installation
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pysat"
 version = "3.2.1"
 description = "Supports science analysis across disparate data platforms"
 readme = "README.md"
-requires-python = ">=3.6"
+requires-python = ">=3.9"
 license = {file = "LICENSE"}
 authors = [
     {name = "Russell Stoneback, et al.", email = "pysat.developers@gmail.com"},
@@ -20,7 +20,7 @@ classifiers = [
   "Topic :: Scientific/Engineering :: Atmospheric Science",
   "License :: OSI Approved :: BSD License",
   "Natural Language :: English",
-  "Programming Language :: Python :: 3.6",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",

--- a/pysat/__init__.py
+++ b/pysat/__init__.py
@@ -34,16 +34,8 @@ Main Features
 
 """
 
-try:
-    from importlib import metadata
-    from importlib import resources
-
-    if not hasattr(resources, 'files'):
-        # The `files` object was introduced in Python 3.9
-        resources = None
-except ImportError:
-    import importlib_metadata as metadata
-    resources = None
+from importlib import metadata
+from importlib import resources
 
 import logging
 import os

--- a/pysat/tests/classes/cls_instrument_library.py
+++ b/pysat/tests/classes/cls_instrument_library.py
@@ -650,15 +650,6 @@ class InstLibTests(object):
             `initialize_test_package` is run.
 
         """
-        # Skip for Python 3.6, keeping information that will allow adding
-        # or skipping particular instruments.
-        # TODO(#1136): Remove skip once memory management is improved
-        if sys.version_info.minor < 7:
-            pytest.skip("skipping 3.6 for {:} ({:} =? {:})".format(
-                inst_dict, inst_dict['inst_module'].__name__.find(
-                    'pysat_testing'), len(inst_dict['inst_module'].__name__)
-                - len('pysat_testing')))
-            return
 
         # Update the Instrument dict with the desired pad
         if 'kwargs' in inst_dict.keys():

--- a/pysat/utils/_core.py
+++ b/pysat/utils/_core.py
@@ -151,12 +151,7 @@ def listify(iterable):
     """
 
     # Cast as an array-like object
-    try:
-        arr_iter = np.asarray(iterable)
-    except ValueError:
-        # This is necessary for Python 3.6 compatibility when using listify
-        # on slices
-        arr_iter = np.asarray([iterable])
+    arr_iter = np.asarray(iterable)
 
     # Treat output differently based on the array shape
     if arr_iter.shape == ():


### PR DESCRIPTION
# Description

- Updates the operational tests for the new configuration (python 3.9, numpy 1.23.5). 
- Sets python 3.9 as the new minimum supported version
- Removes some code designed to interface purely for python 3.6
- Updates .gitignore to play nicely with pyenv-virtualenv

## Type of change

- Bug fix (non-breaking change which fixes an issue)
- This change requires a documentation update

# How Has This Been Tested?

Via GitHub Actions, including the pip rc install workflow.

# Checklist:

- [rc] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
