### PR TITLE
Fix calc_res for non-nanosecond datetime units (pandas 3 DatetimeIndex regression)

### DIFF
--- a/pysat/tests/test_utils_time.py
+++ b/pysat/tests/test_utils_time.py
@@ -12,6 +12,7 @@
 
 import datetime as dt
 import numpy as np
+import pandas as pds
 
 import pytest
 
@@ -161,6 +162,28 @@ class TestCalcFreqRes(object):
         # Get and test the output resolution
         res = pytime.calc_res(tind, use_mean=use_mean)
         assert res == out_res
+        return
+
+    @pytest.mark.parametrize('unit', ['ns', 'us', 'ms'])
+    def test_calc_res_numpy_datetime_units(self, unit):
+        """Test `calc_res` across numpy datetime units."""
+
+        base = np.datetime64('2001-01-01T00:00:00', unit)
+        tind = np.array([base + i * np.timedelta64(1, 's') for i in range(4)],
+                        dtype=f'datetime64[{unit}]')
+
+        assert pytime.calc_res(tind) == 1.0
+        return
+
+    def test_calc_res_pandas_datetimeindex_microseconds(self):
+        """Test `calc_res` for a pandas DatetimeIndex backed by microseconds."""
+
+        base = np.datetime64('2001-01-01T00:00:00', 'us')
+        ntime = np.array([base + i * np.timedelta64(1, 's') for i in range(4)],
+                         dtype='datetime64[us]')
+        tind = pds.DatetimeIndex(ntime)
+
+        assert pytime.calc_res(tind) == 1.0
         return
 
     @pytest.mark.parametrize('func_name', ['calc_freq', 'calc_res'])

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -160,8 +160,6 @@ def calc_res(index, use_mean=False):
     except AttributeError as aerr:
         # Now try as numpy.timedelta64
         if isinstance(del_time, np.timedelta64):
-            # Convert based on explicit units (e.g., ns/us/ms/s), rather than
-            # assuming nanoseconds.
             res_sec = np.float64(del_time / np.timedelta64(1, 's'))
         else:
             raise AttributeError("Input should be times: {:}".format(aerr))

--- a/pysat/utils/time.py
+++ b/pysat/utils/time.py
@@ -160,7 +160,9 @@ def calc_res(index, use_mean=False):
     except AttributeError as aerr:
         # Now try as numpy.timedelta64
         if isinstance(del_time, np.timedelta64):
-            res_sec = np.float64(del_time) * 1.0e-9
+            # Convert based on explicit units (e.g., ns/us/ms/s), rather than
+            # assuming nanoseconds.
+            res_sec = np.float64(del_time / np.timedelta64(1, 's'))
         else:
             raise AttributeError("Input should be times: {:}".format(aerr))
 


### PR DESCRIPTION
Hey pysat folks, Shawn from PyHC here! 

I regularly run pysat unit tests as part of the [pyhc_core](https://github.com/heliophysicsPy/pyhc-core/tree/main) package, and I noticed they were [failing](https://github.com/heliophysicsPy/pyhc-core/actions/runs/22422368796/job/64922826578), so I dug into it and it looks like I found a bug that only appears with `pandas>=3`.

## Summary

Fix a resolution-conversion bug in `pysat.utils.time.calc_res` that assumed `numpy.timedelta64` values were always nanoseconds. This caused incorrect resolution values for non-ns datetime units (notably `datetime64[us]` under pandas 3), which then propagated into Constellation index generation.

## Root Cause

`calc_res` converted `numpy.timedelta64` like this:

```python
res_sec = np.float64(del_time) * 1.0e-9
```

That is only correct when `del_time` is in nanoseconds. For `datetime64[us]`, a 1-second step appears as `1000000 microseconds`, and the old conversion incorrectly returned `0.001` seconds.

This led `Constellation._index()` to pick an artificially small cadence, expanding index size (e.g., `10 -> 9001`) and causing major slowdown/failures in pandas 3 test runs.

## Changes

- Updated `calc_res` to use unit-safe conversion:
  - from: `np.float64(del_time) * 1.0e-9`
  - to: `np.float64(del_time / np.timedelta64(1, 's'))`
- Added/expanded regression coverage in `test_utils_time.py`:
  - `calc_res` returns `1.0` for NumPy datetime arrays with `ns`, `us`, and `ms` units.
  - `calc_res` returns `1.0` for a pandas `DatetimeIndex` backed by `datetime64[us]`.

## Validation

Tested in isolated environments:

- **pandas 2.3.3** (patched):
  - `TestCalcFreqRes`: `15 passed`
  - `test_constellation.py`: `55 passed`
- **pandas 3.0.1** (patched):
  - `TestCalcFreqRes`: `15 passed`
  - `test_constellation.py`: `55 passed`

Control run on unpatched code with pandas 3 reproduced the issue:
- `calc_res(inst.index) == 0.001`
- Constellation index expansion `10 -> 9001`
- `test_constellation.py`: `2 failed, 53 passed`
