### PR TITLE
Fix bug in `cyclic_adjust_range`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Change Log
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](https://semver.org/).
 
+[3.X.X] - 2026-XX-XX
+--------------------
+* Bug Fix
+  * Ensure `utils.coords.adjust_cyclic_data` will adjust data more than one
+    cycle outside of the desired range
+
 [3.2.2] - 2025-03-20
 --------------------
 * Bug Fix

--- a/pysat/tests/test_utils_coords.py
+++ b/pysat/tests/test_utils_coords.py
@@ -43,6 +43,16 @@ class TestCyclicData(object):
         assert ref_angles.min() >= 0.0
         return
 
+    def test_adjust_cyclic_data_extended_range(self):
+        """Test adjust_cyclic_data that deviate by more than one range."""
+
+        ref_rad = np.radians(self.ref_angles) - 9.0 * np.pi
+        ref_angles = coords.adjust_cyclic_data(ref_rad)
+
+        assert ref_angles.max() < 2.0 * np.pi
+        assert ref_angles.min() >= 0.0
+        return
+
     def test_adjust_cyclic_data_custom(self):
         """Test adjust_cyclic_data with a custom range."""
 

--- a/pysat/utils/coords.py
+++ b/pysat/utils/coords.py
@@ -42,8 +42,12 @@ def adjust_cyclic_data(samples, high=2.0 * np.pi, low=0.0):
 
     out_samples = np.asarray(samples)
     sample_range = high - low
-    out_samples[out_samples >= high] -= sample_range
-    out_samples[out_samples < low] += sample_range
+
+    while np.any(out_samples >= high):
+        out_samples[out_samples >= high] -= sample_range
+
+    while np.any(out_samples < low):
+        out_samples[out_samples < low] += sample_range
 
     return out_samples
 


### PR DESCRIPTION
# Description

Fixes issue found when using the function, which did not adjust data more than one deviation outside of the specified range

## Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Added a unit test.  Also:

```
import numpy as np
import pysat

offsets = np.arange(-4.0 * np.pi, 4.0 * np.pi, 1.0)
offsets_adjust = pysat.utils.coords.adjust_cyclic_data(offsets)
print(offsets_adjust.max(), offsets_adjust.min())
```

Yields: `6.150444078461241 0.0`

**Test Configuration**:
* Operating system: OS X Sequoia
* Version number: Python 3.10
* Any details about your local setup that are relevant

# Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have linted the files updated in this pull request
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] Add a note to ``CHANGELOG.md``, summarizing the changes
- [x] Update zenodo.json file for new code contributors

If this is a release PR, replace the first item of the above checklist with the
release checklist on the wiki:
https://github.com/pysat/pysat/wiki/Checklist-for-Release
