### PR TITLE
BUG: include test data in MANIFEST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[3.2.2] - 2025-XX-XX
+--------------------
+* Bug Fix
+  * Include test data in tar.gz so unit test suite can be run from a pip-install
+* Maintenance
+  * Update .gitignore
+
 [3.2.1] - 2024-10-03
 --------------------
 * Bug Fix

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,8 +1,8 @@
 recursive-include pysat *.py
 include *.md
-include *.txt
+recursive-include pysat *.txt
+recursive-include pysat *.tab
 include LICENSE
-include pysat/citation.txt
 prune docs
 global-exclude *.pdf
 global-exclude *.png


### PR DESCRIPTION
# Description

Addresses #TBD

PyHC is testing out a common unit-test environment for core packages. This is currently accomplished by running the unit tests for a pip-installed version of pysat. While the tests are included as core code for use throughout the ecosystem, the test data some of the pysat-unique tests requires are not included here. This updates the manifest so that these files are included.

## Type of change

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

- Created a clean virtual environment.
- Created tar.gz via `python -m build --sdist`
- Installed via pip in clean env directly from the tar.gz => `pip install '../code/core/pysat/dist/pysat-3.2.2rc0.tar.gz[test]'`
- Ran tests via `pytest --pyargs pysat.tests`

**Test Configuration**:
* Operating system: Sonoma 14.7.1
* Version number: Python 3.12
* Clean venv with install procedure above

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
