### PR TITLE
Add dependabot configuration

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,15 @@
+# Dependabot creates pull requests to update versions of dependencies,
+# including in the GitHub Actions ecosystem.
+
+# Documentation: https://docs.github.com/en/code-security/dependabot
+
+version: 2
+
+updates:
+
+- package-ecosystem: github-actions
+  directory: /.github/workflows
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 14


### PR DESCRIPTION
## Description

This PR proposes a dependabot configuration to automagically update the versions of GitHub actions used in GitHub workflows.  

## Motivation

I've found dependabot to be helpful for reducing the maintenance burden since it removes the need to manually update the versions of `actions/checkout`, etc. 

There's a separate PR for each version update, so it's pretty straightforward to figure out if a particular update breaks CI, and then quarantine that change.  

## Type of change

This is an internal change.

## How Has This Been Tested?

This is pretty close to the same configuration I'm using for PlasmaPy.  

## Checklist:

- [x] Make sure you are merging into the ``develop`` (not ``main``) branch
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have linted the files updated in this pull request
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] Add a note to ``CHANGELOG.md``, summarizing the changes
- [ ] Update zenodo.json file for new code contributors
